### PR TITLE
test: observe plugin transport without wizard DOM wait

### DIFF
--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -105,10 +105,33 @@ test("native release workflow proves bundled optional plugins across restart", (
   assert.match(compat, /all-disabled-after-restart/);
   assert.match(compat, /fiberPhase/);
   assert.match(compat, /official\.websocket/);
+  assert.match(compat, /observeOfficialTransport/);
+  assert.doesNotMatch(compat, /observeOfficialSurfaces/);
   assert.doesNotMatch(compat, /phase\.official\.hasRoot/);
   assert.doesNotMatch(compat, /phase\.official\.hasDshBoot/);
   assert.match(compat, /pre-DSH wizard/);
   assert.doesNotMatch(compat, /PENGLAI_ALLOW_TEST_HARNESS/);
+});
+
+test("plugin transport observation does not wait for the post-wizard DOM", async () => {
+  const { observeOfficialTransport } = await import("../../../scripts/lib/browser-window-walk.mjs");
+  const expressions: string[] = [];
+  const session = {
+    send: async (method: string, params: { expression: string }) => {
+      assert.equal(method, "Runtime.evaluate");
+      expressions.push(params.expression);
+      const value = params.expression.includes("fetch(location.origin")
+        ? { status: 200, ok: true, official: true }
+        : params.expression.includes("new WebSocket")
+          ? { opened: true, readyState: 1 }
+          : { wizard: true, hasRoot: false, hasDshBoot: false };
+      return { result: { value } };
+    },
+  };
+  const result = await observeOfficialTransport(session);
+  assert.equal(result.official, true);
+  assert.equal(result.snap.wizard, true);
+  assert.equal(expressions.length, 3);
 });
 
 test("installed harness shutdown waits for the process close after SIGKILL", () => {

--- a/scripts/lib/browser-window-walk.mjs
+++ b/scripts/lib/browser-window-walk.mjs
@@ -308,6 +308,13 @@ export async function observeOfficialSurfaces(session) {
   return { snap, http, websocket, official: Boolean(snap?.hasDshBoot && snap?.hasRoot && !snap?.recovery && http?.official && websocket?.opened) };
 }
 
+export async function observeOfficialTransport(session) {
+  const snap = await evaluate(session, SNAPSHOT_JS);
+  const http = await evaluate(session, HTTP_JS);
+  const websocket = await evaluate(session, WS_JS);
+  return { snap, http, websocket, official: Boolean(http?.official && websocket?.opened) };
+}
+
 async function walkWizardKeyless(session, opts, helpers) {
   const { shot, steps, walked, userData, stopAfter } = helpers;
   const deadEnds = [];

--- a/scripts/u3-first-party-plugins.mjs
+++ b/scripts/u3-first-party-plugins.mjs
@@ -11,7 +11,7 @@ import { join, resolve } from "node:path";
 import { ROOT, gitState } from "./lib/repo.mjs";
 import { finish } from "./lib/exit-contract.mjs";
 import { attachPage, freePort } from "./lib/cdp.mjs";
-import { observeOfficialSurfaces } from "./lib/browser-window-walk.mjs";
+import { observeOfficialTransport } from "./lib/browser-window-walk.mjs";
 import {
   assertInstalledPenglaiIdentity,
   installFromExactInstaller,
@@ -191,7 +191,7 @@ async function runPhase(name, expectedEnabled) {
   let attachErr = "";
   try {
     const { session } = await attachPage(debugPort, 90_000);
-    official = await observeOfficialSurfaces(session);
+    official = await observeOfficialTransport(session);
     session.close();
   } catch (error) {
     attachErr = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary
- add a direct official HTTP/WebSocket transport observation for pre-DSH wizard tests
- stop waiting 45 seconds per phase for post-wizard DOM that is intentionally absent
- prove the transport observer passes with wizard DOM and performs exactly the three intended probes

## Verification
- `pnpm test:unit` (421/421)
- installed-walk tests (13/13)
- `pnpm typecheck`
- script syntax, format, and diff checks