### PR TITLE
ci: build workspace before plugin distribution gate

### DIFF
--- a/.github/workflows/native-release-candidate.yml
+++ b/.github/workflows/native-release-candidate.yml
@@ -25,6 +25,8 @@ jobs:
           corepack enable
           corepack prepare pnpm@10.14.0 --activate
           pnpm install --frozen-lockfile
+      - name: Build source dependencies for the distribution verifier
+        run: pnpm build
       - name: Verify immutable catalog, disabled install, and offline recovery
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The clean Ubuntu distribution job installed dependencies but did not build workspace package outputs before importing the production Plugin Registry. Add the same source build prerequisite used by native jobs. Local format and desktop E2E pass; the full native workflow will be rerun from the merged SHA.