### PR TITLE
fix: resolve native Windows runtime staging

### DIFF
--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -196,9 +196,13 @@ test("soak runner samples IM offline sleep update uninstall on the exact DMG", (
   assert.match(installedHelper, /process-resume/);
   const windowsPayload = readFileSync(join(root, "scripts/package-windows-payload.mjs"), "utf8");
   assert.match(windowsPayload, /build-windows-host\.mjs/);
+  assert.match(windowsPayload, /stagingForTarget\(ROOT, "win32-x86_64"\)/);
   assert.match(windowsPayload, /join\(staging, "runtime", "helpers"\)/);
   assert.match(windowsPayload, /stamp-windows-exe\.mjs/);
   assert.match(windowsPayload, /release-info\.json/);
+  const embedRuntime = readFileSync(join(root, "scripts/embed-runtime.mjs"), "utf8");
+  assert.match(embedRuntime, /packedPlugins !== stagedPlugins/);
+  assert.match(embedRuntime, /cpSync\(packedPlugins, stagedPlugins/);
   const verifyInstalled = readFileSync(join(root, "scripts/verify-installed.mjs"), "utf8");
   assert.match(verifyInstalled, /R50-WIN-009/);
   assert.match(verifyInstalled, /R50-MAC-010/);

--- a/packages/runtime/src/windows-host.test.ts
+++ b/packages/runtime/src/windows-host.test.ts
@@ -184,6 +184,10 @@ test("NSIS script default-preserves user data and only deletes via capability ha
   assert.match(payload, /release-info\.json/);
   assert.match(payload, /stamp-windows-exe\.mjs/);
   assert.match(payload, /Penglai\.ico/);
+  assert.match(payload, /stagingForTarget\(ROOT, "win32-x86_64"\)/);
+  assert.match(packager, /stagingForTarget\(ROOT, "win32-x86_64"\)/);
+  assert.doesNotMatch(payload, /const staging = join\(ROOT, "dist", "runtime-staging-win32-x86_64"\)/);
+  assert.doesNotMatch(packager, /const staging = join\(ROOT, "dist", "runtime-staging-win32-x86_64"\)/);
   assert.match(packager, /local-installer-win32-x86_64\.json/);
   assert.match(packager, /\/DPENGLAI_ICON=/);
   assert.match(script, /!define MUI_ICON "\$\{PENGLAI_ICON\}"/);

--- a/scripts/embed-runtime.mjs
+++ b/scripts/embed-runtime.mjs
@@ -196,6 +196,12 @@ const pack = spawnSync(
   { cwd: ROOT, stdio: "inherit" },
 );
 if (pack.status !== 0) process.exit(pack.status ?? 1);
+const packedPlugins = join(ROOT, "dist", "runtime-staging", "plugins");
+const stagedPlugins = join(staging, "plugins");
+if (packedPlugins !== stagedPlugins) {
+  rmSync(stagedPlugins, { recursive: true, force: true });
+  cpSync(packedPlugins, stagedPlugins, { recursive: true });
+}
 cpSync(join(ROOT, "profile-seed"), join(staging, "profile-seed"), { recursive: true });
 cpSync(join(ROOT, "release-contract.json"), join(staging, "release-contract.json"));
 

--- a/scripts/package-windows-nsis.mjs
+++ b/scripts/package-windows-nsis.mjs
@@ -5,6 +5,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { ROOT } from "./lib/repo.mjs";
+import { stagingForTarget } from "./lib/closure-credential.mjs";
 
 const contract = {
   installer: "Penglai_0.5.1_windows_x64_setup.exe",
@@ -39,7 +40,7 @@ if (!contract.nativeEvidenceAllowed) {
   process.exit(4);
 }
 
-const staging = join(ROOT, "dist", "runtime-staging-win32-x86_64");
+const staging = stagingForTarget(ROOT, "win32-x86_64");
 const payload = join(staging, "payload");
 const nsi = join(ROOT, "scripts", "nsis", "Penglai.nsi");
 const license = join(ROOT, "scripts", "nsis", "license.rtf");

--- a/scripts/package-windows-payload.mjs
+++ b/scripts/package-windows-payload.mjs
@@ -5,8 +5,9 @@ import { dirname, join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { ROOT, gitState } from "./lib/repo.mjs";
 import { finish } from "./lib/exit-contract.mjs";
+import { stagingForTarget } from "./lib/closure-credential.mjs";
 
-const staging = join(ROOT, "dist", "runtime-staging-win32-x86_64");
+const staging = stagingForTarget(ROOT, "win32-x86_64");
 const payload = join(staging, "payload");
 const native = process.platform === "win32" && process.arch === "x64";
 const git = gitState();


### PR DESCRIPTION
## Summary
- use the shared target-aware runtime staging resolver in the native Windows payload and NSIS packagers
- copy packed plugins into a target-specific staging tree during cross-target preparation
- reject the old hard-coded Windows staging path in tests

## Verification
- `pnpm test:unit` (421/421)
- `pnpm typecheck`
- relevant installed/Windows tests (20/20)
- script syntax, formatting, and diff checks

Root cause from native run 32496475574: `embed-runtime` correctly selected the host staging tree while the Windows packager read a different hard-coded tree.