### PR TITLE
fix: install PDF font in release runtime gate

### DIFF
--- a/.github/workflows/host-release.yml
+++ b/.github/workflows/host-release.yml
@@ -127,6 +127,11 @@ jobs:
       - name: Install locked dependencies
         run: npm ci
 
+      - name: Install Unicode PDF test font
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes fonts-droid-fallback
+
       - name: Dependency vulnerability audit
         run: npm audit --audit-level=moderate --registry=https://registry.npmjs.org
 


### PR DESCRIPTION
The first protected v0.4.0 release run stopped before any artifact or Release was created because the Linux release runner lacked the Unicode font already installed by host-test.

This mirrors the existing host-test setup in the release runtime job so the real Chinese PDF capability test runs in both paths.

Verification: actionlint; 18 release-chain tests; 9 basic capability tests including Chinese PDF create/read; the failed tag was removed only after confirming the workflow failed and no GitHub Release existed.