### PR TITLE
ci: build source before native packaging

### DIFF
--- a/.github/workflows/native-release-candidate.yml
+++ b/.github/workflows/native-release-candidate.yml
@@ -43,6 +43,8 @@ jobs:
           pnpm install --frozen-lockfile
       - name: Verify clean public export
         run: pnpm prepare:public-export -- --clean-room
+      - name: Build source from the clean checkout
+        run: pnpm build
       - name: Build exact native installer
         run: pnpm ${{ matrix.package }}
       - name: Installed welcome and process smoke
@@ -85,6 +87,8 @@ jobs:
           choco install nsis --no-progress -y
       - name: Verify clean public export
         run: pnpm prepare:public-export -- --clean-room
+      - name: Build source from the clean checkout
+        run: pnpm build
       - name: Build exact native installer with MSVC
         shell: cmd
         run: |

--- a/scripts/prepare-public-export.mjs
+++ b/scripts/prepare-public-export.mjs
@@ -8,7 +8,7 @@ import { finish } from "./lib/exit-contract.mjs";
 import { PRODUCT_VERSION } from "./lib/product.mjs";
 
 const contractsBuild = spawnSync(
-  "pnpm",
+  process.platform === "win32" ? "pnpm.cmd" : "pnpm",
   ["exec", "tsc", "-b", "packages/contracts", "--pretty", "false", "--force"],
   { cwd: ROOT, encoding: "utf8", env: { ...process.env } },
 );
@@ -16,7 +16,7 @@ if (contractsBuild.status !== 0) {
   finish("FAIL", {
     command: "prepare:public-export",
     reason: "could not build the source dependency required by the export policy",
-    detail: String(contractsBuild.stderr || contractsBuild.stdout || "").slice(-800),
+    detail: String(contractsBuild.error || contractsBuild.stderr || contractsBuild.stdout || "").slice(-800),
   });
 }
 


### PR DESCRIPTION
The clean native runners correctly showed that package scripts were consuming workspace dist outputs without a source build. Add an explicit full build after the clean-room export gate on macOS ARM, macOS Intel, and Windows x64.

Local gates:
- workflow YAML parse
- pnpm format:check
- pnpm build
- git diff --check