### PR TITLE
fix: verify exact Windows helper architecture

### DIFF
--- a/apps/desktop/src/arch.test.ts
+++ b/apps/desktop/src/arch.test.ts
@@ -1,18 +1,46 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import test from "node:test";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, "../../..");
+
 test("R2-ARCH-004 electron main loads official web URL after health", () => {
-  const src = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "electron-main.ts"), "utf8");
+  const src = readFileSync(join(here, "electron-main.ts"), "utf8");
   assert.match(src, /loadURL/);
   assert.match(src, /startDshProxy/);
   assert.doesNotMatch(src, /getAgent:\s*\(\)\s*=>\s*undefined/);
 });
 
 test("R2-DIST-003 supervisor source has no PATH dsh fallback", () => {
-  const src = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "supervisor.ts"), "utf8");
+  const src = readFileSync(join(here, "supervisor.ts"), "utf8");
   assert.doesNotMatch(src, /"dsh"/);
   assert.match(src, /refusing PATH fallback/);
+});
+
+test("native architecture verifier accepts one exact PE executable", () => {
+  const dir = mkdtempSync(join(tmpdir(), "penglai-pe-arch-"));
+  try {
+    const executable = join(dir, "penglai-windows-host.exe");
+    const pe = Buffer.alloc(128);
+    pe.write("MZ", 0, "ascii");
+    pe.writeUInt32LE(64, 0x3c);
+    pe.write("PE\0\0", 64, "ascii");
+    pe.writeUInt16LE(0x8664, 68);
+    writeFileSync(executable, pe);
+
+    const output = execFileSync(
+      process.execPath,
+      [join(root, "scripts/verify-native-arch.mjs"), executable, "win32-x86_64"],
+      { encoding: "utf8" },
+    );
+    assert.match(output, /"verdict":"PASS"/);
+    assert.match(output, /"files":1/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/scripts/verify-native-arch.mjs
+++ b/scripts/verify-native-arch.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Walk a packaged app and refuse the wrong Mach-O / PE machine.
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
 import { extname, join } from "node:path";
 
 const root = process.argv[2];
@@ -9,9 +9,15 @@ if (!root || !target) {
   console.error("verify-native-arch <app-root> <darwin-aarch64|darwin-x86_64|win32-x86_64>");
   process.exit(2);
 }
-if (!existsSync(root)) {
-  console.error("verify-native-arch BLOCKED: app root missing", root);
-  process.exit(4);
+let rootStat;
+try {
+  rootStat = statSync(root);
+} catch (error) {
+  if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+    console.error("verify-native-arch BLOCKED: app root missing", root);
+    process.exit(4);
+  }
+  throw error;
 }
 
 const MACHO_64 = 0xfeedfacf;
@@ -75,7 +81,7 @@ if (!expected) {
   process.exit(1);
 }
 
-const files = walk(root);
+const files = rootStat.isFile() ? [root] : rootStat.isDirectory() ? walk(root) : [];
 const hits = [];
 for (const path of files) {
   const ext = extname(path).toLowerCase();


### PR DESCRIPTION
The native Windows helper now compiles, but its architecture gate passed an exact .exe path to a verifier that only walked directories, so the verifier reported no binaries. Teach the verifier to accept either one exact file or a directory without weakening PE/Mach-O identity checks. Add a cross-platform synthetic AMD64 PE regression test.\n\nLocal evidence: arch tests 3/3 PASS, format PASS, script syntax and diff check PASS.