### PR TITLE
test: close installed app through product lifecycle

### DIFF
--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -141,6 +141,28 @@ test("installed harness shutdown waits for the process close after SIGKILL", () 
   assert.doesNotMatch(helper, /resolveClose\(\[null, "SIGKILL"\]\)/);
 });
 
+test("installed restart requests the product lifecycle before signal fallback", async () => {
+  const { requestBrowserClose } = await import("../../../scripts/lib/installed-app.mjs");
+  const calls: unknown[][] = [];
+  let closed = false;
+  const session = {
+    send: async (...args: unknown[]) => {
+      calls.push(args);
+      return {};
+    },
+    close: () => {
+      closed = true;
+    },
+  };
+  assert.equal(await requestBrowserClose(session, 321), true);
+  assert.deepEqual(calls, [["Browser.close", {}, 321]]);
+  assert.equal(closed, true);
+
+  const compat = readFileSync(join(root, "scripts/u3-first-party-plugins.mjs"), "utf8");
+  assert.match(compat, /requestBrowserClose\(cdpSession\)/);
+  assert.ok(compat.indexOf("requestBrowserClose(cdpSession)") < compat.indexOf("stopChild(launched.child)"));
+});
+
 test("installed harness shutdown returns only after the child is gone", async (context) => {
   const { stopChild } = await import("../../../scripts/lib/installed-app.mjs");
   const child = spawn(

--- a/scripts/lib/installed-app.mjs
+++ b/scripts/lib/installed-app.mjs
@@ -250,6 +250,18 @@ export function waitChildExit(child, timeoutMs = 15_000) {
   });
 }
 
+export async function requestBrowserClose(session, timeoutMs = 5_000) {
+  if (!session) return false;
+  try {
+    await session.send("Browser.close", {}, timeoutMs);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    session.close();
+  }
+}
+
 export async function stopChild(child, timeoutMs = 8_000) {
   if (child.exitCode !== null || child.signalCode) return [child.exitCode, child.signalCode];
   const closed = new Promise((resolveClose) =>

--- a/scripts/u3-first-party-plugins.mjs
+++ b/scripts/u3-first-party-plugins.mjs
@@ -18,6 +18,7 @@ import {
   launchInstalledHarness,
   leftoversByCommand,
   ownedProcessTree,
+  requestBrowserClose,
   resourcesInside,
   stopChild,
   waitForFile,
@@ -189,21 +190,24 @@ async function runPhase(name, expectedEnabled) {
   const sawGateway = await waitForFile(join(userData, "gateway.port"), 90_000);
   let official = null;
   let attachErr = "";
+  let cdpSession = null;
   try {
     const { session } = await attachPage(debugPort, 90_000);
+    cdpSession = session;
     official = await observeOfficialTransport(session);
-    session.close();
   } catch (error) {
     attachErr = error instanceof Error ? error.message : String(error);
   }
   const inventory = await waitInventory(expectedEnabled, startedAt);
   const tree = ownedProcessTree(installed.app, resources, launched.child.pid);
+  const gracefulBrowserClose = await requestBrowserClose(cdpSession);
   await stopChild(launched.child);
   const leftovers = leftoversByCommand(dshNeedle);
   return {
     name,
     expectedEnabled,
     sawGateway,
+    gracefulBrowserClose,
     attachErr: attachErr || undefined,
     official: {
       http: official?.http?.official === true,


### PR DESCRIPTION
## Summary
- request `Browser.close` through CDP before every installed restart
- let Penglai run its real `shutdown()` path for the proxy, DSH, and Electron helpers before signal fallback
- record whether graceful browser close was accepted in each native phase
- prove the close request contract and ordering

## Verification
- `pnpm test:unit` (421/421)
- installed-walk tests (14/14)
- `pnpm typecheck`
- script syntax, format, and diff checks

Root cause evidence: native arm run 32496475574 passed the first installed phase, then a force-terminated Electron helper retained the profile lifecycle and suppressed DSH on subsequent starts.