### PR TITLE
docs(site): credit collaborative development accurately

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -430,13 +430,14 @@
             <p><b>Version boundary:</b> the GenericAgent-based Python product line (0.3.x) is frozen in the historical <code>v0.3.6</code> tag; the current <code>main</code> and formal <code>v0.4.x</code> Releases are the Pi-centered TypeScript rewrite, currently at <code>v0.4.1</code>.</p>
           </div>
           <div class="legal-card reveal reveal-delay-1">
-            <h3>Acknowledgments — standing on these projects</h3>
+            <h3>Acknowledgments — open-source foundations and collaborative tools</h3>
             <ul class="ack-list">
               <li><a href="https://github.com/earendil-works/pi-agent-core" target="_blank" rel="noopener">Pi · @earendil-works/pi-agent-core</a><span class="lic">MIT</span> — the engine: 0.4's open-source kernel</li>
               <li><a href="https://github.com/lsdefine/GenericAgent" target="_blank" rel="noopener">GenericAgent</a><span class="lic">MIT</span> — the genes: 0.3's execution core, and the cleanest agent loop we've seen</li>
               <li><a href="https://github.com/FunAudioLLM/SenseVoice" target="_blank" rel="noopener">SenseVoice</a><span class="lic">MIT</span> · <a href="https://github.com/k2-fsa/sherpa-onnx" target="_blank" rel="noopener">sherpa-onnx</a><span class="lic">Apache-2.0</span> — local voice</li>
               <li><a href="https://github.com/tauri-apps/tauri" target="_blank" rel="noopener">Tauri</a><span class="lic">MIT/Apache-2.0</span> — the desktop shell</li>
-              <li><a href="https://www.moonshot.cn/" target="_blank" rel="noopener">Kimi K3 + Kimi Work</a> — built with: 0.4.0 was designed and implemented by Kimi K3 in Kimi Work</li>
+              <li><b>Collaborative development:</b> <a href="https://www.moonshot.cn/" target="_blank" rel="noopener">Kimi Work</a>, <a href="https://x.ai/" target="_blank" rel="noopener">Grok Build</a>, <a href="https://www.cursor.com/" target="_blank" rel="noopener">Cursor</a>, and <a href="https://openai.com/codex/" target="_blank" rel="noopener">OpenAI Codex</a> contributed to implementation, review, and iteration at different stages.</li>
+              <li><b>Accountability:</b> the owner leads and remains responsible for product direction, architecture choices, risk judgment, acceptance, and releases; no single model or platform independently completed the whole release.</li>
             </ul>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -430,13 +430,14 @@
             <p><b>版本边界：</b>基于 GenericAgent 的 Python 产品线（0.3.x）冻结在历史标签 <code>v0.3.6</code>；当前 <code>main</code> 与正式 <code>v0.4.x</code> Release 是以 Pi 为核心的 TypeScript 重写，最新版本 <code>v0.4.1</code>。</p>
           </div>
           <div class="legal-card reveal reveal-delay-1">
-            <h3>致谢 · 站在这些项目上</h3>
+            <h3>致谢 · 开源基础与协作工具</h3>
             <ul class="ack-list">
               <li><a href="https://github.com/earendil-works/pi-agent-core" target="_blank" rel="noopener">Pi · @earendil-works/pi-agent-core</a><span class="lic">MIT</span> —— 引擎：0.4 的开源内核</li>
               <li><a href="https://github.com/lsdefine/GenericAgent" target="_blank" rel="noopener">GenericAgent</a><span class="lic">MIT</span> —— 基因：0.3 的执行内核，致以最干净的 Agent 实现</li>
               <li><a href="https://github.com/FunAudioLLM/SenseVoice" target="_blank" rel="noopener">SenseVoice</a><span class="lic">MIT</span> · <a href="https://github.com/k2-fsa/sherpa-onnx" target="_blank" rel="noopener">sherpa-onnx</a><span class="lic">Apache-2.0</span> —— 本地语音</li>
               <li><a href="https://github.com/tauri-apps/tauri" target="_blank" rel="noopener">Tauri</a><span class="lic">MIT/Apache-2.0</span> —— 桌面外壳</li>
-              <li><a href="https://www.moonshot.cn/" target="_blank" rel="noopener">Kimi K3 + Kimi Work</a> —— 构建：0.4.0 的设计与实现，由 Kimi K3 在 Kimi Work 中完成</li>
+              <li><b>协作开发：</b><a href="https://www.moonshot.cn/" target="_blank" rel="noopener">Kimi Work</a>、<a href="https://x.ai/" target="_blank" rel="noopener">Grok Build</a>、<a href="https://www.cursor.com/" target="_blank" rel="noopener">Cursor</a> 与 <a href="https://openai.com/codex/" target="_blank" rel="noopener">OpenAI Codex</a> 在不同阶段参与实现、审查与迭代。</li>
+              <li><b>责任归属：</b>产品方向、架构取舍、风险判断、验收和发布由 Owner 主导并负责；没有任何单一模型或平台独立完成整个版本。</li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove the inaccurate claim that Kimi K3/Kimi Work alone designed and implemented 0.4.0
- credit Kimi Work, Grok Build, Cursor, and OpenAI Codex as collaborative tools used at different stages
- state that the owner leads product direction, architecture, risk judgment, acceptance, and releases
- apply the same correction to the Chinese and English official-site pages

## Verification
- in-app Browser rendered both local pages successfully
- all four collaboration links and the owner-accountability statement are visible in both languages
- obsolete single-model attribution has zero DOM matches
- `git diff --check`

No version, runtime, release asset, or desktop-client change.