### PR TITLE
fix(release): recover updater channel safely

### DIFF
--- a/.github/workflows/host-publish.yml
+++ b/.github/workflows/host-publish.yml
@@ -1,18 +1,27 @@
 name: host-publish
 
-# Publishing is deliberately separate from the signed-tag build. The tag
-# workflow can only create and verify a draft. An Owner must inspect that draft
-# and then manually enter an exact confirmation before this workflow can make
-# the immutable version release public and advance the 0.4 updater channel.
+# Publishing is deliberately separate from the signed-tag build. The normal
+# path publishes a verified draft and advances the updater channel. The
+# recovery path repairs only a lagging metadata channel from an already-public,
+# independently verified immutable release; it never rebuilds or replaces a
+# versioned asset.
 on:
   workflow_dispatch:
     inputs:
+      operation:
+        description: "Publish a draft, or recover only the updater channel"
+        required: true
+        default: publish
+        type: choice
+        options:
+          - publish
+          - channel-recovery
       tag:
         description: "Exact signed stable tag to publish (for example v0.4.0)"
         required: true
         type: string
       confirm:
-        description: "Enter publish-<tag> exactly (for example publish-v0.4.0)"
+        description: "Enter publish-<tag> or recover-channel-<tag> exactly"
         required: true
         type: string
 
@@ -25,7 +34,7 @@ concurrency:
 
 jobs:
   publish:
-    name: Re-verify draft, publish, and advance desktop-v0.4
+    name: Re-verify release and publish or recover desktop-v0.4
     if: github.repository == 'kevinchennewbee/PenglaiAgent'
     runs-on: ubuntu-latest
     environment: release
@@ -35,6 +44,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       PUBLISH_TAG: ${{ inputs.tag }}
       PUBLISH_CONFIRM: ${{ inputs.confirm }}
+      PUBLISH_OPERATION: ${{ inputs.operation }}
       TRUSTED_RELEASE_FINGERPRINT: 108B8D1D5592D8F71EEAC9AB362CF5452371B1E5
     steps:
       - name: Require exact Owner confirmation
@@ -45,8 +55,13 @@ jobs:
             echo "::error::tag must be a strict stable v0.4.x tag"
             exit 1
           fi
-          if [[ "$PUBLISH_CONFIRM" != "publish-$PUBLISH_TAG" ]]; then
-            echo "::error::confirmation must equal publish-$PUBLISH_TAG"
+          case "$PUBLISH_OPERATION" in
+            publish) expected_confirm="publish-$PUBLISH_TAG" ;;
+            channel-recovery) expected_confirm="recover-channel-$PUBLISH_TAG" ;;
+            *) echo "::error::unsupported operation: $PUBLISH_OPERATION"; exit 1 ;;
+          esac
+          if [[ "$PUBLISH_CONFIRM" != "$expected_confirm" ]]; then
+            echo "::error::confirmation must equal $expected_confirm"
             exit 1
           fi
 
@@ -113,7 +128,7 @@ jobs:
           fi
           echo "tag_target=$tag_target" >> "$GITHUB_OUTPUT"
 
-      - name: Require an unpublished draft for the exact tag
+      - name: Require the exact release state for this operation
         shell: bash
         run: |
           set -euo pipefail
@@ -121,13 +136,17 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --json tagName,isDraft,isPrerelease \
             --jq '[.tagName,.isDraft,.isPrerelease] | @tsv')"
-          expected_state="$(printf '%s\ttrue\tfalse' "$PUBLISH_TAG")"
+          if [[ "$PUBLISH_OPERATION" == "publish" ]]; then
+            expected_state="$(printf '%s\ttrue\tfalse' "$PUBLISH_TAG")"
+          else
+            expected_state="$(printf '%s\tfalse\tfalse' "$PUBLISH_TAG")"
+          fi
           if [[ "$release_state" != "$expected_state" ]]; then
