### PR TITLE
fix: harden native installer evidence paths for 0.5.1

### DIFF
--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -124,5 +124,10 @@ test("soak runner samples IM offline sleep update uninstall on the exact DMG", (
   const windowsPayload = readFileSync(join(root, "scripts/package-windows-payload.mjs"), "utf8");
   assert.match(windowsPayload, /build-windows-host\.mjs/);
   assert.match(windowsPayload, /join\(staging, "runtime", "helpers"\)/);
+  assert.match(windowsPayload, /stamp-windows-exe\.mjs/);
+  assert.match(windowsPayload, /release-info\.json/);
+  const verifyInstalled = readFileSync(join(root, "scripts/verify-installed.mjs"), "utf8");
+  assert.match(verifyInstalled, /R50-WIN-009/);
+  assert.match(verifyInstalled, /R50-MAC-010/);
   assert.match(soak, /remote-debugging-port/);
 });

--- a/docs/0.5.1/RELEASE_RUNBOOK.md
+++ b/docs/0.5.1/RELEASE_RUNBOOK.md
@@ -10,7 +10,7 @@ Declared installers from one source SHA:
 - `Penglai_0.5.1_macos_x64.dmg`
 - `Penglai_0.5.1_windows_x64_setup.exe`
 
-Missing Intel/Windows native runners, PluginRegistry, immutable Releases, or key backup are **BLOCKED**, never native PASS. Do not push, tag, or publish until Owner freeze.
+The public Plugin Registry exists, both repositories have Immutable Releases enabled, and the embedded public-key fingerprints match the Owner key directory plus backup. Intel/Windows native runners and exact installed evidence remain **BLOCKED** until executed; none may be replaced by cross-build output. Do not tag or publish until Owner freeze.
 
 ## Local source gates
 
@@ -22,12 +22,16 @@ pnpm test:security
 pnpm verify:identity
 pnpm verify:contracts
 pnpm verify:clean-clone
