### PR TITLE
fix: harden native installer builds

### DIFF
--- a/native/windows-host/penglai_windows_host.c
+++ b/native/windows-host/penglai_windows_host.c
@@ -568,5 +568,4 @@ int main(int argc, char **argv) {
     return cmd_delete_plan(file, token, root);
   }
   fail("unknown-command");
-  return 2;
 }

--- a/scripts/build-local-dmg.mjs
+++ b/scripts/build-local-dmg.mjs
@@ -29,6 +29,37 @@ function run(command, args, options = {}) {
   execFileSync(command, args, { cwd: ROOT, stdio: "inherit", ...options });
 }
 
+function waitSync(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function createDmg(args, dmgPath) {
+  const attempts = 3;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const result = spawnSync("hdiutil", args, {
+      cwd: ROOT,
+      encoding: "utf8",
+    });
+    if (result.stdout) process.stdout.write(result.stdout);
+    if (result.stderr) process.stderr.write(result.stderr);
+    if (result.status === 0) return;
+
+    const diagnostic = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+    const retryable = diagnostic.includes("Resource busy");
+    if (!retryable || attempt === attempts) {
+      const detail = result.error?.message ?? `exit ${result.status ?? "unknown"}`;
+      throw new Error(`hdiutil create failed: ${detail}`);
+    }
+
+    rmSync(dmgPath, { force: true });
+    const delayMs = attempt * 2_000;
+    process.stderr.write(
+      `hdiutil create reported Resource busy; retrying ${attempt + 1}/${attempts} after ${delayMs}ms\n`,
+    );
+    waitSync(delayMs);
+  }
+}
+
 function sha256(p) {
   return createHash("sha256").update(readFileSync(p)).digest("hex");
 }
@@ -103,7 +134,7 @@ const staging = mkdtempSync(join(tmpdir(), "penglai-local-dmg-"));
 try {
   run("ditto", [appPath, join(staging, "Penglai.app")]);
   symlinkSync("/Applications", join(staging, "Applications"));
-  run("hdiutil", [
+  createDmg([
     "create",
     "-volname",
     "Penglai",
@@ -115,7 +146,7 @@ try {
     "zlib-level=9",
     "-ov",
     dmgPath,
-  ]);
+  ], dmgPath);
   run("hdiutil", ["verify", dmgPath]);
 } finally {
   rmSync(staging, { recursive: true, force: true });

--- a/scripts/u3-first-party-plugins.mjs
+++ b/scripts/u3-first-party-plugins.mjs
@@ -57,8 +57,8 @@ const target = parseTargetArg();
 const blocked = nativeBlocked("u3-first-party-plugins", target);
 if (blocked) finish("BLOCKED", { command: "u3-first-party-plugins", ...blocked });
 const installer = installerForTarget(target);
-const installedRoot = join(ROOT, ".tmp-u3-plugin-app");
-const userData = join(ROOT, ".tmp-u3-plugin-profile");
+const installedRoot = join(ROOT, ".tmp", "u3-plugin-app");
+const userData = join(ROOT, ".tmp", "u3-plugin-profile");
 const installed = installFromExactInstaller(
   join(ROOT, "dist", installer),
   installedRoot,

--- a/scripts/u3-welcome-smoke.mjs
+++ b/scripts/u3-welcome-smoke.mjs
@@ -73,7 +73,7 @@ if (blocked) finish("BLOCKED", { command: "u3-welcome-smoke", ...blocked });
 const expectedInstaller = installerForTarget(expectedTarget);
 const installed = installFromExactInstaller(
   join(ROOT, "dist", expectedInstaller),
-  join(ROOT, ".tmp-u3-welcome-app"),
+  join(ROOT, ".tmp", "u3-welcome-app"),
   expectedTarget,
 );
 if (!installed.ok) {
@@ -104,7 +104,7 @@ if (!harnessApp) {
     target: expectedTarget,
   });
 }
-const userData = join(ROOT, ".tmp-u3-welcome");
+const userData = join(ROOT, ".tmp", "u3-welcome-profile");
 rmSync(userData, { recursive: true, force: true });
 mkdirSync(userData, { recursive: true });
 


### PR DESCRIPTION
Repairs two native-runner failures found by the exact 0.5.1 candidate workflow. Windows removes an unreachable return rejected by MSVC with warnings-as-errors. macOS retries only hdiutil Resource busy, at most twice after the first attempt; every other failure remains fail-closed.\n\nLocal evidence: format check PASS, script syntax PASS, Windows host tests 8/8 PASS. Native runner evidence is required before merge.