### PR TITLE
docs(release): record final Penglai 0.4 DMG evidence

### DIFF
--- a/docs/RELEASE_NOTES_0.4.0.md
+++ b/docs/RELEASE_NOTES_0.4.0.md
@@ -56,7 +56,7 @@ penglai migrate
 - 语音：使用本机真实模型权重完成 MOSS 中文合成 → SenseVoice 中文识别回环。
 - 官网：中英文桌面页面与 390px 移动布局完成浏览器验收，无脚本错误或横向溢出。
 - 安全与依赖：Host token 不再进入 URL；token/档案文件强制当前用户、普通文件与 0600；公网模型端点强制 HTTPS；文档、网页和 MCP 输出按不可信数据隔离；Evidence、审批与诊断统一脱敏。npm 审计为 0 个已知漏洞，Cargo 审计为 0 个漏洞；Linux GUI 依赖仍有 RustSec 维护性/unsound 警告，0.4.0 不发布 Linux GUI，仅发布不含该 Rust GUI 树的 headless runtime。完整边界与证据见 `docs/SECURITY_AUDIT_0.4.0.md`。
-- DMG：Apple Silicon 本地候选 `Penglai_0.4.0_aarch64.dmg` 为 259,236,192 bytes，SHA-256 `34079daf42a0c8bdb5068c26fc3f204c052ee88bb3aa2cedc49d186acf50ac07`；`hdiutil verify`、只读挂载、Applications 链接、隔离目录复制、完整 adhoc seal、壳启动、独立 Host 握手、向导档案、身份诞生、mock Pi 对话/用量、工作区内产物预览、诊断 ZIP 解压/权限/脱敏、退出、端口释放与卸载均通过。
+- DMG：从最终 `main` 等价源码重建的 Apple Silicon 本地候选 `Penglai_0.4.0_aarch64.dmg` 为 257,426,811 bytes，SHA-256 `95e840c6c2c539da0094468acce2f475bc6265ccbe28836c857167bab9839a69`；`hdiutil verify`、只读挂载、Applications 链接、隔离目录复制、完整 adhoc seal、壳启动、独立 Host 握手、向导档案、身份诞生、mock Pi 对话/用量、工作区内产物预览、诊断 ZIP 解压/权限/脱敏、退出、端口释放与卸载均通过。
 - 包内运行时：固定 Node 22.22.2、21,343 个文件、150 个生产依赖、588,758,731 bytes，并校验 Node、manifest 与所有 Host 直接必需包。第一次隔离安装曾真实抓到 Pi 工作区依赖层级错置，修复打包器和验证器后重建 DMG 才通过。本机真实权重完成 48kHz MOSS 合成（4.64 秒、可听波形）→ SenseVoice 中文识别回环。
 
 ## 发行者签名现状

--- a/docs/SECURITY_AUDIT_0.4.0.md
+++ b/docs/SECURITY_AUDIT_0.4.0.md
@@ -201,8 +201,9 @@ Paths: `SECURITY.md`, `docs/PRIVACY_AND_DATA.md`, `NOTICE`, `README.md`,
 
 ### F-10 — Local installer acceptance — passed with explicit signing limit
 
-The rebuilt Apple Silicon DMG is 259,236,192 bytes with SHA-256
-`34079daf42a0c8bdb5068c26fc3f204c052ee88bb3aa2cedc49d186acf50ac07`.
+The Apple Silicon DMG rebuilt from source equivalent to final `main` is
+257,426,811 bytes with SHA-256
+`95e840c6c2c539da0094468acce2f475bc6265ccbe28836c857167bab9839a69`.
 `hdiutil` verified its image checksum. The mounted app passed ad-hoc seal
 verification and a sandboxed install/use/uninstall lifecycle using its bundled
 Node 22.22.2 Host runtime. This proves local integrity and functionality, not an

--- a/docs/audit/FILE_LEDGER_0.4.0.csv
+++ b/docs/audit/FILE_LEDGER_0.4.0.csv
@@ -37,9 +37,9 @@ assets/tools_schema.json,100644,5896,74,182b239bdc71aa41456b3a96462a150c22ce97c9
 CHANGELOG.md,100644,4869,53,38beb2226985ca1612e8d41f2764ae4f00d3e50ba42bbed4516b03d22c46925e,text,docs-config,byte/line inventory+targeted claim/config consistency review
 CONTRIBUTING.md,100644,2119,39,3faa4b51ea818755cdc94b2e0e40ea54c8371beb0f5c6f7e42bb5825f99a8640,text,docs-config,byte/line inventory+targeted claim/config consistency review
 docs/PRIVACY_AND_DATA.md,100644,3506,61,a7f3f57fb7ec8eacc500615344fb59c8b0b713f9203a5ff06812d7a977d974f8,text,docs-config,byte/line inventory+targeted claim/config consistency review
