### PR TITLE
test: gate installed first-party plugins on native runners

### DIFF
--- a/.github/workflows/native-release-candidate.yml
+++ b/.github/workflows/native-release-candidate.yml
@@ -52,6 +52,11 @@ jobs:
           PENGLAI_TARGET: ${{ matrix.target }}
           PENGLAI_INSTALLED_UI_HARNESS: ${{ github.workspace }}/node_modules/.pnpm/electron@43.4.0/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron
         run: pnpm test:u3:welcome
+      - name: Installed first-party plugin compatibility
+        env:
+          PENGLAI_TARGET: ${{ matrix.target }}
+          PENGLAI_INSTALLED_UI_HARNESS: ${{ github.workspace }}/node_modules/.pnpm/electron@43.4.0/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron
+        run: pnpm test:u3:plugins
       - name: Upload installer and target evidence
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -62,6 +67,7 @@ jobs:
             dist/${{ matrix.installer }}
             evidence/generated/local-installer-${{ matrix.target }}.json
             evidence/generated/u3-welcome-smoke.json
+            evidence/generated/u3-first-party-plugins.json
             evidence/generated/public-export.json
 
   windows:
@@ -100,6 +106,12 @@ jobs:
           PENGLAI_TARGET: win32-x86_64
           PENGLAI_INSTALLED_UI_HARNESS: ${{ github.workspace }}\node_modules\.pnpm\electron@43.4.0\node_modules\electron\dist\electron.exe
         run: pnpm test:u3:welcome
+      - name: Installed first-party plugin compatibility
+        shell: pwsh
+        env:
+          PENGLAI_TARGET: win32-x86_64
+          PENGLAI_INSTALLED_UI_HARNESS: ${{ github.workspace }}\node_modules\.pnpm\electron@43.4.0\node_modules\electron\dist\electron.exe
+        run: pnpm test:u3:plugins
       - name: Upload installer and target evidence
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -110,4 +122,5 @@ jobs:
             dist/Penglai_0.5.1_windows_x64_setup.exe
             evidence/generated/local-installer-win32-x86_64.json
             evidence/generated/u3-welcome-smoke.json
+            evidence/generated/u3-first-party-plugins.json
             evidence/generated/public-export.json

--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -92,6 +92,20 @@ test("installed e2e drives packaged BrowserWindow via CDP and has no in-app prob
   assert.match(e2e, /launchInstalledHarness\(harnessApp, resources, userData/);
 });
 
