### PR TITLE
release: verify immutable update and plugin channels

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "verify:release": "node --import tsx scripts/verify-release.mjs",
     "verify:installed": "node --import tsx scripts/verify-installed.mjs",
     "verify:live": "node scripts/verify-live.mjs",
+    "verify:live-plugin-catalog": "node --import tsx scripts/verify-live-plugin-catalog.mjs",
     "verify:public-export": "node --import tsx scripts/verify-public-export.mjs",
     "prepare:public-export": "node --import tsx scripts/prepare-public-export.mjs",
     "verify:clean-clone": "node --import tsx scripts/verify-clean-clone.mjs",

--- a/scripts/readback-release.mjs
+++ b/scripts/readback-release.mjs
@@ -2,28 +2,170 @@ import { createHash } from "node:crypto";
 import { ROOT } from "./lib/repo.mjs";
 import { PRODUCT_VERSION } from "./lib/product.mjs";
 import { finish } from "./lib/exit-contract.mjs";
+import { EXACT_RELEASE_ASSETS } from "../packages/release-identity/src/contract.ts";
+import {
+  EMBEDDED_UPDATER_PUBLIC_KEY,
+  parseAppUpdateManifest,
+  verifyBytes,
+} from "../packages/plugin-registry/src/index.ts";
 
 const repo = "kevinchennewbee/PenglaiAgent";
 const tag = process.argv[2] || `v${PRODUCT_VERSION}`;
 const api = `https://api.github.com/repos/${repo}/releases/tags/${tag}`;