-docs/RELEASE_NOTES_0.4.0.md,100644,7606,74,1098bef90fa6fbfebd6b4e7a3e7cb484bfbd3ee9b62606c604587fff258d7f03,text,docs-config,byte/line inventory+targeted claim/config consistency review
+docs/RELEASE_NOTES_0.4.0.md,100644,7645,74,5f0a40501233575d2c512b4e53448701e4c417c7298e77fc6ce9493f31aa3082,text,docs-config,byte/line inventory+targeted claim/config consistency review
 docs/RELEASE_PROCESS.md,100644,7905,159,8bfb463cc6c0a5a2ca4b93f7334bd4e28c64094405b62d0858a192f9784fc029,text,docs-config,byte/line inventory+targeted claim/config consistency review
-docs/SECURITY_AUDIT_0.4.0.md,100644,17164,313,2c4f63600a18f5c4cf8fd0f22ff110dc595a833bb5d07694e8ce4154718400a8,text,docs-config,byte/line inventory+targeted claim/config consistency review
+docs/SECURITY_AUDIT_0.4.0.md,100644,17203,314,f66529edffeafec0dac59381d5bd0a5857c9b35aa0a2c7a8e3feea9a9c472554,text,docs-config,byte/line inventory+targeted claim/config consistency review
 docs/UNINSTALL.md,100644,2938,64,487e55b426d6b3473567446d177f5b8a80978ec4540285908e82192c4530cdd2,text,docs-config,byte/line inventory+targeted claim/config consistency review
 docs/website/index.md,100644,1076,16,4a8169ddf0047ed3a4e4370aa270d0986408ebb6605cc47e429c908c6fb3692b,text,docs-config,byte/line inventory+targeted claim/config consistency review
 frontends/at_complete.py,100644,10652,273,bc1b74c2da7efa22bd26cca4e0cfa6fc88b236be7e9d5bab72175f049456df8c,text,legacy-or-support-source,byte/line inventory+syntax compiler+Semgrep/Bandit+targeted dangerous-API review+tests
@@ -457,7 +457,7 @@ packages/host/test/url-safety.test.ts,100644,982,29,2438577cca5a3da193a36d1824b3
 packages/host/test/usage-stats.test.ts,100644,1516,47,10c10a6e453a0716d01ae9750ba85b35ede8ad7580fb794312ce350d17bdc63f,text,tests,line scan+syntax/compiler+executed test suite
 packages/host/test/usage.test.ts,100644,8985,277,81a8036e2988e3e6147b7aa88f5812a0afc0efa9678e8ba2965dc80de1a05286,text,tests,line scan+syntax/compiler+executed test suite
 packages/host/test/voice.test.ts,100644,30420,723,d63f1e7e68036ad01d29a90bed87a943ee34c074b1dd8a9af293dfe8b96dcf50,text,tests,line scan+syntax/compiler+executed test suite
-packages/host/test/wechat-ilink.test.ts,untracked,1566,51,0cafa09fc0ed0d8318209c73f25bbdd8291be8a96866fd035c9ac93173d1eb82,text,tests,line scan+syntax/compiler+executed test suite
+packages/host/test/wechat-ilink.test.ts,100644,1566,51,0cafa09fc0ed0d8318209c73f25bbdd8291be8a96866fd035c9ac93173d1eb82,text,tests,line scan+syntax/compiler+executed test suite
 packages/host/tsconfig.json,100644,140,9,d56002ba285195e85ecb491b62915e017fbbfdf51d792ebc8be4c9669b4fa3cf,text,docs-config,byte/line inventory+targeted claim/config consistency review
 packages/protocol/package.json,100644,225,13,d827e9c3050639a5f91828c269739224b44a3c88bae8b274ac61a56720aad372,text,0.4-protocol,line scan+TypeScript compiler+contract tests
 packages/protocol/src/index.ts,100644,23110,784,23adfbe6363dfaf2295d9316f17595e975f24ec67a14ee3610db15dbc207fce0,text,0.4-protocol,line scan+TypeScript compiler+contract tests


### PR DESCRIPTION
## Summary

- replace stale local DMG size and SHA-256 with the artifact rebuilt from source equivalent to final `main`
- record `hdiutil verify` and the full isolated install/use/uninstall lifecycle result
- regenerate the file-level audit ledger

## Verification

- `TZ=UTC node scripts/release-check.mjs` — 8/8 gates passed
- 862 tests across 72 files
- 17/17 eval replay cases
- final local DMG: 257,426,811 bytes
- SHA-256: `95e840c6c2c539da0094468acce2f475bc6265ccbe28836c857167bab9839a69`

Docs/evidence only. This PR does not create a tag or publish a GitHub Release.