### PR TITLE
fix: close final native distribution gates

### DIFF
--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -109,6 +109,9 @@ test("native release workflow proves bundled optional plugins across restart", (
   assert.match(compat, /writeFileSync\(profilePatch, text, \{ mode: 0o600 \}\)/);
   assert.doesNotMatch(compat, /ftruncateSync/);
   assert.doesNotMatch(compat, /observeOfficialSurfaces/);
+  const welcome = readFileSync(join(root, "scripts/u3-welcome-smoke.mjs"), "utf8");
+  assert.match(welcome, /startup\.error\.log/);
+  assert.match(welcome, /dsh\.stderr\.log/);
   assert.doesNotMatch(compat, /phase\.official\.hasRoot/);
   assert.doesNotMatch(compat, /phase\.official\.hasDshBoot/);
   assert.match(compat, /pre-DSH wizard/);

--- a/packages/plugin-center/src/remotes.ts
+++ b/packages/plugin-center/src/remotes.ts
@@ -16,6 +16,7 @@ import {
   runtimePluginTarget,
   type PluginCatalogEntry,
   type PluginOwnerAction,
+  type ProductPluginTarget,
 } from "@penglai/runtime";
 import {
   rollbackLastGood,
@@ -78,12 +79,12 @@ function catalogEntry(
   entries: readonly PluginCatalogEntry[],
   id: string,
   registry?: PluginDistributionClient,
+  hostTarget: ProductPluginTarget = runtimePluginTarget(),
 ): PluginCatalogEntry {
   const entry = entries.find((candidate) => candidate.id === id);
   if (entry) return entry;
   if (!registry) throw new PenglaiError("INVALID_INPUT", "unlisted package");
   const remote = registry.entry(id);
-  const hostTarget = runtimePluginTarget();
   const artifact = selectCatalogArtifact(remote.artifacts, hostTarget);
   if (remote.dsh.exact !== PINNED_PLUGIN_DSH) {
     throw new PenglaiError("SECURITY_POLICY", `${id} DSH pin is not ${PINNED_PLUGIN_DSH}`);
@@ -164,10 +165,12 @@ export function createCenterRemote(opts: {
   userDataRoot: string;
   registry?: PluginDistributionClient;
   stagePackage?: (pkg: CachedPackage) => Promise<void>;
+  target?: ProductPluginTarget;
 }): CenterRemote {
+  const hostTarget = (): ProductPluginTarget => opts.target ?? runtimePluginTarget();
   const requireOwner = (id: string, action: PluginOwnerAction, capabilityId: string | undefined): void => {
     if (!capabilityId) throw new PenglaiError("SECURITY_POLICY", "native owner capability is required");
-    const entry = catalogEntry(opts.catalog, id, opts.registry);
+    const entry = catalogEntry(opts.catalog, id, opts.registry, hostTarget());
     consumePluginOwnerGrant({
       userDataRoot: opts.userDataRoot,
       capabilityId,
@@ -187,7 +190,7 @@ export function createCenterRemote(opts: {
     id: string,
     action: "enable" | "disable" | "update" | "install",
   ) => {
-    const entry = catalogEntry(opts.catalog, id, opts.registry);
+    const entry = catalogEntry(opts.catalog, id, opts.registry, hostTarget());
     if (action === "disable" && id === "@penglai/plugin-center") {
       throw new PenglaiError("SECURITY_POLICY", "required plugin cannot be disabled");
     }
@@ -315,14 +318,14 @@ export function createCenterRemote(opts: {
     async installDisabled(id: string, capabilityId?: string) {
       if (!opts.registry) throw new PenglaiError("INVALID_INPUT", "remote plugin registry is not configured");
       requireOwner(id, "plugin-install", capabilityId);
-      const pkg = await opts.registry.downloadPackage(id, runtimePluginTarget());
+      const pkg = await opts.registry.downloadPackage(id, hostTarget());
       await opts.stagePackage?.(pkg);
       const installed = await transact(id, "install");
       await waitForInventory(opts.inventory, id, false);
       return { id, version: pkg.version, sha256: pkg.sha256, enabled: false, installed: true, phase: installed.phase };
     },
     async rollback(id: string) {
-      catalogEntry(opts.catalog, id, opts.registry);
+      catalogEntry(opts.catalog, id, opts.registry, hostTarget());
       const enabled = previousEnabledFromJournal(opts.txDir, id);
       const out = await rollbackLastGood({
         userDataRoot: opts.userDataRoot,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -819,6 +819,32 @@ export function dshWebArgs(port: number): string[] {
   return ["--profile", "web", "--no-open", "--host", "127.0.0.1", "--port", String(port)];
 }
 
+export function windowsOwnedProcessEnvironment(
+  userRoot: string,
+  sourceEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const systemRoot = sourceEnv.SystemRoot || sourceEnv.WINDIR || "C:\\Windows";
+  const temp = join(userRoot, "temp");
+  const appData = join(userRoot, "AppData", "Roaming");
+  const localAppData = join(userRoot, "AppData", "Local");
+  for (const path of [temp, appData, localAppData]) {
+    mkdirSync(path, { recursive: true, mode: 0o700 });
+  }
+  return {
+    PATH: `${join(systemRoot, "System32")};${systemRoot}`,
+    SystemRoot: systemRoot,
+    WINDIR: systemRoot,
+    ComSpec: sourceEnv.ComSpec || join(systemRoot, "System32", "cmd.exe"),
+    PATHEXT: sourceEnv.PATHEXT || ".COM;.EXE;.BAT;.CMD",
+    ProgramData: sourceEnv.ProgramData || "C:\\ProgramData",
+    USERPROFILE: userRoot,
+    APPDATA: appData,
+    LOCALAPPDATA: localAppData,
+    TEMP: temp,
+    TMP: temp,
+  };
+}
+
 export class EmbeddedDshSupervisor {
   state: "stopped" | "starting" | "healthy" | "crashed" | "stopping" = "stopped";
   port = 0;
@@ -863,7 +889,7 @@ export class EmbeddedDshSupervisor {
     };
     const dshArgs = dshWebArgs(this.port);
     if (process.platform === "win32") {
-      childEnv.PATH = "C:\\Windows\\System32;C:\\Windows";
+      Object.assign(childEnv, windowsOwnedProcessEnvironment(user.root));
       const spawned = spawnOwnedDshProcess({
         platform: "win32",
         executable: this.layout.nodeBin,

--- a/packages/runtime/src/runtime.test.ts
+++ b/packages/runtime/src/runtime.test.ts
@@ -25,6 +25,7 @@ import {
   FIRST_PARTY_PLUGIN_METADATA,
   profilePluginEnabled,
   runtimePluginTarget,
+  windowsOwnedProcessEnvironment,
 } from "./index.js";
 
 test("embedded DSH Web never opens the operating-system browser", () => {
@@ -37,6 +38,20 @@ test("embedded DSH Web never opens the operating-system browser", () => {
     "--port",
     "3080",
   ]);
+});
+
+test("Windows owned DSH receives only the required OS environment", () => {
+  const root = mkdtempSync(join(tmpdir(), "penglai-win-env-"));
+  const env = windowsOwnedProcessEnvironment(root, {
+    SystemRoot: "C:\\Windows",
+    ComSpec: "C:\\Windows\\System32\\cmd.exe",
+    SECRET_TOKEN: "must-not-cross",
+  });
+  assert.equal(env.SystemRoot, "C:\\Windows");
+  assert.equal(env.USERPROFILE, root);
+  assert.match(String(env.PATH), /System32/);
+  assert.equal("SECRET_TOKEN" in env, false);
+  assert.ok(existsSync(String(env.TEMP)));
 });
 
 function writeTrustedPluginSet(

--- a/scripts/u3-welcome-smoke.mjs
+++ b/scripts/u3-welcome-smoke.mjs
@@ -148,8 +148,10 @@ try {
 
 const tree = ownedProcessTree(app, resources, launched.child.pid);
 const leftoverNeedle = resolve(join(resources, "runtime/dsh/lib/bin.js"));
-await stopChild(launched.child);
+const stopped = await stopChild(launched.child);
 const leftovers = leftoversByCommand(leftoverNeedle);
+const readDiagnostic = (path) =>
+  existsSync(path) ? readFileSync(path, "utf8").slice(-4000) : "";
 
 const welcomeReachable = Boolean(
   welcome?.welcomePenglai && welcome.continueVisible && !welcome.continueDisabled && !welcome.officialInternalNotice,
@@ -205,6 +207,11 @@ const rec = {
       : null,
   },
   processTree: { dshPid: tree.dshPid, ownedAbsolute: tree.ownedAbsolute, leftovers: leftovers.length },
+  stopped: { code: stopped[0], signal: stopped[1] },
+  diagnostics: {
+    startupError: readDiagnostic(join(userData, "logs", "startup.error.log")),
+    dshError: readDiagnostic(join(userData, "logs", "dsh.stderr.log")),
+  },
   outputTail: launched.output().slice(-2000),
 };
 writeRec(rec);

--- a/scripts/verify-live-plugin-catalog.mjs
+++ b/scripts/verify-live-plugin-catalog.mjs
@@ -106,6 +106,7 @@ try {
     txDir,
     pluginsDir,
     userDataRoot,
+    target: "darwin-aarch64",
     async stagePackage(downloaded) {
       const name = `${downloaded.id.replace("@", "").replaceAll("/", "-")}-${downloaded.version}.tgz`;
       writeFileSync(join(pluginsDir, name), readFileSync(downloaded.path), { mode: 0o600 });


### PR DESCRIPTION
## Root causes

- The Ubuntu live catalog verifier correctly selected a supported Penglai target in `PluginDistributionClient`, but the production Center transaction recomputed the host as unsupported `linux-x64`. Inject the product target only for the verifier; ordinary desktop construction still resolves the real native target.
- The Windows installed harness was intentionally scrubbed, but the nested native Job Object supervisor received an environment without Windows runtime primitives such as `SystemRoot`, `ComSpec`, `USERPROFILE`, and temp/app-data roots. Pass a minimal explicit allowlist to the owned DSH process without inheriting arbitrary runner secrets.
- Add startup and DSH stderr tails to failed installed-welcome evidence so another native failure is diagnosable rather than a blank timeout.

## Verification

- format: PASS
- typecheck: PASS
- unit: 422/422
- desktop E2E: 68/68
- authenticated immutable catalog refresh, signed package download, production Center disabled install, capability consumption, offline last-good: PASS

The native workflow must still be rerun from the merged SHA. Windows acceptance is not claimed from source tests.