+node scripts/verify-release-keys.mjs
 ```
 
-`package:mac --target darwin-x64` and `package:windows` must exit 4 on a non-matching host.
+`package:mac --target darwin-x64` and `package:windows` must exit 4 on a non-matching host. Before every native build, run `pnpm prepare:public-export` on the same clean `main` SHA.
 
 ## After Owner approval
 
-1. WIP branch + Draft PR only if the Owner asks to backup collaboration.
-2. Merge main only after review. Build the three artifacts from exact main.
-3. Draft GitHub Release readback; publish only when Hard evidence is PASS.
+1. Build Apple Silicon with `pnpm package:dmg:arm` on a native Apple Silicon Mac.
+2. Build Intel with `pnpm package:dmg:intel` on a native Intel Mac.
+3. From an x64 Native Tools Command Prompt with NSIS installed, build Windows with `pnpm package:windows`. This compiles the native helper, stamps `Penglai.exe`, creates Setup, reinstalls the exact Setup, and writes target-bound installer evidence.
+4. On each native runner, execute `test:e2e:installed`, `verify:installed`, and the two-hour `test:soak:installed` with the exact `PENGLAI_TARGET`; retain the target-specific evidence files.
+5. Aggregate the three native evidence sets and require `verify:installed --aggregate`, `verify:evidence`, and `verify:release` to PASS.
+6. Create draft GitHub Releases, attach all exact assets, and publish only after every Hard gate is PASS. Immutable Releases are effective when the draft is published; read them back afterward.

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
   "devDependencies": {
     "@types/node": "22.16.5",
     "esbuild": "0.25.9",
+    "resedit": "3.0.2",
     "tsx": "4.20.3",
     "typescript": "5.9.2"
   }

--- a/packages/runtime/src/windows-host.test.ts
+++ b/packages/runtime/src/windows-host.test.ts
@@ -167,15 +167,27 @@ test("NSIS script default-preserves user data and only deletes via capability ha
   assert.match(script, /deletion-capability\.json/);
   assert.doesNotMatch(script, /RMDir\s+\/r\s+"\$LOCALAPPDATA\\Penglai\\0\.5"/);
   assert.match(script, /SectionUninstall/);
-  // Numeric downgrade comparison (not lexicographic) and no installer
-  // self-deleting a desktop shortcut it never created.
+  // Numeric downgrade comparison (not lexicographic) and an explicitly
+  // optional desktop shortcut with matching uninstall cleanup.
   assert.match(script, /\$\{VersionCompare\}/);
   assert.doesNotMatch(script, /\$\{If\}\s+\$0\s+S>\s*"\$\{PENGLAI_VERSION\}"/);
-  assert.doesNotMatch(script, /Delete\s+"\$DESKTOP\\Penglai\.lnk"/);
+  assert.match(script, /Section\s+\/o\s+"\$\(DESC_Desktop\)"/);
+  assert.match(script, /CreateShortCut\s+"\$DESKTOP\\Penglai\.lnk"/);
+  assert.match(script, /Delete\s+"\$DESKTOP\\Penglai\.lnk"/);
   // The recursive app-tree delete must be guarded to the default install dir.
   assert.match(script, /RMDir\s+\/r\s+"\$INSTDIR"\s*\n\s*\$\{Else\}/);
   const contract = windowsNativeHostContract();
   assert.equal(contract.posixModeImpersonation, false);
+  const payload = readFileSync(new URL("../../../scripts/package-windows-payload.mjs", import.meta.url), "utf8");
+  const packager = readFileSync(new URL("../../../scripts/package-windows-nsis.mjs", import.meta.url), "utf8");
+  assert.match(payload, /public-export\.json/);
+  assert.match(payload, /release-info\.json/);
+  assert.match(payload, /stamp-windows-exe\.mjs/);
+  assert.match(payload, /Penglai\.ico/);
+  assert.match(packager, /local-installer-win32-x86_64\.json/);
+  assert.match(packager, /\/DPENGLAI_ICON=/);
+  assert.match(script, /!define MUI_ICON "\$\{PENGLAI_ICON\}"/);
+  assert.match(packager, /exact Setup did not reinstall/);
 });
 
 test("Windows inventory helper is not implied by a darwin inspect", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
       esbuild:
         specifier: 0.25.9
         version: 0.25.9
+      resedit:
+        specifier: 3.0.2
+        version: 3.0.2
       tsx:
         specifier: 4.20.3
         version: 4.20.3
@@ -4162,6 +4165,10 @@ packages:
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
+  pe-library@2.0.1:
+    resolution: {integrity: sha512-/qjYFqNSlq59B5DI36am++5/3gMgh02QnzpYigrwrW6s+QpU0mHf09/iA4wjTu21UUxodyV7ZCetV5MiDhaN/A==}
+    engines: {node: '>=20'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -4257,6 +4264,10 @@ packages:
 
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
+  resedit@3.0.2:
+    resolution: {integrity: sha512-FnqVDJYX4etlEnz2AaJYE1c1FTcgrsHiI2U4DXRxO4CIzbGP7r0jml9uZIMlvzCom2pbBLZjIhF26wj92y1cVQ==}
+    engines: {node: '>=20'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -8882,6 +8893,8 @@ snapshots:
 
   path-to-regexp@8.4.2: {}
 
+  pe-library@2.0.1: {}
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
@@ -8968,6 +8981,10 @@ snapshots:
   require-from-string@2.0.2: {}
 
   require-main-filename@2.0.0: {}
+
+  resedit@3.0.2:
+    dependencies:
+      pe-library: 2.0.1
 
   resolve-pkg-maps@1.0.0: {}
 

--- a/scripts/build-local-dmg.mjs
+++ b/scripts/build-local-dmg.mjs
@@ -233,6 +233,24 @@ writeFileSync(
   ),
 );
 writeFileSync(
+  join(ROOT, `evidence/generated/local-installer-${expectedTarget}.json`),
+  JSON.stringify(
+    {
+      dmg: targetSpec.dmg,
+      sha256: hash,
+      sourceSha: head,
+      treeDirty: dirty,
+      signatureKind: "adhoc",
+      phase: "TARGET_BUILT",
+      installer: targetSpec.dmg.split("/").pop(),
+      target: expectedTarget,
+      publicExportTreeSha256: packagedBeforeSeal.release.publicExportTreeSha256,
+    },
+    null,
+    2,
+  ),
+);
+writeFileSync(
   join(ROOT, "evidence/generated/TARGET_BUILT.json"),
   JSON.stringify(
     {

--- a/scripts/nsis/Penglai.nsi
+++ b/scripts/nsis/Penglai.nsi
@@ -27,6 +27,13 @@ InstallDirRegKey HKCU "Software\Penglai\0.5" "InstallDir"
 !define HELPER "$INSTDIR\runtime\helpers\penglai-windows-host.exe"
 !define CAPABILITY "${USERDATA}\uninstall\deletion-capability.json"
 
+!ifdef PENGLAI_ICON
+  !define MUI_ICON "${PENGLAI_ICON}"
+  !define MUI_UNICON "${PENGLAI_ICON}"
+  Icon "${PENGLAI_ICON}"
+  UninstallIcon "${PENGLAI_ICON}"
+!endif
+
 !include "MUI2.nsh"
 !include "LogicLib.nsh"
 !include "FileFunc.nsh"
@@ -40,6 +47,7 @@ InstallDirRegKey HKCU "Software\Penglai\0.5" "InstallDir"
   !define PENGLAI_LICENSE "license.rtf"
 !endif
 !insertmacro MUI_PAGE_LICENSE "${PENGLAI_LICENSE}"
+!insertmacro MUI_PAGE_COMPONENTS
 !insertmacro MUI_PAGE_DIRECTORY
 !insertmacro MUI_PAGE_INSTFILES
 !insertmacro MUI_PAGE_FINISH
@@ -48,6 +56,9 @@ InstallDirRegKey HKCU "Software\Penglai\0.5" "InstallDir"
 
 !insertmacro MUI_LANGUAGE "SimpChinese"
 !insertmacro MUI_LANGUAGE "English"
+
+LangString DESC_Desktop ${LANG_SIMPCHINESE} "桌面快捷方式"
+LangString DESC_Desktop ${LANG_ENGLISH} "Desktop shortcut"
 
 Function .onInit
   ${IfNot} ${RunningX64}
@@ -85,10 +96,15 @@ Section "Penglai" SecApp
   WriteUninstaller "$INSTDIR\Uninstall.exe"
 SectionEnd
 
+Section /o "$(DESC_Desktop)" SecDesktop
+  CreateShortCut "$DESKTOP\Penglai.lnk" "$INSTDIR\Penglai.exe"
+SectionEnd
+
 Section "un.Penglai" SectionUninstall
   ; Default uninstall: app, shortcuts, uninstall registry, update cache.
   ; UserData is preserved unless a one-shot capability file exists.
   Delete "$SMPROGRAMS\Penglai\Penglai.lnk"
+  Delete "$DESKTOP\Penglai.lnk"
   RMDir "$SMPROGRAMS\Penglai"
   DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_ID}"
   DeleteRegKey HKCU "Software\Penglai\0.5"

--- a/scripts/package-windows-nsis.mjs
+++ b/scripts/package-windows-nsis.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 // Windows current-user NSIS Setup. Native PASS is only legal on win32/x64.
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { ROOT } from "./lib/repo.mjs";
 
@@ -42,19 +43,26 @@ const staging = join(ROOT, "dist", "runtime-staging-win32-x86_64");
 const payload = join(staging, "payload");
 const nsi = join(ROOT, "scripts", "nsis", "Penglai.nsi");
 const license = join(ROOT, "scripts", "nsis", "license.rtf");
+const icon = join(ROOT, "dist", "native-win32-x86_64", "Penglai.ico");
 const makensis = spawnSync("makensis", ["/VERSION"], { encoding: "utf8" });
 if (makensis.status !== 0) {
   console.error("package-windows-nsis BLOCKED: makensis missing on Windows x64 runner");
   process.exit(4);
 }
-if (!existsSync(payload) || !existsSync(nsi) || !existsSync(license)) {
-  console.error("package-windows-nsis BLOCKED: win32-x86_64 staging payload, license, or NSIS script missing");
+if (!existsSync(payload) || !existsSync(nsi) || !existsSync(license) || !existsSync(icon)) {
+  console.error("package-windows-nsis BLOCKED: payload, license, icon, or NSIS script missing");
   process.exit(4);
 }
 const out = join(ROOT, "dist", contract.installer);
 const packed = spawnSync(
   "makensis",
-  [`/DPENGLAI_OUTFILE=${out}`, `/DPENGLAI_PAYLOAD=${payload}`, `/DPENGLAI_LICENSE=${license}`, nsi],
+  [
+    `/DPENGLAI_OUTFILE=${out}`,
+    `/DPENGLAI_PAYLOAD=${payload}`,
+    `/DPENGLAI_LICENSE=${license}`,
+    `/DPENGLAI_ICON=${icon}`,
+    nsi,
+  ],
   { cwd: join(ROOT, "scripts", "nsis"), encoding: "utf8", stdio: "inherit" },
 );
 if (packed.status !== 0) {
@@ -65,4 +73,54 @@ if (!existsSync(out)) {
   console.error("package-windows-nsis FAIL: setup missing after makensis");
   process.exit(1);
 }
-console.log(JSON.stringify({ verdict: "PASS", installer: out, makensis: String(makensis.stdout || "").trim() }));
+const installedRoot = resolve(ROOT, "dist", "Penglai-v0.5.1-win32-x64");
+const installedApp = join(installedRoot, "Penglai");
+const installedRelative = relative(resolve(ROOT, "dist"), installedRoot);
+if (!installedRelative || installedRelative === ".." || installedRelative.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute(installedRelative)) {
+  console.error("package-windows-nsis FAIL: from-installer target escaped dist");
+  process.exit(1);
+}
+rmSync(installedRoot, { recursive: true, force: true });
+mkdirSync(installedApp, { recursive: true });
+const applied = spawnSync(out, ["/S", `/D=${installedApp}`], { cwd: ROOT, encoding: "utf8", windowsHide: true });
+if (applied.status !== 0 || !existsSync(join(installedApp, "Penglai.exe"))) {
+  console.error("package-windows-nsis FAIL: exact Setup did not reinstall into the verification tree");
+  process.exit(1);
+}
+const releaseInfoPath = join(installedApp, "resources", "release-info.json");
+if (!existsSync(releaseInfoPath)) {
+  console.error("package-windows-nsis FAIL: installed payload is missing release-info.json");
+  process.exit(1);
+}
+const releaseInfo = JSON.parse(readFileSync(releaseInfoPath, "utf8"));
+const sha256 = createHash("sha256").update(readFileSync(out)).digest("hex");
+mkdirSync(join(ROOT, "evidence", "generated"), { recursive: true });
+writeFileSync(
+  join(ROOT, "evidence", "generated", "local-installer-win32-x86_64.json"),
+  JSON.stringify(
+    {
+      installer: contract.installer,
+      setup: join("dist", contract.installer),
+      sha256,
+      sourceSha: releaseInfo.sourceSha,
+      treeDirty: releaseInfo.treeDirty,
+      signatureKind: "unsigned-nsis",
+      authenticode: false,
+      phase: "TARGET_BUILT",
+      target: "win32-x86_64",
+      publicExportTreeSha256: releaseInfo.publicExportTreeSha256,
+      installedApp,
+    },
+    null,
+    2,
+  ),
+);
+console.log(
+  JSON.stringify({
+    verdict: "PASS",
+    installer: out,
+    sha256,
+    installedApp,
+    makensis: String(makensis.stdout || "").trim(),
+  }),
+);

--- a/scripts/package-windows-payload.mjs
+++ b/scripts/package-windows-payload.mjs
@@ -1,14 +1,29 @@
 #!/usr/bin/env node
 // Assemble win32-x86_64 NSIS payload. Native Setup PASS remains win32-x64 only.
-import { cpSync, existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { spawnSync } from "node:child_process";
-import { ROOT } from "./lib/repo.mjs";
+import { ROOT, gitState } from "./lib/repo.mjs";
 import { finish } from "./lib/exit-contract.mjs";
 
 const staging = join(ROOT, "dist", "runtime-staging-win32-x86_64");
 const payload = join(staging, "payload");
 const native = process.platform === "win32" && process.arch === "x64";
+const git = gitState();
+const publicExportPath = join(ROOT, "evidence", "generated", "public-export.json");
+const publicExport = existsSync(publicExportPath) ? JSON.parse(readFileSync(publicExportPath, "utf8")) : null;
+if (
+  native &&
+  (git.branch !== "main" || git.head !== git.originMain || git.dirty ||
+    publicExport?.privateCandidateSourceSha !== git.head ||
+    publicExport?.treeDirty !== false ||
+    !/^[0-9a-f]{64}$/.test(String(publicExport?.publicExportTreeSha256 ?? "")))
+) {
+  finish("STALE", {
+    command: "package:windows-payload",
+    reason: "native Windows payload requires clean main at origin/main and current public export evidence",
+  });
+}
 
 function run(cmd, args, extra = {}) {
   const result = spawnSync(cmd, args, { cwd: ROOT, encoding: "utf8", stdio: "inherit", ...extra });
@@ -71,9 +86,19 @@ const electronDir = existsSync(join(dirname(electronRoot), "electron.exe"))
 cpSync(electronDir, payload, { recursive: true });
 const electronExe = join(payload, "electron.exe");
 const penglaiExe = join(payload, "Penglai.exe");
+const penglaiIcon = join(ROOT, "dist", "native-win32-x86_64", "Penglai.ico");
 if (existsSync(electronExe) && !existsSync(penglaiExe)) renameSync(electronExe, penglaiExe);
 if (!existsSync(penglaiExe) && !existsSync(join(payload, "Penglai.exe"))) {
   finish("FAIL", { command: "package:windows-payload", reason: "Penglai.exe missing after Electron copy" });
+}
+const stamped = run(process.execPath, [
+  "scripts/stamp-windows-exe.mjs",
+  penglaiExe,
+  join(ROOT, "overlays", "dsh-0.1.1-rc.1", "brand", "logo-256.png"),
+  penglaiIcon,
+]);
+if (stamped !== 0) {
+  finish("FAIL", { command: "package:windows-payload", reason: "Penglai.exe resource stamping failed" });
 }
 
 const resources = join(payload, "resources");
@@ -85,6 +110,38 @@ cpSync(join(staging, "plugins"), join(resources, "plugins"), { recursive: true }
 for (const name of ["runtime-manifest.json", "release-contract.json", ".closure-complete"]) {
   const src = join(staging, name);
   if (existsSync(src)) cpSync(src, join(resources, name === ".closure-complete" ? "closure-credential.json" : name));
+}
+if (native) {
+  writeFileSync(
+    join(resources, "release-info.json"),
+    `${JSON.stringify({
+      productName: "Penglai",
+      productVersion: "0.5.1",
+      buildNumber: 0,
+      candidateOrdinal: 0,
+      candidateKind: "public-publication-candidate",
+      trustTier: "community-verified",
+      generationId: "penglai-dsh-v0.5",
+      phase: "UNFROZEN",
+      sourceSha: git.head,
+      treeDirty: false,
+      targetPlatform: "win32-x64",
+      electron: "43.4.0",
+      node: "22.22.2",
+      embeddedNode: "22.22.2",
+      dsh: "0.1.1-rc.1",
+      profileSchema: 3,
+      catalogSchema: 2,
+      imSchema: 3,
+      schemaVersion: 2,
+      signed: false,
+      notarized: false,
+      authenticode: false,
+      signatureKind: "unsigned-nsis",
+      developerIdSigned: false,
+      publicExportTreeSha256: publicExport.publicExportTreeSha256,
+    }, null, 2)}\n`,
+  );
 }
 if (native && !existsSync(join(resources, "runtime", "helpers", "penglai-windows-host.exe"))) {
   finish("FAIL", { command: "package:windows-payload", reason: "payload is missing the compiled Windows helper" });

--- a/scripts/stamp-windows-exe.mjs
+++ b/scripts/stamp-windows-exe.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Apply Penglai icon and version resources to the unsigned Windows executable.
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import * as ResEdit from "resedit";
+
+const exePath = resolve(process.argv[2] ?? "");
+const pngPath = resolve(process.argv[3] ?? "");
+const icoPath = process.argv[4] ? resolve(process.argv[4]) : null;
+if (!process.argv[2] || !process.argv[3]) {
+  throw new Error("usage: stamp-windows-exe <exe> <256x256 png> [output ico]");
+}
+
+function pngIco(png) {
+  const header = Buffer.alloc(22);
+  header.writeUInt16LE(0, 0);
+  header.writeUInt16LE(1, 2);
+  header.writeUInt16LE(1, 4);
+  header.writeUInt8(0, 6); // 0 means 256 pixels.
+  header.writeUInt8(0, 7);
+  header.writeUInt8(0, 8);
+  header.writeUInt8(0, 9);
+  header.writeUInt16LE(1, 10);
+  header.writeUInt16LE(32, 12);
+  header.writeUInt32LE(png.length, 14);
+  header.writeUInt32LE(22, 18);
+  return Buffer.concat([header, png]);
+}
+
+const png = readFileSync(pngPath);
+if (
+  png.length < 24 ||
+  !png.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) ||
+  png.readUInt32BE(16) !== 256 ||
+  png.readUInt32BE(20) !== 256
+) {
+  throw new Error("Penglai Windows icon source must be a valid 256x256 PNG");
+}
+const ico = pngIco(png);
+if (icoPath) {
+  mkdirSync(dirname(icoPath), { recursive: true });
+  writeFileSync(icoPath, ico);
+}
+
+const source = readFileSync(exePath);
+const executable = ResEdit.NtExecutable.from(source);
+const resources = ResEdit.NtExecutableResource.from(executable);
+const iconGroups = ResEdit.Resource.IconGroupEntry.fromEntries(resources.entries);
+const iconFile = ResEdit.Data.IconFile.from(ico);
+const iconId = iconGroups[0]?.id ?? 1;
+const iconLang = iconGroups[0]?.lang ?? 1033;
+ResEdit.Resource.IconGroupEntry.replaceIconsForResource(
+  resources.entries,
+  iconId,
+  iconLang,
+  iconFile.icons.map((item) => item.data),
+);
+
+const versions = ResEdit.Resource.VersionInfo.fromEntries(resources.entries);
+if (!versions.length) throw new Error("Electron executable has no version resource");
+for (const version of versions) {
+  const languages = version.getAllLanguagesForStringValues();
+  const targets = languages.length ? languages : [{ lang: 1033, codepage: 1200 }];
+  version.setFileVersion(0, 5, 1, 0, 1033);
+  version.setProductVersion(0, 5, 1, 0, 1033);
+  for (const language of targets) {
+    version.setStringValues(language, {
+      CompanyName: "Penglai",
+      FileDescription: "Penglai",
+      FileVersion: "0.5.1.0",
+      InternalName: "Penglai",
+      LegalCopyright: "Penglai contributors",
+      OriginalFilename: "Penglai.exe",
+      ProductName: "Penglai",
+      ProductVersion: "0.5.1.0",
+    });
+  }
+  version.outputToResourceEntries(resources.entries);
+}
+
+resources.outputResource(executable);
+const temp = join(dirname(exePath), `.Penglai.exe.${process.pid}.tmp`);
+rmSync(temp, { force: true });
+writeFileSync(temp, Buffer.from(executable.generate()), { mode: 0o700 });
+renameSync(temp, exePath);
+console.log(JSON.stringify({ verdict: "PASS", command: "stamp-windows-exe", exe: exePath, ico: icoPath }));

--- a/scripts/verify-installed.mjs
+++ b/scripts/verify-installed.mjs
@@ -165,12 +165,22 @@ identity.recordAssertion({
 });
 identity.recordAssertion({
   ...common,
-  acceptanceId: "R50-MAC-009",
+  acceptanceId: target === "win32-x86_64" ? "R50-WIN-009" : "R50-MAC-009",
   runnerId: "installed",
   testId: "verify-installed",
   assertionId: "exact-installer-installed-suite",
   details: { safe: `${target} exact installer suite recorded official boot observations` },
 });
+if (target === "darwin-x86_64") {
+  identity.recordAssertion({
+    ...common,
+    acceptanceId: "R50-MAC-010",
+    runnerId: "installed",
+    testId: "verify-installed",
+    assertionId: "intel-native-runner",
+    details: { safe: "Intel installer evidence was recorded on a native darwin-x86_64 runner" },
+  });
+}
 identity.recordAssertion({
   ...common,
   acceptanceId: "R50-ONB-002",


### PR DESCRIPTION
## Outcome

Hardens source-level native installer and exact-installed evidence paths found during the 0.5.1 review. This is a bounded correction, not release approval.

## Changes

- binds every native build to clean `main == origin/main` plus the current public-export hash
- records target-specific macOS installer evidence so Intel cannot inherit Apple Silicon evidence
- stamps the real Windows x64 PE identity, version, and Penglai icon
- uses the same Penglai icon for the NSIS installer/uninstaller
- compiles the native Windows helper into the payload
- reinstalls the exact Setup silently and records its SHA/source/target/export identity
- maps exact Windows/Intel installed assertions to their proper acceptance IDs
- adds the optional bilingual Windows desktop shortcut contract

## Verification

- format and lint: PASS
- build: PASS
- unit: 420/420 PASS
- desktop E2E: 61/61 PASS
- contracts/dependencies/licenses/secrets: PASS
- real Electron Windows x64 PE resource preflight: PASS (Penglai 0.5.1.0; 256x256 ICO)
- CodeQL and Cloudflare Pages: PASS

## Explicit boundary

This does **not** claim Intel macOS, Windows native NSIS, installed, soak, live, notarization, Authenticode, or 256-Hard-ID release PASS. Those remain native/live release gates; `verify:evidence` and `verify:release` must stay non-zero until real evidence exists.
