### PR TITLE
fix: make Windows private ACL usable

### DIFF
--- a/native/windows-host/penglai_windows_host.c
+++ b/native/windows-host/penglai_windows_host.c
@@ -159,17 +159,12 @@ static int apply_current_user_acl(const wchar_t *path) {
   GetTokenInformation(token, TokenUser, NULL, 0, &needed);
   TOKEN_USER *user = (TOKEN_USER *)calloc(1, needed ? needed : 1);
   int ok = 0;
-  EXPLICIT_ACCESS_W ea[5];
-  PSID users = NULL;
-  PSID everyone = NULL;
+  EXPLICIT_ACCESS_W ea[3];
   PSID system = NULL;
   PSID admins = NULL;
   PACL dacl = NULL;
   SID_IDENTIFIER_AUTHORITY nt = SECURITY_NT_AUTHORITY;
-  SID_IDENTIFIER_AUTHORITY world = SECURITY_WORLD_SID_AUTHORITY;
   if (!user || !GetTokenInformation(token, TokenUser, user, needed, &needed)) goto done;
-  if (!AllocateAndInitializeSid(&nt, 2, SECURITY_BUILTIN_DOMAIN_RID, DOMAIN_ALIAS_RID_USERS, 0, 0, 0, 0, 0, 0, &users)) goto done;
-  if (!AllocateAndInitializeSid(&world, 1, SECURITY_WORLD_RID, 0, 0, 0, 0, 0, 0, 0, &everyone)) goto done;
   if (!AllocateAndInitializeSid(&nt, 1, SECURITY_LOCAL_SYSTEM_RID, 0, 0, 0, 0, 0, 0, 0, &system)) goto done;
   if (!AllocateAndInitializeSid(&nt, 2, SECURITY_BUILTIN_DOMAIN_RID, DOMAIN_ALIAS_RID_ADMINS, 0, 0, 0, 0, 0, 0, &admins)) goto done;
   ZeroMemory(ea, sizeof(ea));
@@ -191,19 +186,10 @@ static int apply_current_user_acl(const wchar_t *path) {
   ea[2].Trustee.TrusteeForm = TRUSTEE_IS_SID;
   ea[2].Trustee.TrusteeType = TRUSTEE_IS_WELL_KNOWN_GROUP;
   ea[2].Trustee.ptstrName = (LPWSTR)admins;
-  ea[3].grfAccessPermissions = GENERIC_ALL;
-  ea[3].grfAccessMode = DENY_ACCESS;
-  ea[3].grfInheritance = SUB_CONTAINERS_AND_OBJECTS_INHERIT;
-  ea[3].Trustee.TrusteeForm = TRUSTEE_IS_SID;
-  ea[3].Trustee.TrusteeType = TRUSTEE_IS_WELL_KNOWN_GROUP;
-  ea[3].Trustee.ptstrName = (LPWSTR)users;
-  ea[4].grfAccessPermissions = GENERIC_ALL;
-  ea[4].grfAccessMode = DENY_ACCESS;
-  ea[4].grfInheritance = SUB_CONTAINERS_AND_OBJECTS_INHERIT;
-  ea[4].Trustee.TrusteeForm = TRUSTEE_IS_SID;
-  ea[4].Trustee.TrusteeType = TRUSTEE_IS_WELL_KNOWN_GROUP;
-  ea[4].Trustee.ptstrName = (LPWSTR)everyone;
-  if (SetEntriesInAclW(5, ea, NULL, &dacl) != ERROR_SUCCESS) goto done;
+  /* A protected DACL containing only these three allow ACEs denies every
+     omitted principal. Explicit DENY_ACCESS ACEs for Users or Everyone would
+     also deny the current user because that user belongs to both groups. */
+  if (SetEntriesInAclW(3, ea, NULL, &dacl) != ERROR_SUCCESS) goto done;
   if (SetNamedSecurityInfoW((LPWSTR)path, SE_FILE_OBJECT,
                             OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
                             user->User.Sid, NULL, dacl, NULL) != ERROR_SUCCESS) {
@@ -212,8 +198,6 @@ static int apply_current_user_acl(const wchar_t *path) {
   ok = 1;
 done:
   if (dacl) LocalFree(dacl);
-  if (users) FreeSid(users);
-  if (everyone) FreeSid(everyone);
   if (system) FreeSid(system);
   if (admins) FreeSid(admins);
   free(user);

--- a/packages/runtime/src/foundation.test.ts
+++ b/packages/runtime/src/foundation.test.ts
@@ -59,10 +59,11 @@ test("posix credential modes and atomic write", () => {
   assert.equal(readFileSync(file, "utf8"), "secret: x\n");
 });
 
-test("Windows ACL plan denies Users/Everyone", () => {
+test("Windows ACL plan denies Users/Everyone by omission, never conflicting ACEs", () => {
   const plan = windowsCredentialAcl();
   assert.ok(plan.deny.includes("Users"));
   assert.ok(plan.deny.includes("Everyone"));
+  assert.equal(plan.denyMode, "implicit-by-omission");
   assert.throws(() => assertWindowsAclHonest([{ id: "Everyone", allow: true }]), PenglaiError);
   assert.doesNotThrow(() => assertWindowsAclHonest([{ id: "current-user", allow: true }]));
 });

--- a/packages/runtime/src/permissions.ts
+++ b/packages/runtime/src/permissions.ts
@@ -12,6 +12,7 @@ export interface WindowsAclPlan {
   owner: "current-user";
   allow: Array<"current-user" | "SYSTEM" | "Administrators">;
   deny: Array<"Users" | "Everyone">;
+  denyMode: "implicit-by-omission";
 }
 
 export function posixCredentialModes(): { dir: number; file: number } {
@@ -23,6 +24,7 @@ export function windowsCredentialAcl(): WindowsAclPlan {
     owner: "current-user",
     allow: ["current-user", "SYSTEM", "Administrators"],
     deny: ["Users", "Everyone"],
+    denyMode: "implicit-by-omission",
   };
 }
 

--- a/packages/runtime/src/windows-host.test.ts
+++ b/packages/runtime/src/windows-host.test.ts
@@ -76,6 +76,8 @@ test("native Windows host source encodes Job Object, ACL, and reparse facts", ()
   assert.match(src, /JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE/);
   assert.match(src, /CREATE_SUSPENDED/);
   assert.match(src, /FILE_ATTRIBUTE_REPARSE_POINT/);
+  assert.match(src, /SetEntriesInAclW\(3,/);
+  assert.doesNotMatch(src, /grfAccessMode\s*=\s*DENY_ACCESS/);
 });
 
 test("Windows native host is unavailable on this runner and fail-closed", () => {


### PR DESCRIPTION
## Root cause

The native helper created explicit deny ACEs for `Users` and `Everyone` in addition to an allow ACE for the current user. Windows evaluates the group deny first, so the owner was denied access to its own DSH home. The installed migration then failed with `EPERM` on `lstat`.

## Fix

- use a protected DACL containing only allow ACEs for the current user, SYSTEM, and Administrators
- deny every other principal by omission, avoiding conflicting group-deny ACEs
- encode the omission semantics in the TypeScript contract and tests

## Verification

- format check PASS
- typecheck PASS
- unit 423/423 PASS
- desktop E2E 68/68 PASS
- security 15/15 PASS
- native source test requires exactly three ACL entries and no assigned DENY_ACCESS ACE

A fresh Windows-native run must compile the C helper and prove installed startup before release.