### PR TITLE
fix: preserve pinned license bytes on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Byte-pinned third-party notices and vendored runtime sources must be
+# identical on every native checkout. Git for Windows otherwise rewrites
+# these text files to CRLF and breaks the supply-chain hash gate.
+packages/asr/third_party/*.txt text eol=lf
+packages/moss-tts/third_party/*.txt text eol=lf
+packages/moss-tts/third_party/*.md text eol=lf
+packages/moss-tts/src/third_party/moss_tts/LICENSE text eol=lf
+packages/moss-tts/src/third_party/moss_tts/runtime.mjs text eol=lf


### PR DESCRIPTION
## Why
Git for Windows checked byte-pinned third-party notice files out with CRLF, so the existing fail-closed license hash gate rejected authentic source bytes during the native Windows package.

## Change
Pin only the byte-verified third-party notice and vendored runtime files to LF through .gitattributes. The raw-byte hash gate remains intact; it is not weakened or normalized at runtime.

## Evidence
- pnpm audit:licenses: PASS
- pnpm pack:plugins -- --target win32-x64: PASS (exact 9 production plugin archives)
- current native Windows runner reached packaging and failed specifically on CRLF-transformed FunASR license bytes