-            echo "::error::$PUBLISH_TAG must exist as a non-prerelease draft"
+            echo "::error::$PUBLISH_TAG has the wrong state for $PUBLISH_OPERATION"
             exit 1
           fi
 
-      - name: Download and cryptographically re-verify every draft asset
+      - name: Download and cryptographically re-verify every release asset
         shell: bash
         run: |
           set -euo pipefail
@@ -139,7 +158,8 @@ jobs:
             --dir release-download \
             --version "${PUBLISH_TAG#v}"
 
-      - name: Reject updater channel rollback before publication
+      - name: Reject updater channel rollback or conflicting replay
+        id: channel_guard
         shell: bash
         env:
           PENGLAI_CHANNEL: ${{ steps.contract.outputs.channel }}
@@ -176,13 +196,24 @@ jobs:
             if (!match) throw new Error(`invalid stable channel version: ${value}`);
             return Number(match[1]);
           };
-          if (patch(candidate.version) <= patch(current.version)) {
-            throw new Error(`refusing updater rollback/replay ${current.version} -> ${candidate.version}`);
+          const currentPatch = patch(current.version);
+          const candidatePatch = patch(candidate.version);
+          if (candidatePatch < currentPatch) {
+            throw new Error(`refusing updater rollback ${current.version} -> ${candidate.version}`);
+          }
+          if (candidatePatch === currentPatch) {
+            const currentBytes = fs.readFileSync(process.env.CURRENT_MANIFEST);
+            const candidateBytes = fs.readFileSync(process.env.CANDIDATE_MANIFEST);
+            if (!currentBytes.equals(candidateBytes)) {
+              throw new Error(`refusing conflicting updater replay for ${candidate.version}`);
+            }
+            console.log(`updater channel already has the exact ${candidate.version} manifest`);
           }
           NODE
           fi
 
       - name: Publish the independently verified immutable version release
+        if: inputs.operation == 'publish'
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/host-release.yml
+++ b/.github/workflows/host-release.yml
@@ -141,7 +141,12 @@ jobs:
           npm run typecheck --workspace @penglai/protocol
           npm run typecheck --workspace @penglai/host
           npm run typecheck --workspace @penglai/desktop
+          node scripts/check-protocol-contract.mjs
           node scripts/check-release-contract.mjs --tag "$GITHUB_REF_NAME"
+          node scripts/check-desktop-allowlist.mjs
+          npm run build --workspace @penglai/desktop
+          node scripts/check-renderer-token-boundary.mjs
+          node scripts/check-renderer-network-boundary.mjs
           node scripts/release-check.mjs --only=scan,deps,files,statement,schema
 
       - name: Build and verify exact runtime

--- a/.github/workflows/host-test.yml
+++ b/.github/workflows/host-test.yml
@@ -108,6 +108,11 @@ jobs:
         # release-time assertion; 0.4 keeps it in CI).
         run: node scripts/check-renderer-token-boundary.mjs
 
+      - name: Renderer network boundary
+        # Host-only DNS, redirect and inference transports must never enter the
+        # browser renderer source graph or its built Vite assets.
+        run: node scripts/check-renderer-network-boundary.mjs
+
       - name: Release gates (fast subset)
         # The slow gates (full vitest/eval) already ran above; run the fast
         # deterministic gates so scan/deps/files/statement/schema cannot rot

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## 0.4.1：它开始读得懂你的资料
 
-- **个人上下文 V1。** 你显式授权一个本地文档目录（向导里一步完成，或 CLI `penglai context source add`），蓬莱在本机用 SQLite + FTS5 建立可删除的派生索引。不上传任何内容，绝不改写原文件，随时可移除授权。
+- **个人上下文 V1。** 你显式授权一个本地文档目录（向导里一步完成，或 CLI `penglai context source add`），蓬莱在本机用 SQLite + FTS5 建立可删除的派生索引。原文件与完整索引不上传、绝不改写原文件，随时可移除授权；使用云模型回答时，本次检索到的相关片段会发送给你选择的模型供应商。
 - **Host 验证的来源引用。** 回答带来源卡片：哪个文件、哪一节、什么状态（current / stale / revoked）。引用跨重启与重索引持久，文件变了徽标如实变——不是模型嘴上的"引用"。
 - **装好即有用。** 向导里交出资料目录，空会话直接给出从你文档真实标题生成的示例问题，点击即问。
 - **一批失真修复。** IM 排队应答不再被当成失败、Owner 取消不再记成 failed、大目录索引不再卡住原生壳等；详见[发布说明](RELEASE_NOTES_0.4.1.md)。
@@ -173,7 +173,7 @@ Penglai 使用 [MIT License](LICENSE)，继承并感谢 GenericAgent 的早期�
 
 Penglai 0.4 is a local AI workbench built around a TypeScript Host and the Pi agent runtime. It preserves the useful product ideas proven by 0.3.x—persistent assistance, IM access, memory and workflows—while adding durable projects, tasks, runs, evidence, approvals, budgets and recovery.
 
-**New in 0.4.1 — Personal Context V1.** You explicitly grant Penglai a local documents directory (one optional step in the setup wizard, or `penglai context source add` in the CLI). The Host builds a deletable derived index on your machine with SQLite + FTS5—nothing is uploaded, original files are never modified, and revoking a grant removes only the index. Answers carry Host-verified source cards showing the file, the section and a live status (current / stale / revoked); references survive restarts and reindexing, and the badges change truthfully when your files do. An empty chat now offers example questions generated offline from your real document titles, so the app is useful the moment setup ends. 0.4.1 also fixes a batch of state-fidelity bugs (queued IM replies shown as failures, owner cancellations recorded as `failed`, large-directory indexing blocking the native shell, and more)—see the [release notes](RELEASE_NOTES_0.4.1.md).
+**New in 0.4.1 — Personal Context V1.** You explicitly grant Penglai a local documents directory (one optional step in the setup wizard, or `penglai context source add` in the CLI). The Host builds a deletable derived index on your machine with SQLite + FTS5: original files and the complete index stay local, original files are never modified, and revoking a grant removes only the index. When a cloud model answers, the relevant snippets retrieved for that request are sent to the model provider you selected. Answers carry Host-verified source cards showing the file, the section and a live status (current / stale / revoked); references survive restarts and reindexing, and the badges change truthfully when your files do. An empty chat now offers example questions generated offline from your real document titles, so the app is useful the moment setup ends. 0.4.1 also fixes a batch of state-fidelity bugs (queued IM replies shown as failures, owner cancellations recorded as `failed`, large-directory indexing blocking the native shell, and more)—see the [release notes](RELEASE_NOTES_0.4.1.md).
 
 There is one assistant and one conversation surface. A conversation either works on the assistant's own ground or is explicitly anchored by the owner to a realpath-checked project directory; this is a boundary change, not a second capability mode. Desktop, CLI, Goal, Feishu, WeChat and durable Tasks all execute through `EpisodeRunner → Pi AgentKernel`.
 

--- a/RELEASE_NOTES_0.4.1.md
+++ b/RELEASE_NOTES_0.4.1.md
@@ -6,7 +6,7 @@
 
 ## 个人上下文 V1
 
-- **显式授权，本地索引。** Owner 通过桌面原生目录选择器或 CLI 授权 global / project 目录；Host 用 SQLite + FTS5 在本机建立离线派生索引。原文件绝不改写或删除；随时可在设置或 CLI 移除授权，移除只删索引。
+- **显式授权，本地索引。** Owner 通过桌面原生目录选择器或 CLI 授权 global / project 目录；Host 用 SQLite + FTS5 在本机建立离线派生索引。原文件与完整索引不上传，原文件绝不改写或删除；随时可在设置或 CLI 移除授权，移除只删索引。使用云模型回答时，本次检索到的相关片段会发送给 Owner 选择的模型供应商。
 - **Host 验证的来源引用。** 助理回答可携带 `contextReferences[]` 来源卡片：文档标题、相对路径、章节/行/键位置与 current / stale / revoked / unavailable 状态。引用由 Host 逐条验证并跨会话持久化，重启、重索引、撤销授权后徽标如实更新——不是模型嘴上的"引用"。
 - **结构化定位。** Markdown/TXT 保留 heading 与偏移；CSV/TSV 保留表头与行组；JSON/YAML/XML 保留 key path。每个引用都能解释"出自哪里"。
 - **Task 证据轨新增 `source` 类别。** 仅由 Host/tool observation 创建，metadata 带相对路径、位置、document/chunk hash 与查询；桌面证据轨新增「资料来源」区。
@@ -44,7 +44,7 @@
 
 - macOS Developer ID / notarization 与 Windows Authenticode 尚未配置；首次启动可能出现 Gatekeeper / SmartScreen 提示。updater 资产由 minisign 保护，但 minisign 不替代操作系统发行者信任。
 - FTS trigram 分词需要至少 3 个字符的查询词；两字中文词请换更长表述。
-- 个人上下文 V1 支持 Markdown / TXT / CSV / TSV / JSON / YAML / XML 等文本格式；PDF / DOCX 索引在后续版本。
+- 个人上下文 V1 当前支持 PDF / DOCX / XLSX / PPTX / Markdown / TXT / CSV / TSV / JSON / YAML / XML / HTML / RTF；复杂版式、扫描件 OCR 与公式还原不属于 V1 保证。
 - 多平台真机安装与 0.4.0 → 0.4.1 updater 生命周期验证在 Release 资产产出后按 [docs/RELEASE_PROCESS.md](docs/RELEASE_PROCESS.md) §7 补做。
 
 ## 从 0.4.0 升级

--- a/docs/PRIVACY_AND_DATA.md
+++ b/docs/PRIVACY_AND_DATA.md
@@ -31,6 +31,9 @@ deliverables remain in the Owner-selected workspace.
 ## What leaves the computer
 
 - Prompts, selected context and tool results sent to the configured model API.
+  Personal-context source files and the complete SQLite/FTS index stay local,
+  but snippets retrieved for a cloud-model request are selected context and
+  therefore leave the computer for that configured provider.
 - Search terms and fetched public URLs when the Owner approves web research.
 - MCP arguments sent to an Owner-connected remote MCP endpoint; stdio MCP runs
   locally but is still third-party code.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -86,19 +86,36 @@ git push <public-remote> v0.4.0
 7. Owner 在 GitHub 页面检查 Actions、草稿说明和全部资产后，手工运行
    `host-publish.yml`，输入 tag 和精确的 `publish-<tag>` 确认词。
 8. `host-publish.yml` 再次验证版本契约、Owner signed annotated tag、draft 状态和全部
-   下载资产；同时拒绝 updater channel 版本回退或同版本重放。全部通过后才
+   下载资产；同时拒绝 updater channel 版本回退或同版本冲突重放。全部通过后才
    publish/mark latest，随后只把已验证的 `latest.json` 推进固定 `desktop-v0.4`
    metadata prerelease。
 
+如果版本 Release 已经公开但 metadata channel 因中断或误操作落后，禁止重打或替换
+同版本安装包。Owner 改用同一 `host-publish` workflow 的 `channel-recovery` operation，
+输入精确 signed tag 与 `recover-channel-<tag>` 确认词。恢复模式要求版本 Release 已是
+公开 stable，仍会重新下载并验证全部资产，只允许把较旧 channel 推进到候选版本；
+同版本仅在 manifest 字节完全一致时幂等成功，任何回退或冲突重放都失败。恢复模式
+不会执行 Release publish 步骤。
+
 构建工作流拒绝覆盖已存在的版本 Release。失败留下 draft 时，Owner 先检查失败证据，
-再手工决定是否删除 draft 后重跑；自动化不会 clobber 一个已有的版本发布。发布工作流
-只接受现存、未公开、非 prerelease 的精确 tag 草稿；对已经公开的 Release 会失败。
+再手工决定是否删除 draft 后重跑；自动化不会 clobber 一个已有的版本发布。正常
+`publish` operation 只接受现存、未公开、非 prerelease 的精确 tag 草稿；已经公开的
+stable Release 只有 `channel-recovery` operation 可以接受，而且该模式不能再次发布或
+替换版本资产。
 
 手工发布时，在 Actions 中选择 `host-publish`，输入例如：
 
 ```text
 tag: v0.4.0
 confirm: publish-v0.4.0
+```
+
+只恢复已经公开版本的更新通道时输入：
+
+```text
+operation: channel-recovery
+tag: v0.4.1
+confirm: recover-channel-v0.4.1
 ```
 
 未配置 protected `release` environment 时不要运行发布工作流；仓库内 YAML 无法替代

--- a/packages/desktop/test/release-chain.test.ts
+++ b/packages/desktop/test/release-chain.test.ts
@@ -331,27 +331,35 @@ describe("manual host-publish workflow policy", () => {
 
   it("requires workflow_dispatch, a protected environment, and an exact confirmation", () => {
     expect(workflow.on.push).toBeUndefined();
+    expect(workflow.on.workflow_dispatch.inputs.operation.required).toBe(true);
+    expect(workflow.on.workflow_dispatch.inputs.operation.options).toEqual([
+      "publish",
+      "channel-recovery",
+    ]);
     expect(workflow.on.workflow_dispatch.inputs.tag.required).toBe(true);
     expect(workflow.on.workflow_dispatch.inputs.confirm.required).toBe(true);
     expect(workflow.permissions).toEqual({ contents: "read" });
     expect(workflow.jobs.publish.permissions).toEqual({ contents: "write" });
     expect(workflow.jobs.publish.environment).toBe("release");
     expect(raw).toContain('"publish-$PUBLISH_TAG"');
+    expect(raw).toContain('"recover-channel-$PUBLISH_TAG"');
   });
 
-  it("re-verifies the signed tag and draft assets before publishing", () => {
+  it("re-verifies signed immutable assets before publishing or recovering the channel", () => {
     for (const gate of [
       "git verify-tag --raw",
       "VALIDSIG",
       "verify-release-assets.mjs",
-      "must exist as a non-prerelease draft",
-      "Reject updater channel rollback",
+      "wrong state for $PUBLISH_OPERATION",
+      "Reject updater channel rollback or conflicting replay",
+      "refusing conflicting updater replay",
       "--draft=false",
       "desktop-v0.4",
     ]) {
       expect(raw).toContain(gate);
     }
     expect(raw.indexOf("verify-release-assets.mjs")).toBeLessThan(raw.indexOf("--draft=false"));
+    expect(raw).toContain("if: inputs.operation == 'publish'");
   });
 
   it("pins every third-party action to a full commit", () => {


### PR DESCRIPTION
## What changed

- add an explicit protected `channel-recovery` operation to `host-publish`
- re-verify the signed tag and all immutable release assets before channel repair
- reject updater rollback and same-version manifests whose bytes conflict
- make exact same-version recovery idempotent
- run the renderer network-boundary gate in both main CI and tag release CI
- correct Personal Context format support and cloud-model data-egress wording
- document the recovery procedure

## Why

The immutable `v0.4.1` release was published while `desktop-v0.4/latest.json` still pointed to `0.4.0`. The channel has been repaired separately after downloading and cryptographically verifying all 17 existing `v0.4.1` assets. This PR prevents the same incident from requiring an unaudited manual upload in the future.

No Host/Desktop runtime behavior or versioned release asset changes are included. Product version remains `0.4.1`.

## Validation

- `npm test` — 84 files / 930 tests
- `npm run eval` — 17/17
- protocol, Host, Desktop typechecks
- Desktop build
- renderer token and network boundaries
- protocol/release/allowlist contracts
- `npm audit --audit-level=moderate` — 0 vulnerabilities
- release scan/dependencies/files/statement/schema — 5/5