### PR TITLE
site: publish Penglai 0.4.0 desktop downloads

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -81,9 +81,9 @@
           <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55 0-.27-.01-1.17-.02-2.12-3.2.7-3.87-1.36-3.87-1.36-.52-1.33-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.76 2.69 1.25 3.35.96.1-.75.4-1.25.72-1.54-2.55-.29-5.23-1.28-5.23-5.68 0-1.26.45-2.28 1.18-3.09-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.16 1.18a11 11 0 0 1 5.76 0c2.2-1.49 3.16-1.18 3.16-1.18.62 1.58.23 2.75.11 3.04.74.81 1.18 1.83 1.18 3.09 0 4.42-2.69 5.39-5.25 5.67.41.35.77 1.05.77 2.12 0 1.53-.01 2.76-.01 3.14 0 .3.2.67.8.55A11.51 11.51 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5z"/></svg>
           GitHub
         </a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases" target="_blank" rel="noopener" class="btn btn-ghost">
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.4.0/Penglai_0.4.0_macos_aarch64.dmg" target="_blank" rel="noopener" class="btn btn-ghost">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          Download for macOS
+          Download for Apple silicon
         </a>
       </div>
       <figure class="shot reveal reveal-delay-3">
@@ -377,7 +377,7 @@
             </div>
             <div class="quick-note">
               <span class="qn-num">2</span>
-              <div><b>Rather avoid the terminal?</b>Grab the macOS installer from <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases" target="_blank" rel="noopener">GitHub Releases</a> — the desktop's first launch opens the very same wizard: pick a vendor, verify the key, watch the identity being born, then land in the workbench.</div>
+              <div><b>Rather avoid the terminal?</b>Download the <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.4.0/Penglai_0.4.0_macos_aarch64.dmg">Apple-silicon build</a> or the <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.4.0/Penglai_0.4.0_macos_x64.dmg">Intel build</a>. The first launch opens the same wizard. These builds use the same local signing approach as 0.3.6; they are not notarized because the project does not use a paid Apple Developer certificate. If Gatekeeper blocks the first launch, explicitly allow it under System Settings → Privacy &amp; Security.</div>
             </div>
             <div class="quick-note">
               <span class="qn-num">3</span>
@@ -421,7 +421,7 @@
             <h3>License</h3>
             <p><b>Code:</b> <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/LICENSE" target="_blank" rel="noopener">MIT</a>. The Pi kernel's copyright notice is preserved in full; the Penglai layer is MIT too — use, modify, and commercialize freely.</p>
             <p><b>Brand:</b> the "Penglai" / "蓬莱" name, logo, and visual assets are <b>all rights reserved</b> and are not covered by the code license. Please obtain written permission before using them for your distribution, derivative, or commercial naming.</p>
-            <p><b>The 0.3 line:</b> the GenericAgent-based Python product is frozen at <code>v0.3.6</code>; 0.4.0 is a TypeScript rewrite. This page describes locally accepted release-candidate capabilities; the final <code>main</code> and Release remain the Owner's publishing decision.</p>
+            <p><b>Version boundary:</b> the GenericAgent-based Python product line (0.3.x) is frozen in the historical <code>v0.3.6</code> tag; the current <code>main</code> and formal <code>v0.4.0</code> Release are the Pi-centered TypeScript rewrite.</p>
           </div>
           <div class="legal-card reveal reveal-delay-1">
             <h3>Acknowledgments — standing on these projects</h3>

--- a/index.html
+++ b/index.html
@@ -81,9 +81,9 @@
           <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.55 0-.27-.01-1.17-.02-2.12-3.2.7-3.87-1.36-3.87-1.36-.52-1.33-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.76 2.69 1.25 3.35.96.1-.75.4-1.25.72-1.54-2.55-.29-5.23-1.28-5.23-5.68 0-1.26.45-2.28 1.18-3.09-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.16 1.18a11 11 0 0 1 5.76 0c2.2-1.49 3.16-1.18 3.16-1.18.62 1.58.23 2.75.11 3.04.74.81 1.18 1.83 1.18 3.09 0 4.42-2.69 5.39-5.25 5.67.41.35.77 1.05.77 2.12 0 1.53-.01 2.76-.01 3.14 0 .3.2.67.8.55A11.51 11.51 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5z"/></svg>
           GitHub
         </a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases" target="_blank" rel="noopener" class="btn btn-ghost">
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.4.0/Penglai_0.4.0_macos_aarch64.dmg" target="_blank" rel="noopener" class="btn btn-ghost">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          下载 macOS 版
+          下载 macOS（Apple 芯片）
         </a>
       </div>
       <figure class="shot reveal reveal-delay-3">
@@ -377,7 +377,7 @@
             </div>
             <div class="quick-note">
               <span class="qn-num">二</span>
-              <div><b>不想碰命令行？</b>macOS 安装包在 <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases" target="_blank" rel="noopener">GitHub Releases</a> 直接下载；桌面首次启动即同一只向导——选供应商 → 验活 → 身份诞生，一分多钟进工作台。</div>
+              <div><b>不想碰命令行？</b>直接下载 <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.4.0/Penglai_0.4.0_macos_aarch64.dmg">Apple 芯片版</a>或 <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.4.0/Penglai_0.4.0_macos_x64.dmg">Intel 版</a>。桌面首次启动即同一只向导。安装包采用与 0.3.6 相同的本地签名方式，未购买 Apple 开发者证书、未公证；首次打开如被 Gatekeeper 拦截，请在“系统设置 → 隐私与安全性”中确认允许。</div>
             </div>
             <div class="quick-note">
               <span class="qn-num">三</span>
@@ -421,7 +421,7 @@
             <h3>许可</h3>
             <p><b>代码：</b>蓬莱与保留的 GenericAgent 代码采用 <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/LICENSE" target="_blank" rel="noopener">MIT</a>；MOSS-TTS Node 适配等第三方组件保留各自许可证与归属，详见 Third-Party Notices。</p>
             <p><b>品牌：</b>「Penglai / 蓬莱」名称、logo 与视觉资产<b>保留所有权利</b>，不在代码许可证内。用于你的发行版、衍生品或商业冠名前，请先取得书面授权。</p>
-            <p><b>0.3 产品线：</b>基于 GenericAgent 的 Python 版本（0.3.x）冻结在 <code>v0.3.6</code>；0.4.0 是 TypeScript 重写。本页只陈述本地发布候选已验收的能力，正式 <code>main</code> 与 Release 仍以 Owner 最终发布决定为准。</p>
+            <p><b>版本边界：</b>基于 GenericAgent 的 Python 产品线（0.3.x）冻结在历史标签 <code>v0.3.6</code>；当前 <code>main</code> 与正式 <code>v0.4.0</code> Release 是以 Pi 为核心的 TypeScript 重写。</p>
           </div>
           <div class="legal-card reveal reveal-delay-1">
             <h3>致谢 · 站在这些项目上</h3>


### PR DESCRIPTION
## Summary
- make the v0.4.0 Apple Silicon and Intel DMGs the primary website downloads
- document ad-hoc signing and the Gatekeeper first-launch path
- distinguish the TypeScript + Pi 0.4 line from historical Python 0.3.x releases

## Release gate
This PR will remain unmerged until the formal v0.4.0 GitHub Release and both DMG assets are public and independently verified.