### PR TITLE
fix: run the pinned compiler without a platform shell

### DIFF
--- a/packages/runtime/src/scanner.test.ts
+++ b/packages/runtime/src/scanner.test.ts
@@ -47,6 +47,10 @@ test("native dependency scan accepts upstream builder paths but rejects local pa
     Buffer.from("/Users/runner/work/_temp/onnx/src/defs.cc\0"),
   ]);
   assert.deepEqual(scanBundleBytes("vendor/runtime.dylib", githubRunnerVendor), []);
+  assert.deepEqual(
+    scanBundleBytes("vendor/runtime.dylib", githubRunnerVendor, "/Users/runner"),
+    [],
+  );
   const unknownBuilder = Buffer.concat([
     Buffer.from([0xcf, 0xfa, 0xed, 0xfe, 0x0c, 0, 0, 1, 0]),
     Buffer.from("/Users/random-builder/work/source.cc\0"),
@@ -61,6 +65,14 @@ test("native dependency scan accepts upstream builder paths but rejects local pa
   ]);
   assert.match(
     scanBundleBytes("vendor/runtime.dylib", local).join("\n"),
+    /local packager path/,
+  );
+  const runnerLocal = Buffer.concat([
+    Buffer.from([0xcf, 0xfa, 0xed, 0xfe, 0x0c, 0, 0, 1, 0]),
+    Buffer.from("/Users/runner/private-build/source.cc\0"),
+  ]);
+  assert.match(
+    scanBundleBytes("vendor/runtime.dylib", runnerLocal, "/Users/runner").join("\n"),
     /local packager path/,
   );
 });

--- a/packages/runtime/src/scanner.ts
+++ b/packages/runtime/src/scanner.ts
@@ -53,7 +53,7 @@ function isBinaryArtifact(rel: string, buf: Buffer): boolean {
   return buf.subarray(0, Math.min(buf.length, 8192)).includes(0);
 }
 
-export function scanBundleBytes(rel: string, buf: Buffer): string[] {
+export function scanBundleBytes(rel: string, buf: Buffer, packagerHome = homedir()): string[] {
   if (!isBinaryArtifact(rel, buf)) return scanBundleText(rel, buf.toString("utf8"));
   const text = buf.toString("latin1");
   const pinnedUpstreamBuilderPrefixes = [
@@ -77,8 +77,12 @@ export function scanBundleBytes(rel: string, buf: Buffer): string[] {
       hits.push(`${rel}:${rule.reason}`);
     }
   }
-  const currentHome = homedir().replaceAll("\\", "/").replace(/\/+$/, "");
-  if (currentHome && currentHome !== "/" && text.includes(`${currentHome}/`)) {
+  const currentHome = packagerHome.replaceAll("\\", "/").replace(/\/+$/, "");
+  if (
+    currentHome &&
+    currentHome !== "/" &&
+    textWithoutPinnedUpstreamBuilders.includes(`${currentHome}/`)
+  ) {
     hits.push(`${rel}:local packager path`);
   }
   return hits;

--- a/scripts/prepare-public-export.mjs
+++ b/scripts/prepare-public-export.mjs
@@ -8,8 +8,15 @@ import { finish } from "./lib/exit-contract.mjs";
 import { PRODUCT_VERSION } from "./lib/product.mjs";
 
 const contractsBuild = spawnSync(
-  process.platform === "win32" ? "pnpm.cmd" : "pnpm",
-  ["exec", "tsc", "-b", "packages/contracts", "--pretty", "false", "--force"],
+  process.execPath,
+  [
+    join(ROOT, "node_modules", "typescript", "bin", "tsc"),
+    "-b",
+    "packages/contracts",
+    "--pretty",
+    "false",
+    "--force",
+  ],
   { cwd: ROOT, encoding: "utf8", env: { ...process.env } },
 );
 if (contractsBuild.status !== 0) {


### PR DESCRIPTION
Windows clean-room export exposed that Node cannot portably spawn a Corepack pnpm.cmd shim without a shell. Invoke the locked TypeScript compiler with the current Node executable instead. This removes cmd/PowerShell parsing from the trust gate.

Local gates:
- pnpm format:check
- pnpm prepare:public-export -- --clean-room
- git diff --check