+test("native release workflow proves bundled optional plugins across restart", () => {
+  const workflow = readFileSync(join(root, ".github/workflows/native-release-candidate.yml"), "utf8");
+  const compat = readFileSync(join(root, "scripts/u3-first-party-plugins.mjs"), "utf8");
+  assert.match(workflow, /pnpm test:u3:plugins/g);
+  assert.match(workflow, /u3-first-party-plugins\.json/g);
+  assert.match(compat, /installFromExactInstaller/);
+  assert.match(compat, /inspectPackagedCandidate/);
+  assert.match(compat, /all-enabled-after-restart/);
+  assert.match(compat, /all-disabled-after-restart/);
+  assert.match(compat, /fiberPhase/);
+  assert.match(compat, /official\.websocket/);
+  assert.doesNotMatch(compat, /PENGLAI_ALLOW_TEST_HARNESS/);
+});
+
 test("single-instance ownership is scoped after the app-private userData path", () => {
   const main = readFileSync(join(root, "apps/desktop/src/electron-main.ts"), "utf8");
   const configure = main.indexOf("configureGenerationPaths({");

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:e2e": "node --import tsx --test apps/desktop/src/*.test.ts",
     "test:e2e:installed": "node scripts/e2e-installed.mjs",
     "test:u3:welcome": "node scripts/u3-welcome-smoke.mjs",
+    "test:u3:plugins": "node scripts/u3-first-party-plugins.mjs",
     "test:failure-baseline": "node --import tsx scripts/failure-baseline.mjs",
     "test:security": "node --import tsx --test packages/routing-core/src/security.test.ts packages/local-control/src/security.test.ts apps/desktop/src/security.test.ts",
     "test:chaos": "node --import tsx --test packages/routing-core/src/chaos.test.ts packages/persistence/src/chaos.test.ts",

--- a/scripts/u3-first-party-plugins.mjs
+++ b/scripts/u3-first-party-plugins.mjs
@@ -1,0 +1,273 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { ROOT, gitState } from "./lib/repo.mjs";
+import { finish } from "./lib/exit-contract.mjs";
+import { attachPage, freePort } from "./lib/cdp.mjs";
+import { observeOfficialSurfaces } from "./lib/browser-window-walk.mjs";
+import {
+  assertInstalledPenglaiIdentity,
+  installFromExactInstaller,
+  launchInstalledHarness,
+  leftoversByCommand,
+  ownedProcessTree,
+  resourcesInside,
+  stopChild,
+  waitForFile,
+} from "./lib/installed-app.mjs";
+import { inspectPackagedCandidate } from "./lib/packaged-candidate.mjs";
+import {
+  installerForTarget,
+  nativeBlocked,
+  parseTargetArg,
+} from "./lib/release-targets.mjs";
+
+const OPTIONAL_PLUGINS = [
+  "@penglai/im",
+  "@penglai/asr",
+  "@penglai/moss-tts",
+  "@penglai/context",
+  "@penglai/memory",
+  "@penglai/budget",
+  "@penglai/companion",
+];
+
+const outDir = join(ROOT, "evidence/generated");
+mkdirSync(outDir, { recursive: true });
+const recPath = join(outDir, "u3-first-party-plugins.json");
+const writeRec = (value) => writeFileSync(recPath, `${JSON.stringify(value, null, 2)}\n`);
+
+const git = gitState();
+if (git.branch !== "main" || git.head !== git.originMain || git.dirty) {
+  finish("STALE", {
+    command: "u3-first-party-plugins",
+    reason: "candidate source must be clean main at origin/main",
+    ...git,
+  });
+}
+
+const target = parseTargetArg();
+const blocked = nativeBlocked("u3-first-party-plugins", target);
+if (blocked) finish("BLOCKED", { command: "u3-first-party-plugins", ...blocked });
+const installer = installerForTarget(target);
+const installedRoot = join(ROOT, ".tmp-u3-plugin-app");
+const userData = join(ROOT, ".tmp-u3-plugin-profile");
+const installed = installFromExactInstaller(
+  join(ROOT, "dist", installer),
+  installedRoot,
+  target,
+);
+if (!installed.ok) {
+  finish(installed.blocked ? "BLOCKED" : "INCOMPLETE", {
+    command: "u3-first-party-plugins",
+    reason: installed.reason ?? "exact installer missing",
+    target,
+  });
+}
+const identity = assertInstalledPenglaiIdentity(installed.app, target);
+if (!identity.ok) {
+  finish("FAIL", {
+    command: "u3-first-party-plugins",
+    reason: `installed app identity ${identity.reason}`,
+  });
+}
+const packaged = inspectPackagedCandidate({
+  app: installed.app,
+  candidateSha: git.head,
+  expectedTarget: target,
+});
+if (packaged.verdict !== "PASS") {
+  finish(packaged.verdict, {
+    command: "u3-first-party-plugins",
+    reason: packaged.reason,
+  });
+}
+const harness = process.env.PENGLAI_INSTALLED_UI_HARNESS;
+if (!harness) {
+  finish("INCOMPLETE", {
+    command: "u3-first-party-plugins",
+    reason: "installed plugin compatibility requires a separate Electron harness",
+    target,
+  });
+}
+
+const resources = resourcesInside(installed.app, target);
+const profilePatch = join(userData, "dsh-home", "profiles", "web", "cordis.patch.yml");
+const inventoryPath = join(userData, "plugins", "inventory-snapshot.json");
+const packageRoot = join(userData, "dsh-home", "profiles", "web", "node_modules", "@penglai");
+const dshNeedle = resolve(join(resources, "runtime/dsh/lib/bin.js"));
+rmSync(userData, { recursive: true, force: true });
+mkdirSync(userData, { recursive: true });
+
+function pluginRows(snapshot) {
+  const entries = Array.isArray(snapshot?.entries) ? snapshot.entries : [];
+  return OPTIONAL_PLUGINS.map((id) => {
+    const hit = entries.find((row) => row?.moduleName === id);
+    return {
+      id,
+      present: Boolean(hit),
+      enabled: hit?.enabled === true,
+      phase: hit?.fiberPhase ?? null,
+    };
+  });
+}
+
+function rowsMatch(snapshot, enabled) {
+  return pluginRows(snapshot).every(
+    (row) => row.present && row.enabled === enabled && (enabled ? row.phase === "active" : row.phase === null),
+  );
+}
+
+async function waitInventory(enabled, notBefore, timeoutMs = 90_000) {
+  const end = Date.now() + timeoutMs;
+  let last = null;
+  while (Date.now() < end) {
+    if (existsSync(inventoryPath)) {
+      try {
+        last = JSON.parse(readFileSync(inventoryPath, "utf8"));
+        if (Date.parse(String(last?.at ?? "")) >= notBefore && rowsMatch(last, enabled)) return last;
+      } catch {
+        // The host replaces this snapshot periodically; retry a partial read.
+      }
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
+  }
+  return last;
+}
+
+function setProfileEnabled(enabled) {
+  if (!existsSync(profilePatch)) throw new Error("installed profile patch missing");
+  let text = readFileSync(profilePatch, "utf8");
+  for (const id of OPTIONAL_PLUGINS) {
+    const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const pattern = new RegExp(`(^\\s+name:\\s+["']?${escaped}["']?\\s*\\r?\\n\\s+disabled:\\s+)(true|false)`, "m");
+    if (!pattern.test(text)) throw new Error(`installed profile is missing ${id}`);
+    text = text.replace(pattern, `$1${enabled ? "false" : "true"}`);
+  }
+  writeFileSync(profilePatch, text);
+}
+
+function installedPackages() {
+  return OPTIONAL_PLUGINS.map((id) => {
+    const file = join(packageRoot, id.split("/")[1], "package.json");
+    if (!existsSync(file)) return { id, present: false };
+    const value = JSON.parse(readFileSync(file, "utf8"));
+    return {
+      id,
+      present: value.name === id,
+      version: value.version,
+    };
+  });
+}
+
+async function runPhase(name, expectedEnabled) {
+  rmSync(join(userData, "gateway.port"), { force: true });
+  const debugPort = await freePort();
+  const startedAt = Date.now();
+  const launched = launchInstalledHarness(harness, resources, userData, [
+    `--remote-debugging-port=${debugPort}`,
+    "--remote-allow-origins=*",
+  ]);
+  const sawGateway = await waitForFile(join(userData, "gateway.port"), 90_000);
+  let official = null;
+  let attachErr = "";
+  try {
+    const { session } = await attachPage(debugPort, 90_000);
+    official = await observeOfficialSurfaces(session);
+    session.close();
+  } catch (error) {
+    attachErr = error instanceof Error ? error.message : String(error);
+  }
+  const inventory = await waitInventory(expectedEnabled, startedAt);
+  const tree = ownedProcessTree(installed.app, resources, launched.child.pid);
+  await stopChild(launched.child);
+  const leftovers = leftoversByCommand(dshNeedle);
+  return {
+    name,
+    expectedEnabled,
+    sawGateway,
+    attachErr: attachErr || undefined,
+    official: {
+      http: official?.http?.official === true,
+      websocket: official?.websocket?.opened === true,
+      hasRoot: official?.snap?.hasRoot === true,
+      hasDshBoot: official?.snap?.hasDshBoot === true,
+    },
+    rows: pluginRows(inventory),
+    packages: installedPackages(),
+    processTree: {
+      dshPid: tree.dshPid,
+      ownedAbsolute: tree.ownedAbsolute,
+      leftovers: leftovers.length,
+    },
+    outputTail: launched.output().slice(-1200),
+  };
+}
+
+let phases = [];
+try {
+  phases.push(await runPhase("fresh-default-disabled", false));
+  setProfileEnabled(true);
+  phases.push(await runPhase("all-enabled", true));
+  phases.push(await runPhase("all-enabled-after-restart", true));
+  setProfileEnabled(false);
+  phases.push(await runPhase("all-disabled-after-restart", false));
+} catch (error) {
+  const rec = {
+    command: "u3-first-party-plugins",
+    verdict: "FAIL",
+    installer,
+    installerSha256: installed.installerSha256,
+    sourceSha: packaged.release.sourceSha,
+    target,
+    reason: error instanceof Error ? error.message : String(error),
+    phases,
+  };
+  writeRec(rec);
+  finish("FAIL", rec);
+}
+
+const activePhases = phases.filter((phase) => phase.expectedEnabled);
+const disabledPhases = phases.filter((phase) => !phase.expectedEnabled);
+const commonOk = phases.every(
+  (phase) =>
+    phase.sawGateway &&
+    !phase.attachErr &&
+    phase.official.http &&
+    phase.official.websocket &&
+    phase.official.hasRoot &&
+    phase.official.hasDshBoot &&
+    phase.processTree.ownedAbsolute &&
+    phase.processTree.dshPid > 0 &&
+    phase.processTree.leftovers === 0,
+);
+const activeOk = activePhases.every(
+  (phase) =>
+    phase.rows.every((row) => row.present && row.enabled && row.phase === "active") &&
+    phase.packages.every((pkg) => pkg.present && pkg.version === "0.5.1"),
+);
+const disabledOk = disabledPhases.every((phase) =>
+  phase.rows.every((row) => row.present && !row.enabled && row.phase === null),
+);
+const ok = commonOk && activeOk && disabledOk;
+const rec = {
+  command: "u3-first-party-plugins",
+  verdict: ok ? "PASS" : "FAIL",
+  installer,
+  installerSha256: installed.installerSha256,
+  sourceSha: packaged.release.sourceSha,
+  target,
+  dsh: packaged.release.dsh,
+  plugins: OPTIONAL_PLUGINS,
+  method:
+    "exact installed profile; enable all bundled optional entries; DSH loader active; restart; disable all; restart",
+  phases,
+};
+writeRec(rec);
+if (!ok) finish("FAIL", rec);
+finish("PASS", rec);

--- a/scripts/u3-first-party-plugins.mjs
+++ b/scripts/u3-first-party-plugins.mjs
@@ -1,6 +1,9 @@
 import {
+  closeSync,
   existsSync,
+  ftruncateSync,
   mkdirSync,
+  openSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -141,15 +144,20 @@ async function waitInventory(enabled, notBefore, timeoutMs = 90_000) {
 }
 
 function setProfileEnabled(enabled) {
-  if (!existsSync(profilePatch)) throw new Error("installed profile patch missing");
-  let text = readFileSync(profilePatch, "utf8");
-  for (const id of OPTIONAL_PLUGINS) {
-    const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const pattern = new RegExp(`(^\\s+name:\\s+["']?${escaped}["']?\\s*\\r?\\n\\s+disabled:\\s+)(true|false)`, "m");
-    if (!pattern.test(text)) throw new Error(`installed profile is missing ${id}`);
-    text = text.replace(pattern, `$1${enabled ? "false" : "true"}`);
+  const fd = openSync(profilePatch, "r+");
+  try {
+    let text = readFileSync(fd, "utf8");
+    for (const id of OPTIONAL_PLUGINS) {
+      const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const pattern = new RegExp(`(^\\s+name:\\s+["']?${escaped}["']?\\s*\\r?\\n\\s+disabled:\\s+)(true|false)`, "m");
+      if (!pattern.test(text)) throw new Error(`installed profile is missing ${id}`);
+      text = text.replace(pattern, `$1${enabled ? "false" : "true"}`);
+    }
+    ftruncateSync(fd, 0);
+    writeFileSync(fd, text);
+  } finally {
+    closeSync(fd);
   }
-  writeFileSync(profilePatch, text);
 }
 
 function installedPackages() {

--- a/scripts/u3-first-party-plugins.mjs
+++ b/scripts/u3-first-party-plugins.mjs
@@ -1,6 +1,5 @@
 import {
   closeSync,
-  existsSync,
   ftruncateSync,
   mkdirSync,
   openSync,
@@ -130,13 +129,13 @@ async function waitInventory(enabled, notBefore, timeoutMs = 90_000) {
   const end = Date.now() + timeoutMs;
   let last = null;
   while (Date.now() < end) {
-    if (existsSync(inventoryPath)) {
-      try {
-        last = JSON.parse(readFileSync(inventoryPath, "utf8"));
-        if (Date.parse(String(last?.at ?? "")) >= notBefore && rowsMatch(last, enabled)) return last;
-      } catch {
-        // The host replaces this snapshot periodically; retry a partial read.
-      }
+    try {
+      last = JSON.parse(readFileSync(inventoryPath, "utf8"));
+      if (Date.parse(String(last?.at ?? "")) >= notBefore && rowsMatch(last, enabled)) return last;
+    } catch (error) {
+      const missing = error && typeof error === "object" && "code" in error && error.code === "ENOENT";
+      if (!missing && !(error instanceof SyntaxError)) throw error;
+      // The host creates and then replaces this snapshot; retry a missing or partial read.
     }
     await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
   }

--- a/scripts/u3-first-party-plugins.mjs
+++ b/scripts/u3-first-party-plugins.mjs
@@ -155,13 +155,19 @@ function setProfileEnabled(enabled) {
 function installedPackages() {
   return OPTIONAL_PLUGINS.map((id) => {
     const file = join(packageRoot, id.split("/")[1], "package.json");
-    if (!existsSync(file)) return { id, present: false };
-    const value = JSON.parse(readFileSync(file, "utf8"));
-    return {
-      id,
-      present: value.name === id,
-      version: value.version,
-    };
+    try {
+      const value = JSON.parse(readFileSync(file, "utf8"));
+      return {
+        id,
+        present: value.name === id,
+        version: value.version,
+      };
+    } catch (error) {
+      if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+        return { id, present: false };
+      }
+      throw error;
+    }
   });
 }
 


### PR DESCRIPTION
## Outcome
Adds a native installer-level compatibility gate for the seven user-facing Penglai optional plugins on Apple Silicon, Intel Mac, and Windows x64.

## Exact path
- install the exact target installer and bind it to the clean main source SHA
- observe the fresh profile with every optional plugin disabled
- enable every bundled optional profile entry and require the official DSH loader to report each one enabled with active fiber phase
- restart and require all seven to remain active
- disable every optional entry, restart, and require all seven inactive
- require official DSH HTTP and WebSocket surfaces, the owned embedded DSH process, exact 0.5.1 package manifests, and zero leftover DSH processes in every phase

This is separate from provider-key testing: it does not claim a live external model call, and it does not add a production test bypass.

## Local source evidence
- node syntax check: PASS
- format: PASS
- unit: 421/421 PASS
- contract: 62/62 PASS
- integration: 21/21 PASS
- desktop E2E: 63/63 PASS

Native proof will be produced only by the three matching GitHub runners after merge.