### PR TITLE
fix(release): verify Windows runtime through bash

### DIFF
--- a/.github/workflows/host-release.yml
+++ b/.github/workflows/host-release.yml
@@ -231,6 +231,7 @@ jobs:
         run: npm run tauri:build:release -- --target "${{ matrix.target }}"
 
       - name: Verify bundled runtime version and target
+        shell: bash
         run: |
           node packages/host/scripts/verify-runtime.mjs \
             --runtime packages/desktop/src-tauri/resources/host-runtime \


### PR DESCRIPTION
## Cause

The Windows matrix successfully built the Tauri installer, then PowerShell parsed the POSIX line continuations in the runtime verification command and rejected `--runtime` before the verifier could run.

## Fix

Pin that verification step to `bash`, matching the already-portable release-contract and artifact collection steps.

## Verification

- `actionlint .github/workflows/host-release.yml`
- `node scripts/release-check.mjs --only=scan,files,statement`
- The failed run proves the Windows installer build itself completed; the signed tag will be recreated only after this protected change reaches `main`.