### PR TITLE
fix: resolve packaged Windows native host

### DIFF
--- a/apps/desktop/src/electron-main.ts
+++ b/apps/desktop/src/electron-main.ts
@@ -412,12 +412,12 @@ async function main(): Promise<void> {
   };
 
   try {
-    ensurePrivateHome(user);
+    const resources = resourcesRoot();
+    const layout = layoutFromResources(resources);
+    ensurePrivateHome(user, layout.appRoot);
     migrateRc8UserData(user.root);
     quarantineRevokedPlugins({ userDataRoot: user.root, profileDir: user.profileWeb });
     recoverProfile(user);
-    const resources = resourcesRoot();
-    const layout = layoutFromResources(resources);
     live.attach(layout);
     process.env.PENGLAI_PLUGINS_DIR = join(layout.appRoot, "plugins");
     activatePrivateProfile(layout, user);
@@ -590,7 +590,7 @@ async function main(): Promise<void> {
             desktopData.managedData,
             protection.roots,
             desktopData.legacyCandidates,
-            deletionInspectionOptionsForPlatform(platform),
+            deletionInspectionOptionsForPlatform(platform, { appRoot: layout.appRoot }),
           );
         }
         if (name === "prepareDataDeletion") {
@@ -609,7 +609,10 @@ async function main(): Promise<void> {
                 protection.roots,
                 desktopData.legacyCandidates,
                 desktopData.uninstall,
-                { dataLayout: desktopData.managedData, ...deletionInspectionOptionsForPlatform(platform) },
+                {
+                  dataLayout: desktopData.managedData,
+                  ...deletionInspectionOptionsForPlatform(platform, { appRoot: layout.appRoot }),
+                },
               );
               const plan = buildDeletionPlan({
                 operationId: `del_${randomBytes(16).toString("hex")}`,

--- a/apps/desktop/src/security.test.ts
+++ b/apps/desktop/src/security.test.ts
@@ -55,6 +55,9 @@ test("renderer lifecycle surface has no arbitrary installer URL path or delete p
   assert.match(main, /operationId: `del_/);
   assert.match(main, /writeWindowsDeletionCapability/);
   assert.match(main, /deletionInspectionOptionsForPlatform/);
+  assert.match(main, /ensurePrivateHome\(user, layout\.appRoot\)/);
+  assert.match(main, /deletionInspectionOptionsForPlatform\(platform, \{ appRoot: layout\.appRoot \}\)/);
+  assert.ok(main.indexOf("const layout = layoutFromResources(resources)") < main.indexOf("ensurePrivateHome(user, layout.appRoot)"));
   assert.doesNotMatch(center, /openVerifiedInstaller|planUninstall|__PENGLAI_VERIFIED_INSTALL_OPERATION/);
   assert.match(center, /DELETE PENGLAI DATA/);
   assert.match(center, /confirmPluginAction/);

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -118,15 +118,16 @@ export function resolveUserLayout(userData: string): UserLayout {
   };
 }
 
-export function ensurePrivateHome(user: UserLayout): void {
+export function ensurePrivateHome(user: UserLayout, appRoot?: string): void {
   for (const p of [user.root, user.dshHome, user.profileWeb, user.transactions, user.snapshots, dirname(user.imDb), user.logs]) {
     mkdirSync(p, { recursive: true, mode: 0o700 });
   }
   if (process.platform === "win32") {
-    applyWindowsCredentialAcl(user.dshHome, { platform: "win32" });
+    if (!appRoot) throw new PenglaiError("SECURITY_POLICY", "Windows private home requires the packaged app root");
+    applyWindowsCredentialAcl(user.dshHome, { platform: "win32", appRoot });
     const yaml = join(user.dshHome, ".credentials.yaml");
     if (existsSync(yaml)) {
-      applyWindowsCredentialAcl(yaml, { platform: "win32" });
+      applyWindowsCredentialAcl(yaml, { platform: "win32", appRoot });
     }
   }
 }
@@ -803,7 +804,7 @@ function waitChildExit(child: ChildProcess, timeoutMs: number): Promise<void> {
 export function killStaleSupervisor(layout: RuntimeLayout, user: UserLayout): void {
   const previous = readIdentity(user);
   if (previous) {
-    killIdentity(previous, "SIGKILL");
+    killIdentity({ ...previous, appRoot: layout.appRoot }, "SIGKILL");
     clearIdentity(user);
   }
   reapDshOrphans(layout);
@@ -919,6 +920,7 @@ export class EmbeddedDshSupervisor {
         port: this.port,
         startedAt: new Date(startMs).toISOString(),
         platform: "win32",
+        appRoot: this.layout.appRoot,
         owner: report.owner,
         jobAssigned: true,
         supervisorPid,

--- a/packages/runtime/src/process.ts
+++ b/packages/runtime/src/process.ts
@@ -16,6 +16,7 @@ export interface ProcessIdentity {
   port: number;
   startedAt: string;
   platform?: "darwin" | "win32";
+  appRoot?: string;
   owner?: string;
   jobAssigned?: boolean;
   supervisorPid?: number;
@@ -30,11 +31,18 @@ function hostPlatform(id?: ProcessIdentity): NodeJS.Platform {
   return process.platform;
 }
 
-export function readProcessStartMs(pid: number, platform: NodeJS.Platform = process.platform): number {
+export function readProcessStartMs(
+  pid: number,
+  platform: NodeJS.Platform = process.platform,
+  appRoot?: string,
+): number {
   if (pid <= 0) return 0;
   if (platform === "win32") {
     try {
-      const report = invokeWindowsHost(["process-identity", "--pid", String(pid)], { platform: "win32" });
+      const report = invokeWindowsHost(["process-identity", "--pid", String(pid)], {
+        platform: "win32",
+        ...(appRoot ? { appRoot } : {}),
+      });
       return typeof report.startMs === "number" && Number.isFinite(report.startMs) ? report.startMs : 0;
     } catch {
       return 0;
@@ -60,9 +68,12 @@ export function readProcessPgid(pid: number, platform: NodeJS.Platform = process
   }
 }
 
-function windowsIdentityReport(pid: number): WindowsHostReport | undefined {
+function windowsIdentityReport(pid: number, appRoot?: string): WindowsHostReport | undefined {
   try {
-    return invokeWindowsHost(["process-identity", "--pid", String(pid)], { platform: "win32" });
+    return invokeWindowsHost(["process-identity", "--pid", String(pid)], {
+      platform: "win32",
+      ...(appRoot ? { appRoot } : {}),
+    });
   } catch {
     return undefined;
   }
@@ -72,7 +83,7 @@ export function processStillMatches(id: ProcessIdentity): boolean {
   if (id.pid <= 0) return false;
   const platform = hostPlatform(id);
   if (platform === "win32") {
-    const report = windowsIdentityReport(id.pid);
+    const report = windowsIdentityReport(id.pid, id.appRoot);
     if (!report || !report.startMs) return false;
     if (Math.abs(report.startMs - id.startMs) > 2000) return false;
     if (report.executable && !report.executable.toLowerCase().includes(id.executable.replace(/\//g, "\\").toLowerCase().split("\\").pop() ?? "node.exe")) {

--- a/packages/runtime/src/windows-host.test.ts
+++ b/packages/runtime/src/windows-host.test.ts
@@ -91,6 +91,19 @@ test("Windows native host is unavailable on this runner and fail-closed", () => 
   }
 });
 
+test("installed Windows helper resolves only through the exact packaged app root", () => {
+  const appRoot = mkdtempSync(join(tmpdir(), "penglai-win-app-root-"));
+  const helper = join(appRoot, "runtime", "helpers", "penglai-windows-host.exe");
+  mkdirSync(join(appRoot, "runtime", "helpers"), { recursive: true });
+  writeFileSync(helper, "fixture");
+  assert.equal(resolveWindowsHostExecutable(appRoot), helper);
+  assert.equal(requireWindowsNativeHost("win32", appRoot), helper);
+  const inspection = deletionInspectionOptionsForPlatform("win32", { appRoot });
+  assert.equal(inspection.platform, "win32");
+  assert.equal(typeof inspection.ownerProbe, "function");
+  assert.equal(typeof inspection.reparseProbe, "function");
+});
+
 test("Windows deletion inspection refuses missing owner and reparse probes", () => {
   const root = mkdtempSync(join(tmpdir(), "penglai-win-del-"));
   const plan = buildDeletionPlan({

--- a/packages/runtime/src/windows-host.ts
+++ b/packages/runtime/src/windows-host.ts
@@ -59,6 +59,7 @@ export interface WindowsAclApplyResult {
 export interface WindowsHostInvokeOptions {
   platform?: NodeJS.Platform;
   hostPath?: string;
+  appRoot?: string;
 }
 
 export function applyWindowsCredentialAcl(
@@ -252,7 +253,7 @@ export function parseWindowsHostReport(raw: string): WindowsHostReport {
 
 export function invokeWindowsHost(args: string[], options: WindowsHostInvokeOptions = {}): WindowsHostReport {
   const platform = options.platform ?? process.platform;
-  const host = options.hostPath ?? requireWindowsNativeHost(platform);
+  const host = options.hostPath ?? requireWindowsNativeHost(platform, options.appRoot);
   let stdout = "";
   try {
     stdout = execFileSync(host, args, { encoding: "utf8", timeout: 8_000, windowsHide: true });
@@ -287,19 +288,21 @@ export function windowsReparseProbe(path: string, options: WindowsHostInvokeOpti
 
 export function deletionInspectionOptionsForPlatform(
   platform: NodeJS.Platform,
-  override?: Partial<DeletionInspectionOptions> & { available?: boolean },
+  override?: Partial<DeletionInspectionOptions> & { available?: boolean; appRoot?: string },
 ): DeletionInspectionOptions {
   if (platform !== "win32") return { platform, ...override };
   if (override?.ownerProbe && override.reparseProbe) {
     return { platform, ...override };
   }
-  if (override?.available === false || !resolveWindowsHostExecutable()) {
+  if (override?.available === false || !resolveWindowsHostExecutable(override?.appRoot)) {
     throw new PenglaiError("SECURITY_POLICY", "Windows inventory requires native owner and reparse-point probes");
   }
   return {
     platform,
-    ownerProbe: (path) => windowsOwnerProbe(path),
-    reparseProbe: (path) => windowsReparseProbe(path),
+    ownerProbe: (path) =>
+      windowsOwnerProbe(path, { platform: "win32", ...(override?.appRoot ? { appRoot: override.appRoot } : {}) }),
+    reparseProbe: (path) =>
+      windowsReparseProbe(path, { platform: "win32", ...(override?.appRoot ? { appRoot: override.appRoot } : {}) }),
     ...override,
   };
 }


### PR DESCRIPTION
## Root cause

The installed Windows app applied native ACLs before resolving its packaged resources root. The helper resolver therefore had no trusted app root and failed closed even though `penglai-windows-host.exe` was present in the installer. The same missing path capability affected process identity and deletion probes.

## Fix

- resolve and validate the installed resources layout before Windows private-home ACLs
- thread the exact packaged app root through ACL, process-identity, and deletion helper calls
- persist the verified app root for the owned Windows DSH identity and override stale persisted identity with the current layout
- keep helper resolution fail-closed; no PATH fallback or inherited arbitrary environment

## Verification

- format check PASS
- typecheck PASS
- unit 423/423 PASS
- contract 62/62 PASS
- integration 21/21 PASS
- desktop E2E 68/68 PASS
- security 15/15 PASS

A new exact-SHA native workflow run is still required before release.