### PR TITLE
fix(release): isolate channel recovery environment

### DIFF
--- a/.github/workflows/host-publish.yml
+++ b/.github/workflows/host-publish.yml
@@ -37,7 +37,12 @@ jobs:
     name: Re-verify release and publish or recover desktop-v0.4
     if: github.repository == 'kevinchennewbee/PenglaiAgent'
     runs-on: ubuntu-latest
-    environment: release
+    # GitHub resolves Environment protection before any step runs. Normal
+    # publishing is dispatched from the signed v0.4.x tag and remains in the
+    # tag-only `release` environment. Recovery uses the protected `main` copy
+    # of this workflow, so it has a separate main-only, Owner-reviewed
+    # environment instead of weakening the release tag policy.
+    environment: ${{ inputs.operation == 'channel-recovery' && 'release-channel-recovery' || 'release' }}
     permissions:
       contents: write
     env:

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -95,7 +95,9 @@ git push <public-remote> v0.4.0
 输入精确 signed tag 与 `recover-channel-<tag>` 确认词。恢复模式要求版本 Release 已是
 公开 stable，仍会重新下载并验证全部资产，只允许把较旧 channel 推进到候选版本；
 同版本仅在 manifest 字节完全一致时幂等成功，任何回退或冲突重放都失败。恢复模式
-不会执行 Release publish 步骤。
+不会执行 Release publish 步骤。GitHub Environment 必须分开配置：`release` 只允许
+`v0.4.*` tags；`release-channel-recovery` 只允许 protected `main`，两者都要求 Owner
+review 且禁止 administrator bypass。不要为了恢复通道而放宽 tag-only `release` 环境。
 
 构建工作流拒绝覆盖已存在的版本 Release。失败留下 draft 时，Owner 先检查失败证据，
 再手工决定是否删除 draft 后重跑；自动化不会 clobber 一个已有的版本发布。正常

--- a/packages/desktop/test/release-chain.test.ts
+++ b/packages/desktop/test/release-chain.test.ts
@@ -340,7 +340,8 @@ describe("manual host-publish workflow policy", () => {
     expect(workflow.on.workflow_dispatch.inputs.confirm.required).toBe(true);
     expect(workflow.permissions).toEqual({ contents: "read" });
     expect(workflow.jobs.publish.permissions).toEqual({ contents: "write" });
-    expect(workflow.jobs.publish.environment).toBe("release");
+    expect(workflow.jobs.publish.environment).toContain("release-channel-recovery");
+    expect(workflow.jobs.publish.environment).toContain("release");
     expect(raw).toContain('"publish-$PUBLISH_TAG"');
     expect(raw).toContain('"recover-channel-$PUBLISH_TAG"');
   });


### PR DESCRIPTION
## What changed

- route normal publish jobs to the existing tag-only `release` Environment
- route `channel-recovery` jobs to a separate `release-channel-recovery` Environment
- document that recovery must not weaken the signed-tag release policy
- pin the workflow contract in tests

## Root cause

GitHub evaluates Environment deployment policies before any workflow step runs. `release` correctly allows only `v0.4.*` tags, while the new recovery workflow code is dispatched from protected `main`; the first recovery rehearsal was therefore rejected with zero steps.

The repository environment is now configured separately for recovery: protected `main` only, Owner required reviewer, administrator bypass disabled. The original `release` Environment remains tag-only and unchanged.

## Validation

- release-chain workflow contract: 18/18
- workflow YAML parse
- diff check