### PR TITLE
test: verify official wizard surfaces independently

### DIFF
--- a/scripts/u3-welcome-smoke.mjs
+++ b/scripts/u3-welcome-smoke.mjs
@@ -155,8 +155,7 @@ const welcomeReachable = Boolean(
   welcome?.welcomePenglai && welcome.continueVisible && !welcome.continueDisabled && !welcome.officialInternalNotice,
 );
 const wizardAdvanced = Boolean(
-  official?.official &&
-    !official.snap?.recovery &&
+  !official?.snap?.recovery &&
     official.http?.official &&
     official.websocket?.opened &&
     welcomeClick.ok &&


### PR DESCRIPTION
## Summary
- accept the wizard as an official live surface when its authenticated HTTP and WebSocket probes pass
- do not require the wizard smoke to have already reached the main DSH DOM

## Evidence
- exact DMG: HTTP 200 official=true
- exact DMG: WebSocket opened=true
- welcome advanced to 隐私说明
- owned DSH process, zero leftovers