### PR TITLE
fix(release): bind updater signing key before builds

### DIFF
--- a/.github/workflows/host-release.yml
+++ b/.github/workflows/host-release.yml
@@ -223,6 +223,18 @@ jobs:
           rustc --print target-list | grep -Fx "${{ matrix.target }}"
           rustc --print cfg --target "${{ matrix.target }}" | grep -E '^target_arch='
 
+      - name: Verify updater signing secret matches embedded public key
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          canary="$RUNNER_TEMP/penglai-updater-signing-canary.txt"
+          printf '%s\n' "Penglai updater signing preflight for $GITHUB_SHA" > "$canary"
+          npm run tauri --workspace @penglai/desktop -- signer sign "$canary"
+          node packages/desktop/updater/verify-signing-key.mjs --file "$canary"
+
       - name: Build Tauri release with updater signing
         working-directory: packages/desktop
         env:

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDZBMzZBNUE5MEMwQjRGNUEKUldSYVR3c01xYVUyYXJrdE42LzcwT0IxSlhYUU5KU1UvdjhkM2ZZc1NMcFpFZlBMWldGMHdTYnQK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDFGMjA3MDIwQUFFOURFNzcKUldSMzN1bXFJSEFnSDhkdVJ4M3lqTGRYU09mTlY1azAybHZ0ODhxRFJCTUI5NlBRR0RDRUUwUDUK",
       "endpoints": [
         "https://github.com/kevinchennewbee/PenglaiAgent/releases/download/desktop-v0.4/latest.json"
       ]

--- a/packages/desktop/test/updater-config.test.ts
+++ b/packages/desktop/test/updater-config.test.ts
@@ -119,6 +119,8 @@ describe("latest.json 契约（模板 ↔ 生成器 ↔ 工作流）", () => {
     expect(workflow).toContain("latest.json");
     expect(workflow).toContain("desktop-v0.4");
     expect(workflow).toContain("verify-release-assets.mjs");
+    expect(workflow).toContain("Verify updater signing secret matches embedded public key");
+    expect(workflow).toContain("verify-signing-key.mjs");
   });
 });
 

--- a/packages/desktop/updater/verify-signing-key.mjs
+++ b/packages/desktop/updater/verify-signing-key.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { readUpdaterPublicKey, verifyUpdaterSignature } from "./release-contract.mjs";
+
+function parseArgs() {
+  const args = { file: null };
+  for (let index = 2; index < process.argv.length; index++) {
+    const value = process.argv[index];
+    if (value === "--file") args.file = path.resolve(process.argv[++index]);
+    else throw new Error(`unknown argument: ${value}`);
+  }
+  if (!args.file) throw new Error("--file is required");
+  return args;
+}
+
+const { file } = parseArgs();
+const signatureFile = `${file}.sig`;
+for (const candidate of [file, signatureFile]) {
+  const stat = fs.lstatSync(candidate);
+  if (stat.isSymbolicLink() || !stat.isFile() || stat.size === 0) {
+    throw new Error(`signing preflight input must be a non-empty regular file: ${candidate}`);
+  }
+}
+
+const publicKey = readUpdaterPublicKey();
+verifyUpdaterSignature(
+  fs.readFileSync(file),
+  fs.readFileSync(signatureFile, "utf8").trim(),
+  publicKey,
+);
+
+const publicText = Buffer.from(publicKey, "base64").toString("utf8");
+const keyId = publicText.match(/minisign public key: ([0-9A-F]{16})/)?.[1];
+if (!keyId) throw new Error("embedded updater public key id is missing");
+console.log(`updater signing key preflight passed (${keyId})`);


### PR DESCRIPTION
## Summary
- rotate the updater signing key away from the public Tauri documentation example key
- bind the encrypted private key and password through protected GitHub Secrets
- verify a signed canary against the embedded updater public key before every desktop build
- retain the independent post-build release-asset signature verification

## Evidence
- local encrypted-key signing canary verified with embedded key `1F207020AAE9DE77`
- targeted updater/release-chain tests: 27/27
- full release gate: 72 files, 862 tests, 17 evals, all 8 gates pass
- actionlint and diff check pass