### PR TITLE
fix: wait for installed app shutdown before plugin restart

### DIFF
--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import test from "node:test";
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -103,7 +105,42 @@ test("native release workflow proves bundled optional plugins across restart", (
   assert.match(compat, /all-disabled-after-restart/);
   assert.match(compat, /fiberPhase/);
   assert.match(compat, /official\.websocket/);
+  assert.doesNotMatch(compat, /phase\.official\.hasRoot/);
+  assert.doesNotMatch(compat, /phase\.official\.hasDshBoot/);
+  assert.match(compat, /pre-DSH wizard/);
   assert.doesNotMatch(compat, /PENGLAI_ALLOW_TEST_HARNESS/);
+});
+
+test("installed harness shutdown waits for the process close after SIGKILL", () => {
+  const helper = readFileSync(join(root, "scripts/lib/installed-app.mjs"), "utf8");
+  assert.match(helper, /closed\.then\(\(value\) => \(\{ exited: true, value \}\)\)/);
+  assert.match(helper, /did not exit after SIGKILL/);
+  assert.doesNotMatch(helper, /resolveClose\(\[null, "SIGKILL"\]\)/);
+});
+
+test("installed harness shutdown returns only after the child is gone", async (context) => {
+  const { stopChild } = await import("../../../scripts/lib/installed-app.mjs");
+  const child = spawn(
+    process.execPath,
+    ["-e", "process.on('SIGTERM',()=>{});setInterval(()=>{},1000)"],
+    { stdio: "ignore" },
+  );
+  context.after(() => {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      /* already gone */
+    }
+  });
+  await once(child, "spawn");
+  const pid = child.pid;
+  assert.ok(pid);
+  await stopChild(child, 50);
+  assert.ok(child.exitCode !== null || child.signalCode);
+  assert.throws(
+    () => process.kill(pid, 0),
+    (error: NodeJS.ErrnoException) => error.code === "ESRCH",
+  );
 });
 
 test("single-instance ownership is scoped after the app-private userData path", () => {

--- a/scripts/lib/installed-app.mjs
+++ b/scripts/lib/installed-app.mjs
@@ -251,25 +251,32 @@ export function waitChildExit(child, timeoutMs = 15_000) {
 }
 
 export async function stopChild(child, timeoutMs = 8_000) {
+  if (child.exitCode !== null || child.signalCode) return [child.exitCode, child.signalCode];
+  const closed = new Promise((resolveClose) =>
+    child.once("close", (code, signal) => resolveClose([code, signal])),
+  );
   try {
     child.kill("SIGTERM");
   } catch {
     /* already gone */
   }
-  const closed = await Promise.race([
-    new Promise((resolveClose) => child.on("close", (c, s) => resolveClose([c, s]))),
-    new Promise((resolveClose) =>
-      setTimeout(() => {
-        try {
-          child.kill("SIGKILL");
-        } catch {
-          /* */
-        }
-        resolveClose([null, "SIGKILL"]);
-      }, timeoutMs),
-    ),
+  const graceful = await Promise.race([
+    closed.then((value) => ({ exited: true, value })),
+    new Promise((resolveTimeout) => setTimeout(() => resolveTimeout({ exited: false }), timeoutMs)),
   ]);
-  return closed;
+  if (graceful.exited) return graceful.value;
+  try {
+    child.kill("SIGKILL");
+  } catch {
+    /* already gone */
+  }
+  const forced = await Promise.race([
+    closed.then((value) => ({ exited: true, value })),
+    new Promise((resolveTimeout) => setTimeout(() => resolveTimeout({ exited: false }), 5_000)),
+  ]);
+  if (!forced.exited) throw new Error(`child ${child.pid ?? "unknown"} did not exit after SIGKILL`);
+  await new Promise((resolveDelay) => setTimeout(resolveDelay, 300));
+  return forced.value;
 }
 
 export function signalPid(pid, signal, windowsHelper) {

--- a/scripts/u3-first-party-plugins.mjs
+++ b/scripts/u3-first-party-plugins.mjs
@@ -253,8 +253,6 @@ const commonOk = phases.every(
     !phase.attachErr &&
     phase.official.http &&
     phase.official.websocket &&
-    phase.official.hasRoot &&
-    phase.official.hasDshBoot &&
     phase.processTree.ownedAbsolute &&
     phase.processTree.dshPid > 0 &&
     phase.processTree.leftovers === 0,
@@ -278,7 +276,7 @@ const rec = {
   dsh: packaged.release.dsh,
   plugins: OPTIONAL_PLUGINS,
   method:
-    "exact installed profile; enable all bundled optional entries; DSH loader active; restart; disable all; restart",
+    "exact installed profile behind the pre-DSH wizard; official DSH HTTP/WebSocket and loader inventory; enable all; restart; disable all; restart",
   phases,
 };
 writeRec(rec);


### PR DESCRIPTION
## Summary
- wait for the installed Electron process to actually close after SIGTERM/SIGKILL before relaunching
- prove the shutdown helper against a real child process that ignores SIGTERM
- verify first-party plugin compatibility through the official DSH HTTP/WebSocket and loader inventory while the pre-DSH wizard remains visible

## Local verification
- `node --import tsx --test apps/desktop/src/installed-walk.test.ts` (12/12)
- `node --check scripts/lib/installed-app.mjs`
- `node --check scripts/u3-first-party-plugins.mjs`
- `pnpm format:check`
- `git diff --check`

The native installed-plugin workflow remains the release acceptance gate.