-const response = await fetch(api, { redirect: "manual" });
+const response = await fetch(api, {
+  redirect: "manual",
+  headers: { Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2026-03-10" },
+});
 if (response.status !== 200) {
   finish("INCOMPLETE", { command: "readback-release", reason: `GitHub ${response.status}`, tag });
 }
 const release = await response.json();
 const assets = Array.isArray(release.assets) ? release.assets : [];
-const rows = [];
-for (const asset of assets) {
-  const body = await fetch(asset.browser_download_url, { redirect: "manual" });
-  if (body.status !== 200) {
-    finish("FAIL", { command: "readback-release", reason: `asset ${asset.name} ${body.status}` });
+const expected = [...EXACT_RELEASE_ASSETS].sort();
+const names = assets.map((asset) => String(asset.name)).sort();
+if (
+  release.tag_name !== tag ||
+  release.draft !== false ||
+  release.prerelease !== false ||
+  release.immutable !== true ||
+  JSON.stringify(names) !== JSON.stringify(expected)
+) {
+  finish("FAIL", {
+    command: "readback-release",
+    reason: "release is mutable, unpublished, prerelease, or has the wrong exact asset set",
+    tag,
+    immutable: release.immutable === true,
+    draft: release.draft,
+    prerelease: release.prerelease,
+    expected,
+    actual: names,
+  });
+}
+
+const allowedDownloadHosts = new Set([
+  "github.com",
+  "api.github.com",
+  "objects.githubusercontent.com",
+  "release-assets.githubusercontent.com",
+]);
+
+async function downloadAsset(url, name) {
+  let current = url;
+  for (let hop = 0; hop <= 4; hop += 1) {
+    const parsed = new URL(current);
+    if (parsed.protocol !== "https:" || !allowedDownloadHosts.has(parsed.hostname)) {
+      finish("FAIL", { command: "readback-release", reason: `asset ${name} redirect host refused`, url: current });
+    }
+    const body = await fetch(current, { redirect: "manual" });
+    if (body.status === 200) return Buffer.from(await body.arrayBuffer());
+    if (body.status < 300 || body.status >= 400 || hop === 4) {
+      finish("FAIL", { command: "readback-release", reason: `asset ${name} ${body.status}` });
+    }
+    const location = body.headers.get("location");
+    await body.body?.cancel?.();
+    if (!location) {
+      finish("FAIL", { command: "readback-release", reason: `asset ${name} redirect missing location` });
+    }
+    current = new URL(location, current).href;
   }
-  const bytes = Buffer.from(await body.arrayBuffer());
+  finish("FAIL", { command: "readback-release", reason: `asset ${name} redirect limit` });
+}
+
+const rows = [];
+const bytesByName = new Map();
+for (const asset of assets) {
+  const bytes = await downloadAsset(asset.browser_download_url, asset.name);
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  const githubDigest = typeof asset.digest === "string" ? asset.digest.replace(/^sha256:/, "") : "";
+  if (bytes.length !== asset.size || (githubDigest && githubDigest !== sha256)) {
+    finish("FAIL", {
+      command: "readback-release",
+      reason: `asset ${asset.name} size or GitHub digest mismatch`,
+    });
+  }
+  bytesByName.set(asset.name, bytes);
   rows.push({
     name: asset.name,
     size: bytes.length,
     declared: asset.size,
-    sha256: createHash("sha256").update(bytes).digest("hex"),
+    sha256,
   });
 }
-finish("PASS", { command: "readback-release", cwd: ROOT, tag, assets: rows });
+
+const sums = bytesByName.get("SHA256SUMS")?.toString("utf8").trim().split(/\r?\n/) ?? [];
+const declaredSums = new Map(
+  sums.map((line) => {
+    const match = /^([0-9a-f]{64})  ([^/\\]+)$/.exec(line);
+    if (!match) finish("FAIL", { command: "readback-release", reason: "SHA256SUMS line invalid", line });
+    return [match[2], match[1]];
+  }),
+);
+const sumNames = names.filter((name) => name !== "SHA256SUMS").sort();
+if (JSON.stringify([...declaredSums.keys()].sort()) !== JSON.stringify(sumNames)) {
+  finish("FAIL", { command: "readback-release", reason: "SHA256SUMS exact set mismatch" });
+}
+for (const row of rows.filter((asset) => asset.name !== "SHA256SUMS")) {
+  if (declaredSums.get(row.name) !== row.sha256) {
+    finish("FAIL", { command: "readback-release", reason: `SHA256SUMS mismatch for ${row.name}` });
+  }
+}
+
+const updateBytes = bytesByName.get("update-manifest-v1.json");
+const updateSignature = bytesByName.get("update-manifest-v1.json.sig");
+const releaseManifestBytes = bytesByName.get("release-manifest.json");
+if (!updateBytes || !updateSignature || !releaseManifestBytes) {
+  finish("FAIL", { command: "readback-release", reason: "signed release metadata missing" });
+}
+verifyBytes(updateBytes, updateSignature, EMBEDDED_UPDATER_PUBLIC_KEY.publicKeyHex);
+const update = parseAppUpdateManifest(JSON.parse(updateBytes.toString("utf8")));
+const releaseManifest = JSON.parse(releaseManifestBytes.toString("utf8"));
+const sourceIdentity = createHash("sha256")
+  .update(String(releaseManifest.privateCandidateSourceSha ?? ""))
+  .digest("hex");
+if (
+  update.version !== PRODUCT_VERSION ||
+  update.releaseTag !== tag ||
+  update.signingKeyId !== EMBEDDED_UPDATER_PUBLIC_KEY.keyId ||
+  update.publicExportTreeSha256 !== releaseManifest.publicExportTreeSha256 ||
+  update.candidateSourceSha !== sourceIdentity
+) {
+  finish("FAIL", { command: "readback-release", reason: "update and release identity mismatch" });
+}
+
+for (const [target, platform] of Object.entries(update.platforms)) {
+  const filename =
+    target === "darwin-aarch64"
+      ? `Penglai_${PRODUCT_VERSION}_macos_aarch64.dmg`
+      : target === "darwin-x86_64"
+        ? `Penglai_${PRODUCT_VERSION}_macos_x64.dmg`
+        : target === "win32-x86_64"
+          ? `Penglai_${PRODUCT_VERSION}_windows_x64_setup.exe`
+          : "";
+  const installer = bytesByName.get(filename);
+  const githubAsset = assets.find((asset) => asset.name === filename);
+  if (
+    !filename ||
+    !installer ||
+    !githubAsset ||
+    platform.assetId !== githubAsset.id ||
+    platform.size !== installer.length ||
+    platform.sha256 !== createHash("sha256").update(installer).digest("hex")
+  ) {
+    finish("FAIL", { command: "readback-release", reason: `update platform identity mismatch for ${target}` });
+  }
+  verifyBytes(installer, Buffer.from(platform.signature, "base64"), EMBEDDED_UPDATER_PUBLIC_KEY.publicKeyHex);
+}
+
+if (Object.keys(update.platforms).sort().join(",") !== "darwin-aarch64,darwin-x86_64,win32-x86_64") {
+  finish("FAIL", { command: "readback-release", reason: "update manifest does not cover exactly three targets" });
+}
+
+finish("PASS", {
+  command: "readback-release",
+  cwd: ROOT,
+  tag,
+  immutable: true,
+  updateSignature: true,
+  installerSignatures: true,
+  assets: rows,
+});

--- a/scripts/readback-release.mjs
+++ b/scripts/readback-release.mjs
@@ -12,9 +12,10 @@ import {
 const repo = "kevinchennewbee/PenglaiAgent";
 const tag = process.argv[2] || `v${PRODUCT_VERSION}`;
 const api = `https://api.github.com/repos/${repo}/releases/tags/${tag}`;
+const githubHeaders = { Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2026-03-10" };
 const response = await fetch(api, {
   redirect: "manual",
-  headers: { Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2026-03-10" },
+  headers: githubHeaders,
 });
 if (response.status !== 200) {
   finish("INCOMPLETE", { command: "readback-release", reason: `GitHub ${response.status}`, tag });
@@ -119,6 +120,7 @@ if (!updateBytes || !updateSignature || !releaseManifestBytes) {
 verifyBytes(updateBytes, updateSignature, EMBEDDED_UPDATER_PUBLIC_KEY.publicKeyHex);
 const update = parseAppUpdateManifest(JSON.parse(updateBytes.toString("utf8")));
 const releaseManifest = JSON.parse(releaseManifestBytes.toString("utf8"));
+const publicExportManifest = JSON.parse(bytesByName.get("public-export-manifest.json").toString("utf8"));
 const sourceIdentity = createHash("sha256")
   .update(String(releaseManifest.privateCandidateSourceSha ?? ""))
   .digest("hex");
@@ -130,6 +132,47 @@ if (
   update.candidateSourceSha !== sourceIdentity
 ) {
   finish("FAIL", { command: "readback-release", reason: "update and release identity mismatch" });
+}
+
+let tagObjectResponse = await fetch(`https://api.github.com/repos/${repo}/git/ref/tags/${tag}`, {
+  redirect: "manual",
+  headers: githubHeaders,
+});
+if (tagObjectResponse.status !== 200) {
+  finish("FAIL", { command: "readback-release", reason: `tag ref ${tagObjectResponse.status}` });
+}
+let tagObject = (await tagObjectResponse.json()).object;
+for (let depth = 0; tagObject?.type === "tag" && depth < 3; depth += 1) {
+  tagObjectResponse = await fetch(tagObject.url, { redirect: "manual", headers: githubHeaders });
+  if (tagObjectResponse.status !== 200) {
+    finish("FAIL", { command: "readback-release", reason: `annotated tag ${tagObjectResponse.status}` });
+  }
+  tagObject = (await tagObjectResponse.json()).object;
+}
+if (
+  tagObject?.type !== "commit" ||
+  tagObject.sha !== releaseManifest.privateCandidateSourceSha ||
+  releaseManifest.product !== "Penglai" ||
+  releaseManifest.version !== PRODUCT_VERSION ||
+  releaseManifest.publicExportTreeSha256 !== publicExportManifest.publicExportTreeSha256
+) {
+  finish("FAIL", { command: "readback-release", reason: "tag, release manifest, or public export identity mismatch" });
+}
+
+const releaseArtifacts = Array.isArray(releaseManifest.artifacts) ? releaseManifest.artifacts : [];
+const installerNames = expected.filter((name) => name.endsWith(".dmg") || name.endsWith(".exe")).sort();
+if (JSON.stringify(releaseArtifacts.map((row) => row.name).sort()) !== JSON.stringify(installerNames)) {
+  finish("FAIL", { command: "readback-release", reason: "release manifest installer set mismatch" });
+}
+for (const declared of releaseArtifacts) {
+  const installer = bytesByName.get(declared.name);
+  if (
+    !installer ||
+    declared.bytes !== installer.length ||
+    declared.sha256 !== createHash("sha256").update(installer).digest("hex")
+  ) {
+    finish("FAIL", { command: "readback-release", reason: `release manifest mismatch for ${declared.name}` });
+  }
 }
 
 for (const [target, platform] of Object.entries(update.platforms)) {

--- a/scripts/verify-live-plugin-catalog.mjs
+++ b/scripts/verify-live-plugin-catalog.mjs
@@ -1,0 +1,86 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { finish } from "./lib/exit-contract.mjs";
+import { PluginDistributionClient } from "../packages/plugin-registry/src/index.ts";
+
+const expectedTag = process.argv[2] || "plugin-catalog-v1.000001";
+const root = mkdtempSync(join(tmpdir(), "penglai-live-plugin-catalog-"));
+const shared = {
+  cacheRoot: join(root, "cas"),
+  trustPath: join(root, "trust-state.json"),
+  lastGoodPath: join(root, "last-good-catalog.json"),
+  penglaiVersion: "0.5.1",
+  dshExact: "0.1.1-rc.1",
+  target: "darwin-aarch64",
+};
+
+let record;
+try {
+  const online = new PluginDistributionClient(shared);
+  const snapshot = await online.refresh();
+  const entry = snapshot.catalog.entries.find((row) => row.id === "@penglai/plugin-pilot");
+  const pkg = await online.downloadPackage("@penglai/plugin-pilot");
+  const offline = new PluginDistributionClient({
+    ...shared,
+    fetchImpl: async () => {
+      throw new Error("offline verification path");
+    },
+  });
+  const lastGood = await offline.refresh();
+  const ok = Boolean(
+    snapshot.source === "github-immutable" &&
+      snapshot.tag === expectedTag &&
+      snapshot.sequence >= 1 &&
+      snapshot.signatureOk &&
+      entry?.defaultEnabled === false &&
+      entry.nativeCode === false &&
+      entry.dsh.exact === "0.1.1-rc.1" &&
+      pkg.id === entry.id &&
+      pkg.version === entry.version &&
+      pkg.sha256 === entry.artifacts[0]?.sha256 &&
+      pkg.manifest.id === entry.id &&
+      pkg.manifest.version === entry.version &&
+      pkg.files.includes("package/index.js") &&
+      pkg.files.includes("package/package.json") &&
+      lastGood.source === "last-good-offline" &&
+      lastGood.sequence === snapshot.sequence &&
+      lastGood.digest === snapshot.digest &&
+      lastGood.signatureOk,
+  );
+  record = {
+    command: "verify-live-plugin-catalog",
+    verdict: ok ? "PASS" : "FAIL",
+    source: snapshot.source,
+    tag: snapshot.tag,
+    sequence: snapshot.sequence,
+    digest: snapshot.digest,
+    signatureOk: snapshot.signatureOk,
+    plugin: {
+      id: pkg.id,
+      version: pkg.version,
+      sha256: pkg.sha256,
+      size: pkg.size,
+      defaultEnabled: entry?.defaultEnabled,
+      nativeCode: entry?.nativeCode,
+      dsh: entry?.dsh.exact,
+      files: pkg.files,
+    },
+    offlineLastGood: {
+      source: lastGood.source,
+      sequence: lastGood.sequence,
+      digest: lastGood.digest,
+      signatureOk: lastGood.signatureOk,
+    },
+  };
+} catch (error) {
+  record = {
+    command: "verify-live-plugin-catalog",
+    verdict: "FAIL",
+    reason: error instanceof Error ? error.message : String(error),
+  };
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}
+
+finish(record.verdict, record);


### PR DESCRIPTION
Adds a live PPDP catalog/package/offline-last-good verification command and hardens final Release readback to require immutable publication, the exact 10 assets, complete SHA256SUMS, a valid updater manifest signature, exact three-platform GitHub asset identities, and valid installer-byte signatures.\n\nLocal evidence:\n- pnpm verify:live-plugin-catalog PASS against plugin-catalog-v1.000001\n- node --check for both scripts\n- pnpm format:check PASS\n- git diff --check PASS