### PR TITLE
fix: prune non-target node-pty binaries

### DIFF
--- a/packages/runtime/src/foundation.test.ts
+++ b/packages/runtime/src/foundation.test.ts
@@ -1,6 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { chmodSync, mkdtempSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { PenglaiError } from "@penglai/contracts";
@@ -113,6 +121,51 @@ test("official DSH closure BFS includes runtime packages that healProfilesModule
   assertDshClosure(links);
   for (const name of REQUIRED_DSH_RUNTIME_PACKAGES) {
     assert.equal(links.has(name), true, name);
+  }
+});
+
+test("DSH closure keeps only the node-pty payload for the declared release target", async () => {
+  const { pruneNodePtyNativePayloads } = await import(
+    "../../../scripts/lib/dsh-closure.mjs"
+  );
+  const targets = [
+    ["darwin-aarch64", "darwin-arm64", "pty.node"],
+    ["darwin-x86_64", "darwin-x64", "pty.node"],
+    ["win32-x86_64", "win32-x64", "conpty.node"],
+  ] as const;
+  for (const [target, keep, binding] of targets) {
+    const modules = mkdtempSync(join(tmpdir(), `penglai-node-pty-${keep}-`));
+    const nodePty = join(modules, "node-pty");
+    for (const platform of ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "win32-arm64", "win32-x64"]) {
+      const dir = join(nodePty, "prebuilds", platform);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, platform.startsWith("win32") ? "conpty.node" : "pty.node"), platform);
+    }
+    for (const platform of ["win10-arm64", "win10-x64"]) {
+      const dir = join(nodePty, "third_party", "conpty", "1.25.260303002", platform);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "conpty.dll"), platform);
+    }
+    const result = pruneNodePtyNativePayloads(modules, target);
+    assert.equal(result.present, true);
+    assert.equal(existsSync(join(nodePty, "prebuilds", keep, binding)), true);
+    for (const platform of ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "win32-arm64", "win32-x64"]) {
+      assert.equal(existsSync(join(nodePty, "prebuilds", platform)), platform === keep);
+    }
+    assert.equal(
+      existsSync(join(nodePty, "third_party", "conpty")),
+      target === "win32-x86_64",
+    );
+    if (target === "win32-x86_64") {
+      assert.equal(
+        existsSync(join(nodePty, "third_party", "conpty", "1.25.260303002", "win10-x64", "conpty.dll")),
+        true,
+      );
+      assert.equal(
+        existsSync(join(nodePty, "third_party", "conpty", "1.25.260303002", "win10-arm64")),
+        false,
+      );
+    }
   }
 });
 

--- a/scripts/lib/dsh-closure.mjs
+++ b/scripts/lib/dsh-closure.mjs
@@ -1,5 +1,5 @@
 import { createRequire } from "node:module";
-import { existsSync, mkdirSync, readFileSync, rmSync, cpSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -20,6 +20,12 @@ export const REQUIRE_BUILTIN_NATIVE_BY_TARGET = {
   "darwin-aarch64": "node-addon-require-builtin-darwin-arm64",
   "darwin-x86_64": "node-addon-require-builtin-darwin-x64",
   "win32-x86_64": "node-addon-require-builtin-win32-x64-msvc",
+};
+
+export const NODE_PTY_PREBUILD_BY_TARGET = {
+  "darwin-aarch64": "darwin-arm64",
+  "darwin-x86_64": "darwin-x64",
+  "win32-x86_64": "win32-x64",
 };
 
 const ROOT_CANDIDATE = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -82,6 +88,46 @@ function copyFlatPackage(dir, dest) {
   rmSync(join(dest, "node_modules"), { recursive: true, force: true });
 }
 
+export function pruneNodePtyNativePayloads(modulesDir, target) {
+  const expected = NODE_PTY_PREBUILD_BY_TARGET[target];
+  if (!expected) throw new Error(`no node-pty native mapping for ${target}`);
+  const nodePty = join(modulesDir, "node-pty");
+  if (!existsSync(nodePty)) return { present: false, target: expected };
+  const prebuilds = join(nodePty, "prebuilds");
+  const expectedPrebuild = join(prebuilds, expected);
+  if (!existsSync(expectedPrebuild)) {
+    throw new Error(`embedded DSH closure missing node-pty ${expected}`);
+  }
+  for (const name of readdirSync(prebuilds)) {
+    if (name !== expected) rmSync(join(prebuilds, name), { recursive: true, force: true });
+  }
+  const binding = join(
+    expectedPrebuild,
+    target === "win32-x86_64" ? "conpty.node" : "pty.node",
+  );
+  if (!existsSync(binding)) {
+    throw new Error(`embedded DSH closure missing node-pty binding ${target}`);
+  }
+  const conpty = join(nodePty, "third_party", "conpty");
+  if (target !== "win32-x86_64") {
+    rmSync(conpty, { recursive: true, force: true });
+  } else if (existsSync(conpty)) {
+    for (const name of readdirSync(conpty)) {
+      if (name !== "1.25.260303002") {
+        rmSync(join(conpty, name), { recursive: true, force: true });
+        continue;
+      }
+      const versionRoot = join(conpty, name);
+      for (const platform of readdirSync(versionRoot)) {
+        if (platform !== "win10-x64") {
+          rmSync(join(versionRoot, platform), { recursive: true, force: true });
+        }
+      }
+    }
+  }
+  return { present: true, target: expected, binding };
+}
+
 export function resolveRequireBuiltinNative(installAnchor, target) {
   const name = REQUIRE_BUILTIN_NATIVE_BY_TARGET[target];
   if (!name) throw new Error(`no require-builtin native mapping for ${target}`);
@@ -108,6 +154,7 @@ export function materializeDshClosure(installAnchor, destRoot, target) {
     if (name === appName) continue;
     copyFlatPackage(dir, join(modulesDir, name));
   }
+  const nodePty = pruneNodePtyNativePayloads(modulesDir, target);
   const native = resolveRequireBuiltinNative(installAnchor, target);
   if (!native.dir || !existsSync(join(native.dir, "package.json"))) {
     throw new Error(`embedded DSH closure missing ${native.name} for ${target}`);
@@ -126,5 +173,6 @@ export function materializeDshClosure(installAnchor, destRoot, target) {
   return {
     packages: [...flattened.keys()],
     native: native.name,
+    nodePty,
   };
 }


### PR DESCRIPTION
## Problem

The first Apple Silicon 0.5.1 DMG build failed its native architecture gate because the embedded DSH node-pty package still carried Intel, Linux, and Windows prebuilds.

## Fix

- map each declared release target to exactly one node-pty prebuild directory
- remove every non-target node-pty prebuild before the runtime manifest is written
- remove Windows conpty payloads from macOS and retain only win10-x64 for Windows x64
- fail closed if the expected native binding is absent
- add behavioral coverage for Apple Silicon, Intel Mac, and Windows x64

## Evidence

- format PASS
- targeted runtime tests 10/10 PASS
- full unit suite 421/421 PASS

The native DMG build will be rerun from clean main after merge.