### PR TITLE
fix: drive installed UI through separate harness

### DIFF
--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { readFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -87,6 +88,8 @@ test("installed e2e drives packaged BrowserWindow via CDP and has no in-app prob
   assert.match(walk, /await delay\(1_200\)/);
   assert.match(walk, /clickButtonText\(\["\^蓬莱\$", "\^Penglai\$"\]\)/);
   assert.match(e2e, /assertInstalledPenglaiIdentity/);
+  assert.match(e2e, /launchPackaged\(exe, resources, refuseUser/);
+  assert.match(e2e, /launchInstalledHarness\(harnessApp, resources, userData/);
 });
 
 test("single-instance ownership is scoped after the app-private userData path", () => {
@@ -101,6 +104,25 @@ test("installed app helper refuses Electron executable and wrong Info.plist iden
   assert.match(helper, /CFBundleExecutable/);
   assert.match(helper, /com\.penglai\.dsh/);
   assert.doesNotMatch(helper, /for \(const name of \["Penglai", "Electron"\]\)/);
+});
+
+test("installed UI harness executes only the exact installed resources/app", async () => {
+  const { installedHarnessSpec } = await import("../../../scripts/lib/installed-app.mjs");
+  const rootDir = mkdtempSync(join(tmpdir(), "penglai-installed-harness-"));
+  const harness = join(rootDir, "Electron");
+  const resources = join(rootDir, "installed", "resources");
+  mkdirSync(join(resources, "app"), { recursive: true });
+  writeFileSync(harness, "harness");
+  writeFileSync(join(resources, "app", "package.json"), "{}");
+  writeFileSync(join(resources, "app", "electron-main.js"), "main");
+  assert.deepEqual(installedHarnessSpec(harness, resources), {
+    executable: harness,
+    appEntry: join(resources, "app"),
+  });
+  assert.throws(
+    () => installedHarnessSpec(join(rootDir, "missing"), resources),
+    /harness executable missing/,
+  );
 });
 
 test("soak runner samples IM offline sleep update uninstall on the exact DMG", () => {

--- a/scripts/e2e-installed.mjs
+++ b/scripts/e2e-installed.mjs
@@ -8,6 +8,7 @@ import {
   exeInside,
   findWelcomeAck,
   installFromExactInstaller,
+  launchInstalledHarness,
   launchPackaged,
   waitChildExit,
   leftoversByCommand,
@@ -149,7 +150,7 @@ if (!harnessApp) {
   });
 }
 const debugPort = await freePort();
-const launched = launchPackaged(exe, resources, userData, [
+const launched = launchInstalledHarness(harnessApp, resources, userData, [
   `--remote-debugging-port=${debugPort}`,
   "--remote-allow-origins=*",
 ]);
@@ -191,7 +192,7 @@ if (walk?.wizardKeyless?.ok) {
   const ledgerBefore = existsSync(ledgerPath) ? JSON.parse(readFileSync(ledgerPath, "utf8")) : null;
   await stopChild(launched.child);
   const debugPort2 = await freePort();
-  const launched2 = launchPackaged(exe, resources, userData, [
+  const launched2 = launchInstalledHarness(harnessApp, resources, userData, [
     `--remote-debugging-port=${debugPort2}`,
     "--remote-allow-origins=*",
   ]);

--- a/scripts/lib/installed-app.mjs
+++ b/scripts/lib/installed-app.mjs
@@ -169,6 +169,55 @@ export function launchPackaged(exe, resources, userData, extraArgs = [], extraEn
   return { child, output: () => output };
 }
 
+export function installedHarnessSpec(harnessExe, resources) {
+  const executable = resolve(String(harnessExe ?? ""));
+  const appEntry = resolve(join(resources, "app"));
+  if (!harnessExe || !existsSync(executable)) {
+    throw new Error("installed UI harness executable missing");
+  }
+  if (
+    !existsSync(join(appEntry, "package.json")) ||
+    !existsSync(join(appEntry, "electron-main.js"))
+  ) {
+    throw new Error("installed UI harness requires the exact installed resources/app");
+  }
+  return { executable, appEntry };
+}
+
+export function launchInstalledHarness(
+  harnessExe,
+  resources,
+  userData,
+  extraArgs = [],
+  extraEnv = {},
+) {
+  const spec = installedHarnessSpec(harnessExe, resources);
+  const child = spawn(
+    spec.executable,
+    ["--disable-gpu", "--in-process-gpu", ...extraArgs, spec.appEntry],
+    {
+      env: {
+        PATH: "/usr/bin:/bin",
+        NODE_PATH: "",
+        HOME: userData,
+        PENGLAI_USER_DATA: userData,
+        PENGLAI_RESOURCES: resources,
+        PENGLAI_PLUGINS_DIR: join(resources, "plugins"),
+        ...extraEnv,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let output = "";
+  child.stdout.on("data", (d) => {
+    output += String(d);
+  });
+  child.stderr.on("data", (d) => {
+    output += String(d);
+  });
+  return { child, output: () => output, spec };
+}
+
 export function ownedProcessTree(app, resources, electronPid) {
   const windows = existsSync(join(app, "Penglai.exe"));
   const nodeBin = resolve(join(resources, windows ? "runtime/node/node.exe" : "runtime/node/bin/node"));

--- a/scripts/soak-installed.mjs
+++ b/scripts/soak-installed.mjs
@@ -7,7 +7,7 @@ import { HTTP_JS, SNAPSHOT_JS, walkInstalledBrowserWindow } from "./lib/browser-
 import {
   exeInside,
   installFromExactInstaller,
-  launchPackaged,
+  launchInstalledHarness,
   leftoversByCommand,
   ownedProcessTree,
   resourcesInside,
@@ -99,6 +99,14 @@ if (expectedArtifact !== installed.installerSha256) {
 const exe = exeInside(installed.app, expectedTarget);
 if (!exe) finish("FAIL", { command: "test:soak:installed", reason: "installed Penglai executable missing", target: expectedTarget });
 const resources = resourcesInside(installed.app, expectedTarget);
+const harnessApp = process.env.PENGLAI_INSTALLED_UI_HARNESS;
+if (!harnessApp) {
+  finish("INCOMPLETE", {
+    command: "test:soak:installed",
+    reason: "installed soak requires a separate Electron harness executable",
+    target: expectedTarget,
+  });
+}
 const userData = join(ROOT, ".tmp-installed-soak");
 rmSync(userData, { recursive: true, force: true });
 mkdirSync(userData, { recursive: true });
@@ -107,8 +115,8 @@ const installedNode = join(resources, expectedTarget === "win32-x86_64" ? "runti
 const installedDsh = join(resources, "runtime/dsh/lib/bin.js");
 
 const debugPort = await freePort();
-const launched = launchPackaged(
-  exe,
+const launched = launchInstalledHarness(
+  harnessApp,
   resources,
   userData,
   [`--remote-debugging-port=${debugPort}`, "--remote-allow-origins=*"],

--- a/scripts/u3-welcome-smoke.mjs
+++ b/scripts/u3-welcome-smoke.mjs
@@ -5,9 +5,8 @@ import { finish } from "./lib/exit-contract.mjs";
 import { attachPage, evaluate, freePort, waitEval } from "./lib/cdp.mjs";
 import { SNAPSHOT_JS, observeOfficialSurfaces } from "./lib/browser-window-walk.mjs";
 import {
-  exeInside,
   installFromExactInstaller,
-  launchPackaged,
+  launchInstalledHarness,
   leftoversByCommand,
   ownedProcessTree,
   resourcesInside,
@@ -94,14 +93,21 @@ if (packaged.verdict !== "PASS") {
 }
 
 const app = installed.app;
-const exe = exeInside(app, expectedTarget);
 const resources = resourcesInside(app, expectedTarget);
+const harnessApp = process.env.PENGLAI_INSTALLED_UI_HARNESS;
+if (!harnessApp) {
+  finish("INCOMPLETE", {
+    command: "u3-welcome-smoke",
+    reason: "installed UI walk requires a separate Electron harness executable",
+    target: expectedTarget,
+  });
+}
 const userData = join(ROOT, ".tmp-u3-welcome");
 rmSync(userData, { recursive: true, force: true });
 mkdirSync(userData, { recursive: true });
 
 const debugPort = await freePort();
-const launched = launchPackaged(exe, resources, userData, [
+const launched = launchInstalledHarness(harnessApp, resources, userData, [
   `--remote-debugging-port=${debugPort}`,
   "--remote-allow-origins=*",
 ]);


### PR DESCRIPTION
## Problem

Installed UI, welcome, and soak runners asked for PENGLAI_INSTALLED_UI_HARNESS but ignored it. They tried to add a remote debugging switch to the production Penglai executable, which correctly refuses debugger switches. Installed browser evidence could therefore never complete.

## Fix

- keep a direct production launch that proves the exact installer refuses debugger switches
- run CDP only through an explicitly supplied Electron harness executable
- make that harness execute the exact resources/app copied from the installed DMG or Setup
- continue using the exact installed runtime, plugins, release identity, and isolated user data
- use the same separation in installed E2E, welcome smoke, and installed soak
- add behavioral and source-contract coverage

## Evidence

- format PASS
- desktop E2E 62/62 PASS
- all modified runner scripts pass node syntax checks

Native installed execution will be run from clean main after merge.