### PR TITLE
fix: release Penglai 0.5.2 onboarding recovery

### DIFF
--- a/.github/workflows/native-release-candidate.yml
+++ b/.github/workflows/native-release-candidate.yml
@@ -1,4 +1,4 @@
-name: Native 0.5.1 release candidate
+name: Native 0.5.2 release candidate
 
 on:
   workflow_dispatch:
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: native-0.5.1-${{ github.ref }}
+  group: native-0.5.2-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -41,11 +41,11 @@ jobs:
           - runner: macos-15
             target: darwin-aarch64
             package: package:dmg:arm
-            installer: Penglai_0.5.1_macos_aarch64.dmg
+            installer: Penglai_0.5.2_macos_aarch64.dmg
           - runner: macos-15-intel
             target: darwin-x86_64
             package: package:dmg:intel
-            installer: Penglai_0.5.1_macos_x64.dmg
+            installer: Penglai_0.5.2_macos_x64.dmg
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     steps:
@@ -66,6 +66,12 @@ jobs:
         run: pnpm prepare:public-export -- --clean-room
       - name: Build source from the clean checkout
         run: pnpm build
+      - name: Source and onboarding regression gates
+        run: |
+          pnpm test:unit
+          pnpm test:contract
+          pnpm test:security
+          pnpm verify:contracts
       - name: Build exact native installer
         run: pnpm ${{ matrix.package }}
       - name: Installed welcome and process smoke
@@ -82,7 +88,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: penglai-0.5.1-${{ matrix.target }}
+          name: penglai-0.5.2-${{ matrix.target }}
           if-no-files-found: error
           retention-days: 14
           path: |
@@ -117,6 +123,12 @@ jobs:
         run: pnpm prepare:public-export -- --clean-room
       - name: Build source from the clean checkout
         run: pnpm build
+      - name: Source and onboarding regression gates
+        run: |
+          pnpm test:unit
+          pnpm test:contract
+          pnpm test:security
+          pnpm verify:contracts
       - name: Build exact native installer with MSVC
         shell: cmd
         run: |
@@ -138,11 +150,11 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: penglai-0.5.1-win32-x86_64
+          name: penglai-0.5.2-win32-x86_64
           if-no-files-found: error
           retention-days: 14
           path: |
-            dist/Penglai_0.5.1_windows_x64_setup.exe
+            dist/Penglai_0.5.2_windows_x64_setup.exe
             evidence/generated/local-installer-win32-x86_64.json
             evidence/generated/u3-welcome-smoke.json
             evidence/generated/u3-first-party-plugins.json

--- a/PRODUCT_CONSTITUTION.md
+++ b/PRODUCT_CONSTITUTION.md
@@ -1,6 +1,6 @@
 # 蓬莱产品宪法
 
-> 生效日期：2026-08-16；2026-08-20 经 Owner 明确修订 0.5.0 首发平台与公开授权；2026-08-21 修订 0.5.1 为 DSH `0.1.1-rc.1` 三端社区验证发行版。本文是仓库内最高产品约束。用户最新明确指令高于本文；方向改变时必须先同步本文、`STATE.md` 和决策日志，再开始编码。
+> 生效日期：2026-08-16；2026-08-20 经 Owner 明确修订 0.5.0 首发平台与公开授权；2026-08-21 修订 0.5.1 为 DSH `0.1.1-rc.1` 三端社区验证发行版；2026-08-22 授权 0.5.2 修复首次引导并验收 0.5.1 → 0.5.2 辅助更新。本文是仓库内最高产品约束。用户最新明确指令高于本文；方向改变时必须先同步本文和决策日志，再开始编码。
 
 ## 一句话定义
 
@@ -23,7 +23,7 @@
 9. **安装包必须自带可运行产品。** 干净 Mac/Windows 不应预装 Node、pnpm、Python、系统 ffmpeg 或 `dsh`。包内固定目标平台运行时、完整 DSH 闭包、profile seed、第一方插件（含语音 native/WASM engines）、许可证、SBOM 与完整性清单；生产禁止静默回退系统 PATH。大型 ASR/TTS 权重可在用户明确操作后按 immutable manifest/hash 按需下载，不得成为 DSH 启动依赖。
 10. **二次开发不得删减 DSH。** Penglai 可以替换产品名、字标、欢迎/引导文案和默认组合，并增加 Center/IM；但 official DSH 的浅色、深色、跟随系统动态主题、中英文切换、Models、Workspace、Session、工具、审批和设置能力必须保留。中文是 fresh install 默认值，不是删除 English。
 11. **安装、升级、卸载是产品能力。** 0.5.0 必须提供 fresh install、首次引导、0.5 系列后续升级、失败恢复和完整卸载/数据管理；升级或卸载不得误删用户 Workspace、旧版本数据或未明确选择的数据类别。
-12. **公开发布只消费精确验收资产。** 0.5.0 已发布边界仍是单一 Apple Silicon DMG。0.5.1 声明三个 target：`darwin-aarch64`、`darwin-x86_64`、`win32-x86_64`，必须来自同一 source SHA。缺对应原生 runner 的 Intel/Windows 只能写 `BLOCKED`/`NOT_RUN`，不得写成 native PASS 或混入 0.5.0 支持声明。公开 Release 必须上传验收过的同一 bytes，不能重建偷换。
+12. **公开发布只消费精确验收资产。** 0.5.0 已发布边界仍是单一 Apple Silicon DMG。0.5.1 及 0.5.2 声明三个 target：`darwin-aarch64`、`darwin-x86_64`、`win32-x86_64`，必须来自同一 source SHA。缺对应原生 runner 的 Intel/Windows 只能写 `BLOCKED`/`NOT_RUN`，不得写成 native PASS。公开 Release 必须上传验收过的同一 bytes，不能重建偷换。
 
 插件生态分三层：DSH official core plugins 原样保留；Penglai 原生插件由蓬莱维护并经 Center 事务管理（0.5.0 内置 Center、IM、SenseVoice ASR、MOSS-TTS-Nano、个人上下文、分层记忆、预算与主动陪伴）；社区插件未来只有在来源审核、签名/完整性、权限、兼容、隔离、迁移和回滚门完整后才可加入受控 catalog，绝不等同于任意 npm/Git 安装。
 
@@ -39,8 +39,8 @@
 
 ## 当前发行边界
 
-- 当前目标是 **Penglai v0.5.1** — 以官方 DSH `0.1.1-rc.1` 为唯一核心的三端社区验证发行版。机器可读身份只来自 `packages/release-identity/src/pins.ts` 与 `release-contract.json`。
-- 三个 target key 全仓统一：`darwin-aarch64`、`darwin-x86_64`、`win32-x86_64`。用户安装包分别为 `Penglai_0.5.1_macos_aarch64.dmg`、`Penglai_0.5.1_macos_x64.dmg`、`Penglai_0.5.1_windows_x64_setup.exe`。禁止把 ARM Electron 改名成 Intel 包；禁止把 Windows 预检或交叉编译写成 native PASS。
+- 当前目标是 **Penglai v0.5.2** — 以官方 DSH `0.1.1-rc.1` 为唯一核心的三端引导可靠性热修复。机器可读身份只来自 `packages/release-identity/src/pins.ts` 与 `release-contract.json`。
+- 三个 target key 全仓统一：`darwin-aarch64`、`darwin-x86_64`、`win32-x86_64`。用户安装包分别为 `Penglai_0.5.2_macos_aarch64.dmg`、`Penglai_0.5.2_macos_x64.dmg`、`Penglai_0.5.2_windows_x64_setup.exe`。禁止把 ARM Electron 改名成 Intel 包；禁止把 Windows 预检或交叉编译写成 native PASS。
 - 0.5.0 已发布的 Apple Silicon 客户端只能手动覆盖安装到 0.5.1；0.5.1 之后同平台才走 PUDP。不得声称 0.5.0 可一键升级。Intel/Windows 在 0.5.0 没有客户端，视为全新安装。
 - PPDP 是 0.5.1 产品能力，不是未来 TODO：签名目录、受限 GitHub 资产下载、默认禁用、主进程 Owner capability、DSH loader/profile 事务、inventory 回读。
 - 本地语音与第一方插件合同不变：`@penglai/asr`、`@penglai/moss-tts` 必须进入真实 DSH loader/Center，并服务 DSH Web、微信私聊语音和飞书私聊语音。两渠道仍不支持群聊、图片、普通文件、视频或富卡片。`@penglai/context`、`@penglai/memory`、`@penglai/budget`、`@penglai/companion` 同样纳入；Goal/Todo/Skills/MCP/Web/Attachments/Schedule/TokenMeter 使用 official DSH。
@@ -48,7 +48,7 @@
 - 0.4.1 到 0.5.0 是明确的架构代际切换：不提供自动升级，不导入旧会话、凭据或配置，不删除旧数据。0.5.0 使用隔离的数据根 `Penglai/0.5`。0.5.1 必须提供 rc.8 → rc.1 的显式、可回滚数据迁移。
 - community trust tier 不变：macOS ad-hoc / not notarized；Windows 无 Authenticode/SmartScreen 声誉。安装包及更新/插件清单仍须有 SHA-256、SBOM/notices，并诚实提示系统信誉警告。Penglai 自己的 Ed25519 更新/插件签名必须使用。
 - GitHub Actions 与 required CodeQL 当前可用，但不能替代安装包验收。Apple Silicon 本机可产生 darwin-aarch64 候选；Intel 与 Windows 的 native PASS 必须来自对应原生 runner。交叉构建或 Rosetta 只能作为补充证据。
-- 0.5.1 本轮本地工程不得自行 push/tag/Release。Owner 未书面接受密钥离线备份、上游冻结证据与全部硬门禁前，不得发布依赖该信任根的第一版。
+- Owner 已明确授权完成 0.5.2 修复、三端构建、发布与 0.5.1 → 0.5.2 实际升级验收。仍不得在门禁失败时发布，也不得把本机临时 API key 上传到 GitHub 或写入 evidence。
 
 ## 反偏航自检
 
@@ -70,7 +70,7 @@
 - 飞书是否用假二维码或用户 OAuth Device Flow 冒充一键扫码，或把官方 `app/registration` 落地页 URL 直接当图片地址？
 - 品牌或中文 overlay 是否隐藏、破坏了 DSH 原有主题、语言、模型、会话、工作区、工具、审批或设置能力？
 - 升级/卸载是否可能静默迁移或删除 0.4.1 数据、用户 Workspace 或未选择的数据类别？
-- 是否把 ad-hoc 安装包写成已公证，或把缺少原生 runner 的 Intel/Windows 写成 0.5.1 已支持？
+- 是否把 ad-hoc 安装包写成已公证，或把缺少原生 runner 的 Intel/Windows 写成 0.5.2 已支持？
 - 是否把下载目录、renderer `confirmed: true` 或未进入 DSH inventory 的包写成插件已启用？
 
 只要存在一个“是”，该候选就不是本产品定义下的蓬莱。

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/desktop",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "main": "dist/electron-main.js",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -2,7 +2,7 @@ import { DshSupervisor } from "./supervisor.js";
 
 export const APP_NAME = "Penglai";
 export const UNSIGNED_NOTICE =
-  "Penglai 0.5.1 community release. trustTier=community-verified. macOS ad-hoc, not notarized. Windows no Authenticode. Gatekeeper/SmartScreen may warn. Do not disable system security. DSH plugins share the local DSH process. Updates require user confirmation and are never installed silently.";
+  "Penglai 0.5.2 community release. trustTier=community-verified. macOS ad-hoc, not notarized. Windows no Authenticode. Gatekeeper/SmartScreen may warn. Do not disable system security. DSH plugins share the local DSH process. Updates require user confirmation and are never installed silently.";
 
 export function createDesktopRuntime() {
   const supervisor = new DshSupervisor();

--- a/apps/desktop/src/wizard-gate.test.ts
+++ b/apps/desktop/src/wizard-gate.test.ts
@@ -24,7 +24,7 @@ test("onboarding ledger is complete only when current is COMPLETE", () => {
   writeFileSync(join(root, "onboarding", "onboarding-facts.json"), JSON.stringify(facts));
   assert.equal(onboardingLedgerComplete(root), false, "JSON-only COMPLETE cannot skip");
   mkdirSync(join(root, "dsh-home"), { recursive: true });
-  writeFileSync(join(root, "dsh-home", ".credentials.yaml"), "DEEPSEEK_API_KEY: sk-test-value\n");
+  writeFileSync(join(root, "dsh-home", ".credentials.yaml"), "version: 1\nrefs:\n  DEEPSEEK_API_KEY: sk-test-value\n");
   mkdirSync(join(root, "dsh-home", "workspaces", "ws-1"), { recursive: true });
   mkdirSync(join(root, "dsh-home", "sessions", "s1"), { recursive: true });
   mkdirSync(join(root, "dsh-home", "sessions", "s-first"), { recursive: true });
@@ -36,28 +36,32 @@ test("onboarding ledger is complete only when current is COMPLETE", () => {
     JSON.stringify({ initialized: true, workspaceIds: ["ws-1"] }),
   );
   assert.equal(onboardingLedgerComplete(root), false, "guessed storage/workspace.json is not the official domain file");
+  mkdirSync(join(root, "dsh-home", "storages"), { recursive: true });
   writeFileSync(
-    join(root, "dsh-home", "workspace.json"),
-    JSON.stringify({ initialized: true, workspaceIds: ["ws-1"] }),
+    join(root, "dsh-home", "storages", "workspace.json"),
+    JSON.stringify({ unit: { name: "workspace", version: 2 }, global: { initialized: true, workspaceIds: ["ws-1"] } }),
   );
-  mkdirSync(join(root, "dsh-home", "projects", "_no-cwd", "s1"), { recursive: true });
-  mkdirSync(join(root, "dsh-home", "projects", "_no-cwd", "s-first"), { recursive: true });
-  writeFileSync(join(root, "dsh-home", "projects", "_no-cwd", "s1", "session.jsonl"), "{}\n");
-  writeFileSync(join(root, "dsh-home", "projects", "_no-cwd", "s-first", "session.jsonl"), "{}\n");
+  mkdirSync(join(root, "dsh-home", "sessions", "_no-cwd", "s1"), { recursive: true });
+  mkdirSync(join(root, "dsh-home", "sessions", "_no-cwd", "session-s-first"), { recursive: true });
+  writeFileSync(join(root, "dsh-home", "sessions", "_no-cwd", "s1", "session.jsonl.zstd"), "zstd-fixture");
+  writeFileSync(join(root, "dsh-home", "sessions", "_no-cwd", "session-s-first", "session.jsonl.zstd"), "zstd-fixture");
   assert.equal(onboardingLedgerComplete(root), true);
   writeFileSync(join(root, "dsh-home", ".credentials.yaml"), "# gone\n");
   assert.equal(onboardingLedgerComplete(root), false, "deleted credential cannot skip");
-  writeFileSync(join(root, "dsh-home", ".credentials.yaml"), "DEEPSEEK_API_KEY: sk-test-value\n");
-  writeFileSync(join(root, "dsh-home", "workspace.json"), JSON.stringify({ initialized: true, workspaceIds: [] }));
+  writeFileSync(join(root, "dsh-home", ".credentials.yaml"), "version: 1\nrefs:\n  DEEPSEEK_API_KEY: sk-test-value\n");
+  writeFileSync(
+    join(root, "dsh-home", "storages", "workspace.json"),
+    JSON.stringify({ global: { initialized: true, workspaceIds: [] } }),
+  );
   assert.equal(onboardingLedgerComplete(root), false, "deleted Workspace cannot skip");
   writeFileSync(
-    join(root, "dsh-home", "workspace.json"),
-    JSON.stringify({ initialized: true, workspaceIds: ["ws-1"] }),
+    join(root, "dsh-home", "storages", "workspace.json"),
+    JSON.stringify({ global: { initialized: true, workspaceIds: ["ws-1"] } }),
   );
   writeFileSync(join(root, "onboarding", "current-nonce.digest"), `${"e".repeat(64)}\n`);
   assert.equal(onboardingLedgerComplete(root), false, "stale nonce cannot skip");
   writeFileSync(join(root, "onboarding", "current-nonce.digest"), `${"a".repeat(64)}\n`);
-  rmSync(join(root, "dsh-home", "projects", "_no-cwd", "s-first"), { recursive: true, force: true });
+  rmSync(join(root, "dsh-home", "sessions", "_no-cwd", "session-s-first"), { recursive: true, force: true });
   assert.equal(onboardingLedgerComplete(root), false, "missing first conversation cannot skip");
 });
 

--- a/apps/desktop/src/wizard-gate.ts
+++ b/apps/desktop/src/wizard-gate.ts
@@ -47,27 +47,28 @@ function existingDir(path: string): boolean {
 function workspaceJsonHasId(path: string, workspaceId: string): boolean {
   if (!regularFile(path)) return false;
   try {
-    const raw = JSON.parse(readFileSync(path, "utf8")) as { workspaceIds?: unknown };
-    return Array.isArray(raw.workspaceIds) && raw.workspaceIds.includes(workspaceId);
+    const raw = JSON.parse(readFileSync(path, "utf8")) as {
+      workspaceIds?: unknown;
+      global?: { workspaceIds?: unknown };
+    };
+    const ids = Array.isArray(raw.global?.workspaceIds) ? raw.global.workspaceIds : raw.workspaceIds;
+    return Array.isArray(ids) && ids.includes(workspaceId);
   } catch {
     return false;
   }
 }
 
-/** Official workspace domain JSON: `$DSH_HOME/workspace.json`. */
+/** Official rc.1 workspace domain JSON, with the rc.8 path retained for overlay migration. */
 export function officialWorkspaceRecord(dshHome: string, workspaceId: string): boolean {
   if (!workspaceId || workspaceId.includes("..") || workspaceId.includes("/") || workspaceId.includes("\\")) {
     return false;
   }
-  return workspaceJsonHasId(join(dshHome, "workspace.json"), workspaceId);
+  return [join(dshHome, "storages", "workspace.json"), join(dshHome, "workspace.json")].some((path) =>
+    workspaceJsonHasId(path, workspaceId),
+  );
 }
 
-/** Official session JSONL: `projectDir(DSH_HOME, cwd)/<sessionId>/session.jsonl`. */
-export function officialSessionLog(dshHome: string, sessionId: string): boolean {
-  if (!sessionId || sessionId.includes("..") || sessionId.includes("/") || sessionId.includes("\\")) {
-    return false;
-  }
-  const root = join(dshHome, "projects");
+function sessionRootHasLog(root: string, sessionId: string): boolean {
   if (!existingDir(root)) return false;
   let projects: string[];
   try {
@@ -75,12 +76,28 @@ export function officialSessionLog(dshHome: string, sessionId: string): boolean 
   } catch {
     return false;
   }
-  for (const project of projects.slice(0, 64)) {
-    const log = join(root, project, sessionId, "session.jsonl");
-    const gz = join(root, project, sessionId, "session.jsonl.gz");
-    if (regularFile(log) || regularFile(gz)) return true;
+  const sessionDirs = [sessionId, `session-${sessionId}`];
+  const logNames = ["session.jsonl.zstd", "session.jsonl.gz", "session.jsonl"];
+  for (const project of projects.slice(0, 128)) {
+    const projectRoot = join(root, project);
+    if (!existingDir(projectRoot)) continue;
+    for (const sessionDir of sessionDirs) {
+      const sessionRoot = join(projectRoot, sessionDir);
+      if (!existingDir(sessionRoot)) continue;
+      if (logNames.some((name) => regularFile(join(sessionRoot, name)))) return true;
+    }
   }
   return false;
+}
+
+/** Official rc.1 session store, with the rc.8 root retained for overlay migration. */
+export function officialSessionLog(dshHome: string, sessionId: string): boolean {
+  if (!sessionId || sessionId.includes("..") || sessionId.includes("/") || sessionId.includes("\\")) {
+    return false;
+  }
+  return [join(dshHome, "sessions"), join(dshHome, "projects")].some((root) =>
+    sessionRootHasLog(root, sessionId),
+  );
 }
 
 function credentialStillConfigured(userRoot: string, credentialRef: string): boolean {
@@ -88,7 +105,18 @@ function credentialStillConfigured(userRoot: string, credentialRef: string): boo
   if (!regularFile(yaml)) return false;
   const text = readFileSync(yaml, "utf8");
   const escaped = credentialRef.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`^${escaped}\\s*:\\s*\\S+`, "m").test(text);
+  if (new RegExp(`^${escaped}\\s*:\\s*\\S+`, "m").test(text)) return true;
+  const lines = text.split(/\r?\n/);
+  let inRefs = false;
+  for (const line of lines) {
+    if (/^refs\s*:\s*(?:#.*)?$/.test(line)) {
+      inRefs = true;
+      continue;
+    }
+    if (inRefs && /^\S/.test(line)) break;
+    if (inRefs && new RegExp(`^\\s+${escaped}\\s*:\\s*\\S+`).test(line)) return true;
+  }
+  return false;
 }
 
 export function onboardingFactsProveReady(dir: string, userRoot = join(dir, "..")): boolean {

--- a/apps/desktop/src/wizard-ui.test.ts
+++ b/apps/desktop/src/wizard-ui.test.ts
@@ -157,8 +157,12 @@ test("wizard API-test classifier distinguishes auth, rate, model, timeout, netwo
   assert.match(js, /formatWizardError/);
   assert.match(js, /errorJail/);
   assert.match(js, /errorRpc/);
+  assert.match(js, /errorReady/);
   assert.match(js, /kind === "api-test"/);
   assert.match(js, /screen.id === "keytest"/);
+  assert.match(js, /failedScreen === "keytest" \|\| failedScreen === "firstturn"/);
+  assert.match(js, /rpc\("rewindOnboarding", \{ step \}\)/);
+  assert.match(js, /step: "credential-v1"/);
   assert.match(js, /testing/);
   assert.match(
     js,

--- a/apps/desktop/static/wizard/wizard.js
+++ b/apps/desktop/static/wizard/wizard.js
@@ -47,6 +47,7 @@
       errorNetwork: "无法连接模型接口。请检查网络后重试。",
       errorAdapter: "这个供应商还不能用，请另选一个。",
       errorCatalog: "暂时读不到供应商列表。请重试。",
+      errorReady: "真实调用已经完成，但本地完成记录校验失败。请重试；若仍失败，请保留现场用于诊断。",
       retryCatalog: "重新读取列表",
       errorJail: "这个文件夹不能用作工作区（蓬莱数据目录或应用安装目录）。请另选一个。",
       errorRpc: "这一步的官方请求失败。请重试，或回到上一步检查输入。",
@@ -98,6 +99,7 @@
       errorNetwork: "The model API could not be reached. Check the network and retry.",
       errorAdapter: "This provider is not available yet. Choose another one.",
       errorCatalog: "The provider list could not be loaded. Retry.",
+      errorReady: "The real request completed, but local completion evidence failed validation. Retry and preserve the state for diagnostics if it still fails.",
       retryCatalog: "Reload list",
       errorJail: "That folder cannot be a workspace (Penglai data or the app install directory). Choose another folder.",
       errorRpc: "This official request failed. Retry, or go back and check the input.",
@@ -198,7 +200,8 @@
       };
       return t(keys[classifyApiTestError(err)] || "errorGeneric");
     }
-    if (/SECURITY_POLICY|jail|install directory|userData|onboarding/i.test(text)) return t("errorJail");
+    if (/onboarding ledger|completion evidence|not COMPLETE/i.test(text)) return t("errorReady");
+    if (/SECURITY_POLICY|jail|workspace path|install directory|userData|inside .* tree/i.test(text)) return t("errorJail");
     if (kind === "rpc" || /DSH_UNAVAILABLE|INVALID_INPUT|Typert|rpc/i.test(text)) return t("errorRpc");
     return t("errorGeneric");
   }
@@ -346,9 +349,31 @@
 
   async function goBack() {
     if (state.viewIndex <= 0) return;
-    state.viewIndex -= 1;
+    const target = LEDGER_SCREENS[state.viewIndex - 1];
     state.error = "";
+    const stepByScreen = {
+      models: "model-provider-v1",
+      keytest: "credential-v1",
+      workspace: "workspace-v1",
+      firstturn: "first-turn-v1",
+    };
+    const step = stepByScreen[target.id];
+    if (!step) {
+      state.viewIndex -= 1;
+      render();
+      return;
+    }
+    state.busy = true;
     render();
+    try {
+      await rpc("rewindOnboarding", { step });
+      await refreshStatus();
+    } catch (err) {
+      state.error = formatWizardError(err, "rpc");
+    } finally {
+      state.busy = false;
+      render();
+    }
   }
 
   async function finishWizard() {
@@ -417,8 +442,19 @@
       } else {
         await advanceLive();
       }
+      state.error = "";
     } catch (err) {
-      const kind = currentScreen().id === "keytest" ? "api-test" : "rpc";
+      const failedScreen = currentScreen().id;
+      const kind = failedScreen === "keytest" || failedScreen === "firstturn" ? "api-test" : "rpc";
+      const failureClass = kind === "api-test" ? classifyApiTestError(err) : "unknown";
+      if (failedScreen === "firstturn" && failureClass === "auth") {
+        try {
+          await rpc("rewindOnboarding", { step: "credential-v1" });
+          await refreshStatus();
+        } catch {
+          /* Preserve the original provider failure; Back remains available. */
+        }
+      }
       state.error = formatWizardError(err, kind);
     } finally {
       state.busy = false;

--- a/docs/0.5.2/RELEASE_RUNBOOK.md
+++ b/docs/0.5.2/RELEASE_RUNBOOK.md
@@ -4,7 +4,7 @@
 2. On native Apple Silicon, Intel Mac, and Windows x64 runners, build the exact installer named in `release-contract.json`; run installed welcome/process and first-party-plugin compatibility checks against that installer.
 3. On Apple Silicon, install the candidate over the real completed 0.5.1 data generation and verify it enters official DSH Web. Then run one clean onboarding with the temporary BYOK through model test, Workspace, first official Turn, and final transition. Record only redacted verdicts and digests.
 4. Collect the three installer bytes without rebuilding. Create `release-manifest.json`, SBOM, notices, public-export manifest, and detached signatures. Create `update-manifest-v1.json` with `minimumSourceVersion: 0.5.1`, then sign its exact bytes using the existing offline updater key.
-5. Create a draft `v0.5.2` Release, upload the exact eleven assets, verify names, sizes, hashes, signatures, source SHA, and target architectures, then publish immutable.
+5. Create a draft `v0.5.2` Release, upload the exact ten assets, verify names, sizes, hashes, signatures, source SHA, and target architectures, then publish immutable.
 6. Reinstall the exact public 0.5.1 Apple Silicon app without deleting `Penglai/0.5`. Through its own updater, discover, download, verify, confirm, and install the public 0.5.2 DMG. Verify the installed version, official DSH Web, preserved Workspace, preserved onboarding facts, and update ledger.
 7. Run remote immutable read-back. Only then update README/website current-download links and publication evidence. Remove the temporary provider credential from local storage and ask the owner to revoke it.
 

--- a/docs/0.5.2/RELEASE_RUNBOOK.md
+++ b/docs/0.5.2/RELEASE_RUNBOOK.md
@@ -1,0 +1,11 @@
+# Penglai 0.5.2 three-target release runbook
+
+1. From a clean `main` equal to `origin/main`, run all source, contract, security, identity, dependency, export, secret, and release-key gates.
+2. On native Apple Silicon, Intel Mac, and Windows x64 runners, build the exact installer named in `release-contract.json`; run installed welcome/process and first-party-plugin compatibility checks against that installer.
+3. On Apple Silicon, install the candidate over the real completed 0.5.1 data generation and verify it enters official DSH Web. Then run one clean onboarding with the temporary BYOK through model test, Workspace, first official Turn, and final transition. Record only redacted verdicts and digests.
+4. Collect the three installer bytes without rebuilding. Create `release-manifest.json`, SBOM, notices, public-export manifest, and detached signatures. Create `update-manifest-v1.json` with `minimumSourceVersion: 0.5.1`, then sign its exact bytes using the existing offline updater key.
+5. Create a draft `v0.5.2` Release, upload the exact eleven assets, verify names, sizes, hashes, signatures, source SHA, and target architectures, then publish immutable.
+6. Reinstall the exact public 0.5.1 Apple Silicon app without deleting `Penglai/0.5`. Through its own updater, discover, download, verify, confirm, and install the public 0.5.2 DMG. Verify the installed version, official DSH Web, preserved Workspace, preserved onboarding facts, and update ledger.
+7. Run remote immutable read-back. Only then update README/website current-download links and publication evidence. Remove the temporary provider credential from local storage and ask the owner to revoke it.
+
+Any failed hard gate stops publication. Cross-build or source-only evidence cannot be reported as native installed PASS.

--- a/docs/ACCEPTANCE.md
+++ b/docs/ACCEPTANCE.md
@@ -1,8 +1,8 @@
-# Penglai 0.5.1 三端公开版验收合同
+# Penglai 0.5.2 三端公开版验收合同
 
 ## 1. 判定对象与结论
 
-唯一验收对象是一个 exact private `Penglai 0.5.1` release set：同一 clean private source、同一 deterministic public-export tree、Apple Silicon DMG、Intel Mac DMG、Windows x64 Setup、配套 manifests/SBOM/notices、三个目标各自的 native installed/soak evidence 和集中真实 live evidence。三个安装包必须来自同一 source SHA；交叉构建只能作为预检，不能替代对应原生 runner。
+唯一验收对象是一个 exact private `Penglai 0.5.2` release set：同一 clean private source、同一 deterministic public-export tree、Apple Silicon DMG、Intel Mac DMG、Windows x64 Setup、配套 manifests/SBOM/notices、三个目标各自的 native installed/soak evidence 和集中真实 live evidence。三个安装包必须来自同一 source SHA；交叉构建只能作为预检，不能替代对应原生 runner。
 
 允许结论：
 
@@ -14,12 +14,12 @@
 
 ## 2. Evidence 规则
 
-以下每一行都是 Hard。registry由本文机器动态解析；0.5.1 将 Intel Mac 与 Windows x64 纳入正式发行，预期共 **256** 个唯一`R50-*` ID。实现必须动态解析，不能把计数写成散落的完成映射。每个ID必须指向真实runner的具体assertion，包含candidate/source/export/target/artifact/runner native/时间/exit/result digest。不能通过文件名、字符串存在或一个smoke扇出PASS。
+以下每一行都是 Hard。registry由本文机器动态解析；0.5.2 将 Intel Mac 与 Windows x64 纳入正式发行，预期共 **256** 个唯一`R50-*` ID。实现必须动态解析，不能把计数写成散落的完成映射。每个ID必须指向真实runner的具体assertion，包含candidate/source/export/target/artifact/runner native/时间/exit/result digest。不能通过文件名、字符串存在或一个smoke扇出PASS。
 
 平台标记：
 
 - `all`：平台类门禁展开为全部三个目标；非平台类门禁只执行一次源码/聚合检查。
-- `mac-arm`、`mac-x64`、`win-x64`：分别绑定三个 exact native artifact，均参与 0.5.1 PASS。
+- `mac-arm`、`mac-x64`、`win-x64`：分别绑定三个 exact native artifact，均参与 0.5.2 PASS。
 - `live`：真实账户最后集中执行。
 - `aggregate`：release-set/public-export聚合。
 
@@ -29,14 +29,14 @@
 
 | ID | 要求 | Runner |
 | --- | --- | --- |
-| `R50-TRUTH-001` | root/workspace/desktop/profile/plugin/release contract版本全部为0.5.1 | contract/all |
+| `R50-TRUTH-001` | root/workspace/desktop/profile/plugin/release contract版本全部为0.5.2 | contract/all |
 | `R50-TRUTH-002` | candidateKind、trustTier、generation、三个target与三个exact filename一致 | contract/all |
 | `R50-TRUTH-003` | 旧alpha artifact/evidence/READY全部STALE并被verifier拒绝 | failure/all |
 | `R50-TRUTH-004` | UNFROZEN identity不得携带artifact/signature/live/READY | unit/all |
 | `R50-TRUTH-005` | private工作流只有main，无branch/worktree/PR/tag，push为fast-forward | git/aggregate |
 | `R50-TRUTH-006` | candidate freeze时HEAD=origin/main且dirty=false | git/aggregate |
 | `R50-TRUTH-007` | 任一子门FAIL/INCOMPLETE/STALE都使verify:release non-zero | fault/all |
-| `R50-TRUTH-008` | repo=`kevinchennewbee/PenglaiAgent`、tag/release=`v0.5.1`，且发布前updater channel保持未发布 | manifest/aggregate |
+| `R50-TRUTH-008` | repo=`kevinchennewbee/PenglaiAgent`、tag/release=`v0.5.2`，且发布前updater channel保持未发布 | manifest/aggregate |
 
 ### B. DSH唯一核心与 capability parity（8）
 
@@ -61,7 +61,7 @@
 | `R50-UI-004` |light/dark/system三态覆盖全部Penglai UI | visual/all |
 | `R50-UI-005` |system主题运行时变化即时响应并持久 | installed/all |
 | `R50-UI-006` |品牌overlay不阻断DSH导航、Models、Workspace、Session、设置 | parity/all |
-| `R50-UI-007` |About显示0.5.1、DSH/target/trust/data/license准确 | installed/all |
+| `R50-UI-007` |About显示0.5.2、DSH/target/trust/data/license准确 | installed/all |
 | `R50-UI-008` |UI/README不出现已公证、Authenticode或silent auto-update误述 | content/aggregate |
 
 ### D. 首次引导、多API、Workspace与Turn（12）
@@ -235,7 +235,7 @@
 | `R50-UPD-009` |新版本post-verify成功commit，失败rollback/recovery | chaos+installed/all |
 | `R50-UPD-010` |每个update state crash可重放，inbox/outbox不丢不双发 | chaos/all |
 | `R50-UPD-011` |fixture key/server/test payload不进入production artifact | artifact/all |
-| `R50-UPD-012` |三个native target的0.5.1→test-next valid/failure suites PASS | installed/all |
+| `R50-UPD-012` |三个native target的0.5.2→test-next valid/failure suites PASS，且 Apple Silicon 公开版0.5.1→公开版0.5.2实装升级 PASS | installed/all |
 
 ### O. 卸载、数据管理与legacy隔离（10）
 
@@ -430,4 +430,4 @@
 - 任一平台使用cross/translated/emulated结果冒充native，或Release缺少/多出未验收的三端安装包。
 - verifier INCOMPLETE却exit 0、Hard ID硬编码PASS、旧SHA/evidence复用。
 - ad-hoc候选被称为已公证、Developer ID或系统信任。
-- 未经 Owner 明确授权修改开源仓库或发布0.5.1。
+- 未经 Owner 明确授权修改开源仓库或发布0.5.2。

--- a/docs/PLATFORM_MATRIX.md
+++ b/docs/PLATFORM_MATRIX.md
@@ -1,16 +1,16 @@
-# Penglai 0.5.1 三端平台矩阵
+# Penglai 0.5.2 三端平台矩阵
 
 ## 1. 固定矩阵
 
-0.5.1 声明三个 desktop target。每个 target 的“支持”必须同时包含正确 closure、可安装产物、installed E2E 和 native smoke。缺 runner 时该行是 `BLOCKED`，不是 PASS。
+0.5.2 声明三个 desktop target。每个 target 的“支持”必须同时包含正确 closure、可安装产物、installed E2E 和 native smoke。缺 runner 时该行是 `BLOCKED`，不是 PASS。
 
 | key | OS/arch | 用户安装包 | embedded Node | Electron | final runner |
 | --- | --- | --- | --- | --- | --- |
-| `darwin-aarch64` | macOS 13+ / Apple Silicon | `Penglai_0.5.1_macos_aarch64.dmg` | `node-v22.22.2-darwin-arm64` | pinned darwin-arm64 | Apple Silicon Mac |
-| `darwin-x86_64` | macOS 13+ / Intel | `Penglai_0.5.1_macos_x64.dmg` | `node-v22.22.2-darwin-x64` | pinned darwin-x64 | Intel Mac（Rosetta 不能替代） |
-| `win32-x86_64` | Windows 10+ / x64 | `Penglai_0.5.1_windows_x64_setup.exe` | `node-v22.22.2-win-x64` | pinned win32-x64 | Windows x64 native runner |
+| `darwin-aarch64` | macOS 13+ / Apple Silicon | `Penglai_0.5.2_macos_aarch64.dmg` | `node-v22.22.2-darwin-arm64` | pinned darwin-arm64 | Apple Silicon Mac |
+| `darwin-x86_64` | macOS 13+ / Intel | `Penglai_0.5.2_macos_x64.dmg` | `node-v22.22.2-darwin-x64` | pinned darwin-x64 | Intel Mac（Rosetta 不能替代） |
+| `win32-x86_64` | Windows 10+ / x64 | `Penglai_0.5.2_windows_x64_setup.exe` | `node-v22.22.2-win-x64` | pinned win32-x64 | Windows x64 native runner |
 
-0.5.0 已发布资产仍只有 Apple Silicon DMG。0.5.1 不得把 ARM Electron 改名成 x64，也不得把 Windows 预检写成 native PASS。
+0.5.0 已发布资产仍只有 Apple Silicon DMG。0.5.2 不得把 ARM Electron 改名成 x64，也不得把 Windows 预检写成 native PASS。
 
 `release-info.json` / `MINIMUM_MACOS` / Info.plist `LSMinimumSystemVersion` 一律 `13.0`。打包脚本会把 Electron 默认的 `14.0` 改写为 `13.0`，不得再分叉。
 
@@ -24,7 +24,7 @@ Grok 必须新增单一 `release-contract.json`（具体路径由实现固定）
 {
   "schemaVersion": 1,
   "product": "Penglai",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "candidateKind": "public-community-release",
   "trustTier": "community-verified",
   "electronVersion": "43.4.0",
@@ -35,7 +35,7 @@ Grok 必须新增单一 `release-contract.json`（具体路径由实现固定）
       "key": "darwin-aarch64",
       "platform": "darwin",
       "arch": "arm64",
-      "installer": "Penglai_0.5.1_macos_aarch64.dmg"
+      "installer": "Penglai_0.5.2_macos_aarch64.dmg"
     }
   ]
 }
@@ -134,14 +134,14 @@ Windows 必须用 job object 或等价受测进程树监管，不能只 kill 父
 
 ## 7. 打包器选择门
 
-0.5.0 canonical maker 是当前已审计的 macOS arm64 pipeline。后续跨平台工作继续遵守：
+0.5.2 使用三端受控 pipeline；每个平台仍必须遵守：
 
 - Windows后续格式预定为current-user NSIS；Squirrel只可作为官方更新机制研究，不能静默替换用户确认的NSIS Setup。
 - 可以采用electron-builder/NSIS、Forge packager加受控NSIS maker，或继续受控自研pipeline，但必须解释为何更适合，并钉死依赖、下载、checksum、license、hook和安全面。
 - 不允许同时维持两套 canonical maker；旧 `package-mac.mjs` 若保留只能作为被新 contract 调用的实现细节或 historical tool。
 - 选择不得改变 Electron + DSH 产品架构，也不得为了打包迁移回 Tauri 0.4.1。
 
-0.5.0 只要求真实生成并验收 Apple Silicon DMG。x64 staging 与 Windows maker fixture 是未来工程证据，不能升级为本版支持声明。
+0.5.2 必须分别在 Apple Silicon、Intel Mac 与 Windows x64 原生 runner 真实生成并验收对应安装包；staging、交叉编译与 Rosetta 不能升级为本版支持声明。
 
 ## 8. 本地 runner 协议
 
@@ -161,7 +161,7 @@ evidence bundle 是内容寻址 tar/zip，包含 runner JSON/JUnit、artifact ha
 
 ## 9. 每平台 installed suites
 
-当前 Apple Silicon target 必须从 exact DMG 开始：
+每个 target 必须从该平台 exact installer 开始；以下清单三端适用，平台差异单独记录：
 
 1. 在干净 OS user/profile 安装。
 2. 验 product name、publisher/trust tier 声明、安装位置、快捷方式/Applications link。
@@ -177,7 +177,7 @@ evidence bundle 是内容寻址 tar/zip，包含 runner JSON/JUnit、artifact ha
 12. 执行默认卸载与完整数据删除两条路径，确认 Workspace、授权源目录、legacy data 与未选 local voices/memory 不动。
 13. 只有 feature freeze、短门和 exact artifact 均通过后才开始 offline/sleep/wake/crash/restart/2h soak。
 
-`darwin-aarch64` 在当前机器全量执行。未来 Rosetta 的 x64 结果仍只能标记 `translated=true`，Windows ARM emulation 只能标记 `emulated=true`；二者都不能反向改写 0.5.0 支持矩阵。
+`darwin-aarch64` 在当前机器全量执行。Rosetta 的 x64 结果仍只能标记 `translated=true`，Windows ARM emulation 只能标记 `emulated=true`；二者都不能反向改写 0.5.2 支持矩阵。
 
 ## 10. 平台出错即停的条件
 

--- a/docs/PUBLICATION_0.5.2.md
+++ b/docs/PUBLICATION_0.5.2.md
@@ -1,0 +1,15 @@
+# PenglaiAgent 0.5.2 publication contract
+
+0.5.2 is a three-target hotfix release of official DSH `0.1.1-rc.1`. Publication is authorized only after the merged clean `main` SHA produces native-verified Apple Silicon, Intel Mac, and Windows x64 installers and the exact release set is signed, published immutable, and read back from GitHub.
+
+The required installers are:
+
+- `Penglai_0.5.2_macos_aarch64.dmg`
+- `Penglai_0.5.2_macos_x64.dmg`
+- `Penglai_0.5.2_windows_x64_setup.exe`
+
+Hard release evidence includes the source suites, clean public export, native installer architecture and identity, installed welcome/process smoke, first-party plugin compatibility, detached installer signatures, signed update manifest, exact asset hashes, and immutable remote read-back. A cross-build cannot replace an Intel or Windows native runner.
+
+Before the Release is marked current, an installed public 0.5.1 client must discover 0.5.2 through PUDP/1, verify and download the matching asset, require user/system confirmation, complete the overlay install, preserve the `Penglai/0.5` data generation and external Workspace, and launch as 0.5.2. The temporary provider key used for the Apple Silicon live onboarding gate must never enter source, evidence, CI, or GitHub.
+
+macOS remains ad-hoc and not notarized. Windows remains without Authenticode. The public README and website may claim PASS only for native jobs and installed paths that actually completed.

--- a/docs/PUBLICATION_MANIFEST_0.5.2.md
+++ b/docs/PUBLICATION_MANIFEST_0.5.2.md
@@ -1,0 +1,26 @@
+# PUBLICATION_MANIFEST 0.5.2
+
+Status: `UNFROZEN`
+
+| Field | Value |
+| --- | --- |
+| productVersion | `0.5.2` |
+| DSH | `0.1.1-rc.1` |
+| trustTier | `community-verified` |
+| source SHA | `UNFROZEN` |
+| publicExportTreeSha256 | `UNFROZEN` |
+| repository | `kevinchennewbee/PenglaiAgent` |
+| tag / Release | `v0.5.2` |
+| publication channel | `stable-v0.5.2` |
+
+| Target | Exact installer | Native result | SHA-256 |
+| --- | --- | --- | --- |
+| Apple Silicon | `Penglai_0.5.2_macos_aarch64.dmg` | NOT_RUN | UNFROZEN |
+| Intel Mac | `Penglai_0.5.2_macos_x64.dmg` | NOT_RUN | UNFROZEN |
+| Windows x64 | `Penglai_0.5.2_windows_x64_setup.exe` | NOT_RUN | UNFROZEN |
+
+The immutable Release must contain exactly those three installers plus `update-manifest-v1.json`, `update-manifest-v1.json.sig`, `release-manifest.json`, `SBOM.cdx.json`, `THIRD_PARTY_NOTICES.txt`, `SHA256SUMS`, and `public-export-manifest.json`.
+
+The update manifest must declare version `0.5.2`, release tag `v0.5.2`, all three exact target assets, and minimum source version `0.5.1`. It must bind each asset's GitHub asset ID, size, SHA-256, detached signature, source identity, public-export tree, and release-manifest digest.
+
+This file may move from `UNFROZEN` only after the exact merged-main bytes and native evidence are known. It must not predict hashes or PASS results.

--- a/docs/RELEASE_NOTES_0.5.2.md
+++ b/docs/RELEASE_NOTES_0.5.2.md
@@ -1,0 +1,22 @@
+# Penglai 0.5.2
+
+Penglai 0.5.2 is a focused onboarding and update-reliability release. It keeps official DeepSeek Harness `0.1.1-rc.1` as the only core and ships the same three community-verified targets: `darwin-aarch64`, `darwin-x86_64`, and `win32-x86_64`.
+
+## Fixed
+
+- The final setup gate now reads the real rc.1 workspace, session, compression, and credential layouts. A successful API test and first official Turn no longer end in a false workspace error.
+- Back navigation now rewinds the persisted onboarding ledger and clears dependent evidence. Re-entering a key, choosing another model, or replacing a Workspace is a real reconfiguration rather than a visual-only change.
+- First-Turn authentication failures return to credential entry, and completion-evidence failures no longer masquerade as workspace-jail errors.
+- Regression coverage reproduces a completed flow, rewinds it, replaces credentials, creates a Workspace, sends another official Turn, and completes again.
+
+## Upgrade
+
+Penglai 0.5.1 users can open **Penglai → Update**, choose **Check for updates**, download the signed 0.5.2 installer, and confirm the normal system installer. The updater enumerates stable immutable GitHub Releases, verifies the Penglai Ed25519 signature and exact installer hash, and never installs silently. User data under the `Penglai/0.5` generation and external Workspaces are preserved.
+
+Penglai 0.5.0 still requires a manual 0.5.2 overlay on Apple Silicon because 0.5.0 did not contain this production update trust path. Intel Mac and Windows x64 users can install 0.5.2 directly.
+
+## Trust and platform limits
+
+This remains a `community-verified` release. macOS packages are ad-hoc signed and not notarized; Windows is not Authenticode signed. Gatekeeper or SmartScreen may warn. Do not disable system security. Updates require user confirmation and are not silent.
+
+The Plugin Center continues using the signed public [Penglai Plugin Registry](https://github.com/kevinchennewbee/PenglaiPluginRegistry). A client update is not required merely to publish another compatible, signed catalog generation or plugin archive.

--- a/docs/UPDATE_UNINSTALL.md
+++ b/docs/UPDATE_UNINSTALL.md
@@ -4,8 +4,8 @@
 
 本合同覆盖：
 
-- 0.5.0 Apple Silicon fresh install 与首次启动；Intel/Windows 生命周期实现保留为后续版本。
-- 0.5.0 开始面向未来版本的更新发现、验证和 assisted install。
+- 0.5.2 在 Apple Silicon、Intel Mac 与 Windows x64 的 fresh install、首次启动与恢复。
+- 公开版 0.5.1 → 0.5.2 的更新发现、签名验证、用户确认和 assisted install。
 - profile/plugin/IM schema 的事务迁移与失败恢复。
 - Windows 原生卸载器和 macOS 应用内卸载准备/数据管理。
 - 0.4.1 旧架构的只读检测与 clean-generation 提示。
@@ -89,7 +89,7 @@ NOT_STARTED
 {
   "schemaVersion": 1,
   "channel": "desktop-v0.5",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "publishedAt": "...",
   "minimumVersion": "0.5.0",
   "notesUrl": "...",
@@ -157,7 +157,7 @@ Electron官方说明macOS autoUpdater需要已签名app。当前0.5 community ca
 
 - loopback-only update server。
 - ephemeral test signing key；private fixture key 只在测试临时目录生成，不提交。
-- `0.5.1-test.N` payload，包含可识别版本但不含产品 secret。
+- `0.5.2-test.N` payload，包含可识别版本但不含产品 secret。
 - valid、tampered payload、wrong key、wrong arch、rollback、same version、truncated download、disconnect/resume、disk full、installer cancel、crash between every journal transition。
 
 fixture 不能通过 `/penglai/usable-fixture` 暴露给 production renderer。test-only entry 必须在 build-time test target 中编译隔离，release bundle scanner 证明不存在。

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -346,6 +346,12 @@
 - 决定：0.5.1 以 `@deepseek-ai/dsh@0.1.1-rc.1`（tag `dsh-v0.1.1-rc.1`，commit `528c682e061696f5a160f363f236ecbf53cbd006`，npm integrity `sha512-HVauMT0F7MWUctkxzBcu5PMFc8j0lm0kX+4IbcUsA7Oh+/xv7xhigEDP0SaSOM/kR48U/BldHbZru116DcZz0w==`）为唯一核心。release target 为 `darwin-aarch64`、`darwin-x86_64`、`win32-x86_64`。0.5.0→0.5.1 仅手动覆盖；PPDP 与后续同平台 PUDP 属于 0.5.1。
 - 后果：不得跟随 npm `latest`/`next`；Intel/Windows 缺原生 runner 时该 target 为 BLOCKED；不得把 ARM Electron 改名成 x64。
 
+### D-056 — 0.5.2 修复 rc.1 首次引导并实测 0.5.1 辅助升级
+
+- 状态：ACCEPTED（Owner 2026-08-22 明确授权修复、三端构建、发布和升级验收）
+- 决定：0.5.2 继续固定 DSH `0.1.1-rc.1`，修正完成门禁对 rc.1 `storages/workspace.json`、`global.workspaceIds`、`sessions/**/session.jsonl.zstd` 与嵌套 `credentials.refs` 的读取；“上一步”必须回滚持久引导状态和依赖事实。发布前必须用临时 BYOK 在 Apple Silicon 安装包完成真实模型测试与第一条 Turn，并用公开版 0.5.1 的 PUDP 路径发现、下载和安装公开版 0.5.2。
+- 后果：临时 secret 不得进入源码、命令输出、evidence 或 GitHub；Intel Mac 与 Windows x64 仍必须由对应原生 runner 构建并运行安装/插件兼容门禁。0.5.2 Release 继续使用现有离线 Ed25519 信任根、不可变 tag 资产和用户确认的系统安装器，不引入 silent update。
+
 ## Superseded
 
 已从执行面移出的决议正文：`D-014`、`D-020`、`D-021`、`D-025`、`D-030`。它们仍保留编号以便审计，但不得再当当前产品合同。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "penglai-v2",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.14.0",

--- a/packages/asr/package.json
+++ b/packages/asr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/asr",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/asr/src/models.ts
+++ b/packages/asr/src/models.ts
@@ -599,7 +599,7 @@ export class AsrModelManager {
       existing = info.size;
     }
     const headers: Record<string, string> = {
-      "User-Agent": "Penglai/0.5.1 model-manager",
+      "User-Agent": "Penglai/0.5.2 model-manager",
     };
     if (existing) headers.Range = `bytes=${existing}-`;
     const response = await this.fetchPinned(file.url, headers, signal);

--- a/packages/audio-codecs/package.json
+++ b/packages/audio-codecs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/audio-codecs",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/audio-codecs/src/index.ts
+++ b/packages/audio-codecs/src/index.ts
@@ -292,7 +292,7 @@ function opusHead(preSkip: number): Buffer {
 }
 
 function opusTags(): Buffer {
-  const vendor = Buffer.from("Penglai 0.5.1", "utf8");
+  const vendor = Buffer.from("Penglai 0.5.2", "utf8");
   const out = Buffer.alloc(8 + 4 + vendor.length + 4);
   out.write("OpusTags", 0);
   out.writeUInt32LE(vendor.length, 8);

--- a/packages/budget/package.json
+++ b/packages/budget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/budget",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/channel-feishu/package.json
+++ b/packages/channel-feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/channel-feishu",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/channel-mock/package.json
+++ b/packages/channel-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/channel-mock",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/channel-weixin/package.json
+++ b/packages/channel-weixin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/channel-weixin",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/channel-weixin/src/protocol.ts
+++ b/packages/channel-weixin/src/protocol.ts
@@ -6,7 +6,7 @@ export const ILINK_BASE = "https://ilinkai.weixin.qq.com";
 export const ILINK_CDN_BASE = "https://novac2c.cdn.weixin.qq.com/c2c";
 export const DEFAULT_ILINK_BOT_TYPE = "3";
 export const ILINK_APP_ID = "bot";
-export const ILINK_BOT_AGENT = "Penglai/0.5.1";
+export const ILINK_BOT_AGENT = "Penglai/0.5.2";
 /** Exact Tencent channel package pinned by docs/compatibility/WEIXIN_R2.md. */
 export const ILINK_CHANNEL_VERSION = "2.4.6";
 /** 0x00MMNNPP, matching Tencent's buildClientVersion("2.4.6"). */

--- a/packages/channel-weixin/src/weixin.test.ts
+++ b/packages/channel-weixin/src/weixin.test.ts
@@ -300,7 +300,7 @@ test("ilink client maps endpoints and never logs token", async () => {
   assert.ok(seen.every((s) => s.clientVersion === "132102"));
   for (const request of seen.filter((s) => s.body)) {
     const body = JSON.parse(request.body!) as { base_info?: { channel_version?: string; bot_agent?: string } };
-    assert.deepEqual(body.base_info, { channel_version: "2.4.6", bot_agent: "Penglai/0.5.1" });
+    assert.deepEqual(body.base_info, { channel_version: "2.4.6", bot_agent: "Penglai/0.5.2" });
     assert.match(Buffer.from(request.wechatUin!, "base64").toString("utf8"), /^\d+$/);
   }
 });

--- a/packages/companion/package.json
+++ b/packages/companion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/companion",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/context",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/contracts",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/contracts/src/i18n.ts
+++ b/packages/contracts/src/i18n.ts
@@ -9,7 +9,7 @@ export const PENGLAI_I18N = {
     asrTitle: "蓬莱语音识别",
     ttsTitle: "蓬莱语音合成",
     aboutTitle: "关于蓬莱",
-    aboutVersion: "版本 0.5.1",
+    aboutVersion: "版本 0.5.2",
     aboutDsh: "核心：DeepSeek Harness 0.1.1-rc.1",
     aboutTrust: "社区验证发行：macOS ad-hoc 未公证，Windows 无 Authenticode。不是静默自动更新。DSH 插件与本地 DSH 进程共享权限；蓬莱只分发逐版本审核并签名的插件。权限字段不是操作系统沙箱。",
     aboutData: "数据位于本机 Penglai/0.5，密钥写入 app-private YAML。",
@@ -39,7 +39,7 @@ export const PENGLAI_I18N = {
     updateTitle: "更新",
     uninstallTitle: "存储与卸载",
     pluginSharedProcess: "DSH 插件与本地 DSH 进程共享权限；权限列表用于审核与确认，不是沙箱。",
-    pluginNoArbitraryInstall: "0.5.1 只安装蓬莱签名目录中的插件，不提供任意 URL、npm 或 Git 安装。",
+    pluginNoArbitraryInstall: "0.5.2 只安装蓬莱签名目录中的插件，不提供任意 URL、npm 或 Git 安装。",
   },
   en: {
     appName: "Penglai",
@@ -49,7 +49,7 @@ export const PENGLAI_I18N = {
     asrTitle: "Penglai Speech Recognition",
     ttsTitle: "Penglai Speech Synthesis",
     aboutTitle: "About Penglai",
-    aboutVersion: "Version 0.5.1",
+    aboutVersion: "Version 0.5.2",
     aboutDsh: "Core: DeepSeek Harness 0.1.1-rc.1",
     aboutTrust: "Community-verified: macOS ad-hoc not notarized, Windows no Authenticode. This is not silent auto-update. DSH plugins share the local DSH process; Penglai only distributes version-reviewed signed plugins. Permission fields are not an OS sandbox.",
     aboutData: "Data stays in local Penglai/0.5. Secrets use app-private YAML.",
@@ -80,7 +80,7 @@ export const PENGLAI_I18N = {
     updateTitle: "Updates",
     uninstallTitle: "Storage and uninstall",
     pluginSharedProcess: "DSH plugins share the local DSH process. Permission lists are for review and confirmation, not a sandbox.",
-    pluginNoArbitraryInstall: "0.5.1 installs only plugins from the Penglai-signed catalog. Arbitrary URL, npm, or Git install is not offered.",
+    pluginNoArbitraryInstall: "0.5.2 installs only plugins from the Penglai-signed catalog. Arbitrary URL, npm, or Git install is not offered.",
   },
 } as const;
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -3,7 +3,7 @@ export * from "./i18n.js";
 export * from "./typert.js";
 
 export const SCHEMA_VERSION = 11;
-export const RELEASE = "0.5.1";
+export const RELEASE = "0.5.2";
 
 export const CONFIG = Object.freeze({
   pairingTtlMs: 5 * 60_000,

--- a/packages/dsh-bridge/package.json
+++ b/packages/dsh-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/dsh-bridge",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/im/package.json
+++ b/packages/im/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/im",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/local-control/package.json
+++ b/packages/local-control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/local-control",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/local-control/src/index.ts
+++ b/packages/local-control/src/index.ts
@@ -64,7 +64,7 @@ export async function startControlServer(
         return;
       }
       if (req.url === "/health") {
-        res.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify({ ok: true, release: "0.5.1" }));
+        res.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify({ ok: true, release: "0.5.2" }));
         return;
       }
       const hdr = String(req.headers["x-penglai-token"] ?? "");

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/memory",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/memory/src/service.ts
+++ b/packages/memory/src/service.ts
@@ -64,7 +64,7 @@ export function createMemoryService(store?: MemoryStore): MemoryService {
     const rows = new Map<number, MemoryWrite & { id: number }>();
     return {
       name: "@penglai/memory",
-      version: "0.5.1",
+      version: "0.5.2",
       assertReadable,
       modelCannotWriteGlobal,
       write(input) {
@@ -109,7 +109,7 @@ export function createMemoryService(store?: MemoryStore): MemoryService {
   }
   const service: MemoryService = {
     name: "@penglai/memory",
-    version: "0.5.1",
+    version: "0.5.2",
     assertReadable,
     modelCannotWriteGlobal,
     write(input, receipt = "manual") {

--- a/packages/moss-tts/package.json
+++ b/packages/moss-tts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/moss-tts",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/moss-tts/src/models.ts
+++ b/packages/moss-tts/src/models.ts
@@ -535,7 +535,7 @@ export class TtsModelManager {
       }
       existing = info.size;
     }
-    const headers: Record<string, string> = { "User-Agent": "Penglai/0.5.1 model-manager" };
+    const headers: Record<string, string> = { "User-Agent": "Penglai/0.5.2 model-manager" };
     const validator = op.validators?.[file.path];
     if (existing) {
       headers.Range = `bytes=${existing}-`;

--- a/packages/persistence/package.json
+++ b/packages/persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/persistence",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/plugin-center/package.json
+++ b/packages/plugin-center/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/plugin-center",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/plugin-center/src/center.test.ts
+++ b/packages/plugin-center/src/center.test.ts
@@ -644,7 +644,7 @@ test("R50-CENTER-006 desired enabled cannot impersonate loaded/active", () => {
   const host = hostWith({ list: () => [] });
   host.setDesired("@penglai/im", true);
   const im = host.reconcile().find((r) => r.id === "@penglai/im");
-  assert.equal(im?.desired, "0.5.1");
+  assert.equal(im?.desired, "0.5.2");
   assert.equal(im?.loaded, false);
   assert.equal(im?.actual, "failed");
   assert.equal(im?.healthy, false);

--- a/packages/plugin-center/src/onboarding-remote.ts
+++ b/packages/plugin-center/src/onboarding-remote.ts
@@ -22,6 +22,7 @@ import {
   verifyWorkspaceInRegistry,
   type OnboardingHost,
   type PublicOnboardingState,
+  type ReconfigurableOnboardingStep,
   type OfficialUsableCtx,
 } from "./onboarding.js";
 
@@ -43,6 +44,7 @@ export function createPenglaiOnboardingRemoteImpl(opts: {
   officialWelcomeAck?: () => boolean;
   agents?: OfficialUsableCtx;
 }): OnboardingHost & {
+  rewindOnboarding(input: { step: ReconfigurableOnboardingStep }): PublicOnboardingState;
   completeWelcome(): Promise<PublicOnboardingState>;
   enterCredential(input: {
     provider: string;
@@ -87,6 +89,9 @@ export function createPenglaiOnboardingRemoteImpl(opts: {
   };
   return {
     ...host,
+    rewindOnboarding(input) {
+      return host.rewind(input.step);
+    },
     async completeWelcome() {
       const persisted = await persistWelcomeAckToOfficialSettings(official());
       if (!persisted)
@@ -514,6 +519,11 @@ export class PenglaiOnboardingRemote extends TypertRemoteService {
   @Remote
   completePrivacy() {
     return this.impl.advance("privacy-v1");
+  }
+
+  @Remote
+  rewindOnboarding(input: { step: ReconfigurableOnboardingStep }) {
+    return this.impl.rewindOnboarding(input);
   }
 
   @Remote

--- a/packages/plugin-center/src/onboarding-wizard.test.ts
+++ b/packages/plugin-center/src/onboarding-wizard.test.ts
@@ -307,7 +307,7 @@ test("completeWelcome writes penglai welcomeNoticeVersion then advances welcome-
   assert.deepEqual(ops, [
     { ns: "ui-onboarding", path: ["welcomeNoticeVersion"], value: PENGLAI_WELCOME_NOTICE_VERSION },
   ]);
-  assert.equal(PENGLAI_WELCOME_NOTICE_VERSION, "penglai-0.5.1.0");
+  assert.equal(PENGLAI_WELCOME_NOTICE_VERSION, "penglai-0.5.2.0");
   const again = await impl.completeWelcome();
   assert.equal(again.current, "appearance-locale-v1");
   assert.equal(ops.length, 2);

--- a/packages/plugin-center/src/onboarding.test.ts
+++ b/packages/plugin-center/src/onboarding.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { mkdtempSync } from "node:fs";
+import { existsSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readFileSync } from "node:fs";
@@ -435,6 +435,22 @@ test("R50-ONB-009 first conversation is a visible official Session and survives 
   });
   assert.equal(resumed.status().current, "COMPLETE");
   assert.deepEqual(resumed.facts(), impl.facts());
+
+  const rewound = resumed.rewindOnboarding({ step: "credential-v1" });
+  assert.equal(rewound.current, "credential-v1");
+  assert.deepEqual(resumed.facts().selection, { provider: "deepseek", model: "deepseek-chat" });
+  assert.equal(resumed.facts().credentialRef, undefined);
+  assert.equal(resumed.facts().apiTest, undefined);
+  assert.equal(resumed.facts().workspaceId, undefined);
+  assert.equal(resumed.facts().firstConversation, undefined);
+  assert.equal(existsSync(join(dir, "current-nonce.digest")), false);
+  await resumed.enterCredential({ provider: "deepseek", value: "sk-replacement" });
+  assert.equal(resumed.status().current, "model-test-v1");
+  await resumed.testSelectedModel({ nonce: "api2" });
+  await resumed.createWorkspace({ path: wsDir, title: "Docs" });
+  const retried = await resumed.runFirstConversation({ message: "重试成功" });
+  assert.equal((retried as { passed?: boolean }).passed, true);
+  assert.equal(resumed.status().current, "COMPLETE");
 });
 
 test("R50-ONB-002 completeAppearance persists locale/theme through official settings", async () => {

--- a/packages/plugin-center/src/onboarding.ts
+++ b/packages/plugin-center/src/onboarding.ts
@@ -73,7 +73,7 @@ export const OFFICIAL_THEME_SETTINGS_NS = "ui-theme" as const;
 export const OFFICIAL_SETTINGS_PREFERENCE_FIELD = "preference" as const;
 export const OFFICIAL_WELCOME_SETTINGS_NS = "ui-onboarding" as const;
 export const OFFICIAL_WELCOME_ACK_FIELD = "welcomeNoticeVersion" as const;
-export const PENGLAI_WELCOME_NOTICE_VERSION = "penglai-0.5.1.0" as const;
+export const PENGLAI_WELCOME_NOTICE_VERSION = "penglai-0.5.2.0" as const;
 
 export const ONBOARDING_STEPS = [
   "welcome-v1",

--- a/packages/plugin-center/src/onboarding.ts
+++ b/packages/plugin-center/src/onboarding.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { PenglaiError, classifyApiTestError, type ApiTestErrorClass } from "@penglai/contracts";
 
@@ -102,6 +102,13 @@ export const OFFICIAL_ONBOARDING_STEPS = [
 ] as const;
 
 export type OnboardingStepId = (typeof ONBOARDING_STEPS)[number];
+export const RECONFIGURABLE_ONBOARDING_STEPS = [
+  "model-provider-v1",
+  "credential-v1",
+  "workspace-v1",
+  "first-turn-v1",
+] as const;
+export type ReconfigurableOnboardingStep = (typeof RECONFIGURABLE_ONBOARDING_STEPS)[number];
 
 export interface OnboardingState {
   schema: 2;
@@ -609,6 +616,7 @@ export interface OnboardingHost {
     workspaceId?: string;
   };
   advance(id: OnboardingStepId, evidence?: StepEvidence): OnboardingState;
+  rewind(id: ReconfigurableOnboardingStep): OnboardingState;
   facts(): OnboardingFacts;
   saveFacts(patch: Partial<OnboardingFacts>): OnboardingFacts;
 }
@@ -658,6 +666,33 @@ export function createOnboardingHost(opts: {
       persistOnboarding(opts.dir, next);
       return next;
     },
+    rewind(id) {
+      const state = load();
+      const target = ONBOARDING_STEPS.indexOf(id);
+      if (target < 0) throw new PenglaiError("INVALID_INPUT", "unknown onboarding rewind step");
+      const current = state.current === "COMPLETE" ? ONBOARDING_STEPS.length : ONBOARDING_STEPS.indexOf(state.current);
+      if (current < target) throw new PenglaiError("INVALID_INPUT", `onboarding cannot rewind forward to ${id}`);
+      const next: OnboardingState = {
+        schema: 2,
+        completed: state.completed.filter((step) => ONBOARDING_STEPS.indexOf(step) < target),
+        current: id,
+        advanceToken: randomUUID(),
+      };
+      const facts = loadOnboardingFacts(opts.dir);
+      if (target <= ONBOARDING_STEPS.indexOf("model-provider-v1")) delete facts.selection;
+      if (target <= ONBOARDING_STEPS.indexOf("credential-v1")) {
+        delete facts.credentialRef;
+        delete facts.apiTest;
+      }
+      if (target <= ONBOARDING_STEPS.indexOf("workspace-v1")) {
+        delete facts.workspaceId;
+        delete facts.workspacePath;
+      }
+      if (target <= ONBOARDING_STEPS.indexOf("first-turn-v1")) delete facts.firstConversation;
+      persistOnboardingFacts(opts.dir, facts);
+      persistOnboarding(opts.dir, next);
+      return next;
+    },
     facts() {
       return loadOnboardingFacts(opts.dir);
     },
@@ -685,6 +720,12 @@ export function persistOnboardingFacts(dir: string, facts: OnboardingFacts): voi
   atomicWritePrivateJson(join(dir, "onboarding-facts.json"), facts);
   if (facts.apiTest?.nonceDigest) {
     writeFileSync(join(dir, "current-nonce.digest"), `${facts.apiTest.nonceDigest}\n`, { mode: 0o600 });
+  } else {
+    try {
+      unlinkSync(join(dir, "current-nonce.digest"));
+    } catch {
+      /* already absent */
+    }
   }
 }
 

--- a/packages/plugin-pilot/package.json
+++ b/packages/plugin-pilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/plugin-pilot",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/plugin-reference/package.json
+++ b/packages/plugin-reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/plugin-reference",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/plugin-registry/package.json
+++ b/packages/plugin-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/plugin-registry",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/release-identity/package.json
+++ b/packages/release-identity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/release-identity",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/release-identity/src/artifact-provenance.test.ts
+++ b/packages/release-identity/src/artifact-provenance.test.ts
@@ -28,7 +28,7 @@ function fixture(
   writeFileSync(join(resources, "runtime/node/bin/node"), "node");
   writeFileSync(join(resources, "runtime/dsh/lib/bin.js"), "dsh");
   const manifest = {
-    release: "0.5.1",
+    release: "0.5.2",
     target: overrides.manifestTarget ?? "darwin-aarch64",
     dsh: "0.1.1-rc.1",
     files: [
@@ -45,7 +45,7 @@ function fixture(
     join(resources, "release-info.json"),
     `${JSON.stringify({
       productName: "Penglai",
-      productVersion: "0.5.1",
+      productVersion: "0.5.2",
       generationId: "penglai-dsh-v0.5",
       trustTier: "community-verified",
       sourceSha: overrides.sourceSha ?? sourceSha,

--- a/packages/release-identity/src/contract.ts
+++ b/packages/release-identity/src/contract.ts
@@ -103,8 +103,8 @@ export function assertCanonicalUpdaterManifestUrl(url: string, signature = false
     throw new PenglaiError("INVALID_INPUT", "invalid updater manifest URL");
   }
   const expectedPath = signature
-    ? "/kevinchennewbee/PenglaiAgent/releases/download/v0.5.1/update-manifest-v1.json.sig"
-    : "/kevinchennewbee/PenglaiAgent/releases/download/v0.5.1/update-manifest-v1.json";
+    ? "/kevinchennewbee/PenglaiAgent/releases/download/v0.5.2/update-manifest-v1.json.sig"
+    : "/kevinchennewbee/PenglaiAgent/releases/download/v0.5.2/update-manifest-v1.json";
   if (
     parsed.protocol !== "https:" ||
     parsed.hostname !== "github.com" ||
@@ -152,9 +152,9 @@ export function assertReleaseContract(raw: unknown): ReleaseContract {
   const pub = raw.publication;
   if (!isRecord(pub)) throw new PenglaiError("INVALID_INPUT", "publication");
   if (pub.repo !== "kevinchennewbee/PenglaiAgent") throw new PenglaiError("SECURITY_POLICY", "publication.repo");
-  if (pub.tag !== "v0.5.1") throw new PenglaiError("SECURITY_POLICY", "publication.tag");
-  if (pub.release !== "v0.5.1") throw new PenglaiError("SECURITY_POLICY", "publication.release");
-  if (pub.channel !== "stable-v0.5.1") throw new PenglaiError("SECURITY_POLICY", "publication.channel");
+  if (pub.tag !== "v0.5.2") throw new PenglaiError("SECURITY_POLICY", "publication.tag");
+  if (pub.release !== "v0.5.2") throw new PenglaiError("SECURITY_POLICY", "publication.release");
+  if (pub.channel !== "stable-v0.5.2") throw new PenglaiError("SECURITY_POLICY", "publication.channel");
   if (!Array.isArray(raw.targets) || raw.targets.length !== RELEASE_TARGETS.length) {
     throw new PenglaiError("INVALID_INPUT", "targets");
   }

--- a/packages/release-identity/src/identity.test.ts
+++ b/packages/release-identity/src/identity.test.ts
@@ -17,16 +17,16 @@ import {
   TRUST_TIER,
 } from "./pins.js";
 
-test("R50-TRUTH-001 identity pins are 0.5.1", () => {
+test("R50-TRUTH-001 identity pins are 0.5.2", () => {
   const id = emptyIdentity("a".repeat(40), false);
   const checked = assertReleaseIdentity(id);
   assert.equal(checked.productVersion, PRODUCT_VERSION);
-  assert.equal(checked.productVersion, "0.5.1");
+  assert.equal(checked.productVersion, "0.5.2");
   recordAssertion({
     acceptanceId: "R50-TRUTH-001",
     runnerId: "release-identity.identity",
-    testId: "identity-pins-0.5.1",
-    assertionId: "productVersion-is-0.5.1",
+    testId: "identity-pins-0.5.2",
+    assertionId: "productVersion-is-0.5.2",
     status: "PASS",
     candidateSourceSha: "a".repeat(40),
     exitCode: 0,
@@ -136,14 +136,14 @@ test("tampered sourceSha is rejected", () => {
 test("R50-TRUTH-008 publication fields match the owner-authorized public target", () => {
   const id = assertReleaseIdentity(emptyIdentity("e".repeat(40), false));
   assert.equal(id.publication.repo, "kevinchennewbee/PenglaiAgent");
-  assert.equal(id.publication.tag, "v0.5.1");
-  assert.equal(id.publication.release, "v0.5.1");
-  assert.equal(id.publication.channel, "stable-v0.5.1");
+  assert.equal(id.publication.tag, "v0.5.2");
+  assert.equal(id.publication.release, "v0.5.2");
+  assert.equal(id.publication.channel, "stable-v0.5.2");
   assert.throws(
     () =>
       assertReleaseIdentity({
         ...emptyIdentity("e".repeat(40), false),
-        publication: { ...id.publication, tag: "v0.5.2" },
+        publication: { ...id.publication, tag: "v0.5.1" },
       }),
     /publication.tag/,
   );

--- a/packages/release-identity/src/identity.ts
+++ b/packages/release-identity/src/identity.ts
@@ -126,7 +126,7 @@ function publicationOk(raw: unknown): PublicationBoundary {
 
 function assertTargets(raw: unknown): ReleaseTarget[] {
   if (!Array.isArray(raw) || raw.length !== RELEASE_TARGETS.length) {
-    throw new PenglaiError("INVALID_INPUT", "identity must declare the exact 0.5.1 release targets");
+    throw new PenglaiError("INVALID_INPUT", "identity must declare the exact 0.5.2 release targets");
   }
   const got = raw as ReleaseTarget[];
   for (let i = 0; i < RELEASE_TARGETS.length; i += 1) {

--- a/packages/release-identity/src/installed-evidence.test.ts
+++ b/packages/release-identity/src/installed-evidence.test.ts
@@ -105,8 +105,8 @@ test("installed exact-DMG evidence is attributed only from runner output", () =>
   const path = join(root, "evidence/generated/installed-e2e.json");
   if (!existsSync(path)) return;
   const rec = JSON.parse(readFileSync(path, "utf8"));
-  if (rec.verdict !== "PASS" || rec.fromExactDmg !== true || rec.productVersion !== "0.5.1") return;
-  if (rec.installer !== "Penglai_0.5.1_macos_aarch64.dmg") return;
+  if (rec.verdict !== "PASS" || rec.fromExactDmg !== true || rec.productVersion !== "0.5.2") return;
+  if (rec.installer !== "Penglai_0.5.2_macos_aarch64.dmg") return;
   const sourceSha = declaredSourceSha();
   const app = packagedAppForTarget(root, "darwin-aarch64");
   const packaged = inspectPackagedCandidate({ app, candidateSha: sourceSha, expectedTarget: "darwin-aarch64" });
@@ -135,7 +135,7 @@ test("installed exact-DMG evidence is attributed only from runner output", () =>
     runnerId: "installed",
     testId: "installed-e2e-file-R50-E2E-001",
     assertionId: "exact-dmg-not-staging",
-    details: { safe: "installed-e2e.json came from exact Penglai_0.5.1_macos_aarch64.dmg" },
+    details: { safe: "installed-e2e.json came from exact Penglai_0.5.2_macos_aarch64.dmg" },
   });
   recordAssertion({
     ...common,

--- a/packages/release-identity/src/pins.ts
+++ b/packages/release-identity/src/pins.ts
@@ -1,5 +1,5 @@
 export const PRODUCT_NAME = "Penglai";
-export const PRODUCT_VERSION = "0.5.1";
+export const PRODUCT_VERSION = "0.5.2";
 export const CANDIDATE_KIND = "public-community-release";
 export const TRUST_TIER = "community-verified";
 export const GENERATION_ID = "penglai-dsh-v0.5";
@@ -80,9 +80,9 @@ export const UPDATER_CHANNEL = "desktop-v0.5";
 
 export const PUBLICATION_TARGET = Object.freeze({
   repo: "kevinchennewbee/PenglaiAgent",
-  tag: "v0.5.1",
-  release: "v0.5.1",
-  channel: "stable-v0.5.1",
+  tag: "v0.5.2",
+  release: "v0.5.2",
+  channel: "stable-v0.5.2",
 });
 
 export const RELEASE_TARGETS = [
@@ -90,19 +90,19 @@ export const RELEASE_TARGETS = [
     key: "darwin-aarch64",
     platform: "darwin",
     arch: "arm64",
-    installer: "Penglai_0.5.1_macos_aarch64.dmg",
+    installer: "Penglai_0.5.2_macos_aarch64.dmg",
   },
   {
     key: "darwin-x86_64",
     platform: "darwin",
     arch: "x64",
-    installer: "Penglai_0.5.1_macos_x64.dmg",
+    installer: "Penglai_0.5.2_macos_x64.dmg",
   },
   {
     key: "win32-x86_64",
     platform: "win32",
     arch: "x64",
-    installer: "Penglai_0.5.1_windows_x64_setup.exe",
+    installer: "Penglai_0.5.2_windows_x64_setup.exe",
   },
 ] as const;
 

--- a/packages/release-identity/src/public-docs.test.ts
+++ b/packages/release-identity/src/public-docs.test.ts
@@ -8,9 +8,9 @@ import { declaredSourceSha, recordAssertion } from "./assertion.js";
 const root = join(dirname(fileURLToPath(import.meta.url)), "../../..");
 
 test("R50-PREP-007 release notes state fresh install, trust, upgrade and uninstall", () => {
-  const notes = readFileSync(join(root, "docs/RELEASE_NOTES_0.5.1.md"), "utf8");
-  assert.match(notes, /manual DMG overlay/i);
-  assert.match(notes, /0\.5\.0/);
+  const notes = readFileSync(join(root, "docs/RELEASE_NOTES_0.5.2.md"), "utf8");
+  assert.match(notes, /Penglai → Update/i);
+  assert.match(notes, /0\.5\.1/);
   assert.match(notes, /community-verified/);
   assert.match(notes, /not notarized/);
   assert.match(notes, /silent auto-update/i);
@@ -26,15 +26,15 @@ test("R50-PREP-007 release notes state fresh install, trust, upgrade and uninsta
     status: "PASS",
     candidateSourceSha: declaredSourceSha(),
     exitCode: 0,
-    details: { safe: "0.5.1 notes state manual 0.5.0 overlay, three targets, community trust, and future signed updates" },
+    details: { safe: "0.5.2 notes state signed 0.5.1 upgrade, three targets, community trust, and update confirmation" },
   });
 });
 
 test("R50-PREP-008 publication manifest lists the exact three-target release", () => {
-  const md = readFileSync(join(root, "docs/PUBLICATION_MANIFEST_0.5.1.md"), "utf8");
-  assert.match(md, /Penglai_0\.5\.1_macos_aarch64\.dmg/);
-  assert.match(md, /Penglai_0\.5\.1_macos_x64\.dmg/);
-  assert.match(md, /Penglai_0\.5\.1_windows_x64_setup\.exe/);
+  const md = readFileSync(join(root, "docs/PUBLICATION_MANIFEST_0.5.2.md"), "utf8");
+  assert.match(md, /Penglai_0\.5\.2_macos_aarch64\.dmg/);
+  assert.match(md, /Penglai_0\.5\.2_macos_x64\.dmg/);
+  assert.match(md, /Penglai_0\.5\.2_windows_x64_setup\.exe/);
   assert.match(md, /public-export-manifest\.json/);
   assert.match(md, /kevinchennewbee\/PenglaiAgent/);
   assert.match(md, /UNFROZEN/);

--- a/packages/release-identity/src/public-export.test.ts
+++ b/packages/release-identity/src/public-export.test.ts
@@ -130,6 +130,9 @@ test("R50-PREP-005 required public docs are enumerated", () => {
       "docs/PUBLICATION_0.5.1.md",
       "docs/PUBLICATION_MANIFEST_0.5.1.md",
       "docs/RELEASE_NOTES_0.5.1.md",
+      "docs/PUBLICATION_0.5.2.md",
+      "docs/PUBLICATION_MANIFEST_0.5.2.md",
+      "docs/RELEASE_NOTES_0.5.2.md",
     ]),
   );
   recordAssertion({
@@ -200,7 +203,7 @@ test("R50-PREP-010 publication fields match the owner-authorized target", () => 
     status: "PASS",
     candidateSourceSha: declaredSourceSha(),
     exitCode: 0,
-    details: { safe: "public repo, v0.5.1 tag and release are exact; updater channel remains unpublished until freeze" },
+    details: { safe: "public repo, v0.5.2 tag and release are exact; updater channel remains unpublished until freeze" },
   });
 });
 

--- a/packages/release-identity/src/public-export.ts
+++ b/packages/release-identity/src/public-export.ts
@@ -36,6 +36,10 @@ export const PUBLIC_EXPORT_ALLOW = [
   "docs/PUBLICATION_MANIFEST_0.5.1.md",
   "docs/RELEASE_NOTES_0.5.1.md",
   "docs/0.5.1",
+  "docs/PUBLICATION_0.5.2.md",
+  "docs/PUBLICATION_MANIFEST_0.5.2.md",
+  "docs/RELEASE_NOTES_0.5.2.md",
+  "docs/0.5.2",
   "docs/ACCEPTANCE.md",
   "docs/RELEASE_RUNBOOK.md",
   "docs/decisions.md",
@@ -100,6 +104,9 @@ export const REQUIRED_PUBLIC_DOCS = [
   "docs/PUBLICATION_0.5.1.md",
   "docs/PUBLICATION_MANIFEST_0.5.1.md",
   "docs/RELEASE_NOTES_0.5.1.md",
+  "docs/PUBLICATION_0.5.2.md",
+  "docs/PUBLICATION_MANIFEST_0.5.2.md",
+  "docs/RELEASE_NOTES_0.5.2.md",
 ] as const;
 
 export interface ExportFile {
@@ -209,7 +216,8 @@ export function buildPublicationDraft(input: {
       `${PRODUCT_VERSION} declares darwin-aarch64, darwin-x86_64, and win32-x86_64; native PASS requires a matching runner`,
       "community-verified: macOS ad-hoc/not notarized; Windows has no Authenticode",
       "0.5.0 to 0.5.1 is a manual overlay install on Apple Silicon; Intel/Windows are fresh installs",
-      `no silent auto-update from 0.5.0; 0.5.1 discovers later immutable PenglaiAgent Releases`,
+      "0.5.1 to 0.5.2 uses signed assisted update after user confirmation; 0.5.0 remains manual",
+      `no silent auto-update; ${PRODUCT_VERSION} discovers only later stable immutable PenglaiAgent Releases`,
       "public destination is owner-authorized; execution is verified after publication",
     ],
     publication: {

--- a/packages/release-identity/src/rc0.test.ts
+++ b/packages/release-identity/src/rc0.test.ts
@@ -243,12 +243,12 @@ test("build inputs reject dirty named SHA and HEAD drift", () => {
   );
 });
 
-test("GitHub Actions is AVAILABLE for the 0.5.1 source candidate", () => {
+test("GitHub Actions is AVAILABLE for the 0.5.2 source candidate", () => {
   assert.equal(GITHUB_ACTIONS_STATUS, "AVAILABLE");
 });
 
-test("product version is 0.5.1 and registry count matches the document", () => {
-  assert.equal(PRODUCT_VERSION, "0.5.1");
+test("product version is 0.5.2 and registry count matches the document", () => {
+  assert.equal(PRODUCT_VERSION, "0.5.2");
   const md = readFileSync(join(root, "docs/ACCEPTANCE.md"), "utf8");
   const ids = parseAcceptanceIds(md);
   const entries = assertRegistryConsistent(md);

--- a/packages/routing-core/package.json
+++ b/packages/routing-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/routing-core",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/runtime",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/runtime/src/boot-revoke.ts
+++ b/packages/runtime/src/boot-revoke.ts
@@ -75,7 +75,7 @@ export function quarantineRevokedPlugins(opts: {
     cacheRoot: join(opts.userDataRoot, "plugins", "cas"),
     trustPath,
     lastGoodPath,
-    penglaiVersion: "0.5.1",
+    penglaiVersion: "0.5.2",
     dshExact: PINNED_PLUGIN_DSH,
   });
   const snap = client.snapshot();

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -49,7 +49,7 @@ export * from "./windows-host.js";
 export * from "./packaging.js";
 export * from "./fuses.js";
 
-export const PENGLAI_VERSION = "0.5.1";
+export const PENGLAI_VERSION = "0.5.2";
 export const PINNED_DSH = "0.1.1-rc.1";
 export const PINNED_NODE = "22.22.2";
 export const PINNED_ELECTRON = "43.4.0";

--- a/packages/runtime/src/leftover.test.ts
+++ b/packages/runtime/src/leftover.test.ts
@@ -75,7 +75,7 @@ test("R50-REL-006/007 a11y contract covers live region, QR alt, contrast, and zo
 
 test("R50-UPD-008/009/010 verified installer and crash replay", () => {
   const root = mkdtempSync(join(tmpdir(), "penglai-update-handoff-"));
-  const path = join(root, "Penglai_0.5.1_macos_aarch64.dmg");
+  const path = join(root, "Penglai_0.5.2_macos_aarch64.dmg");
   const payload = Buffer.from("signed-installer");
   writeFileSync(path, payload);
   const { publicKey, privateKey } = generateKeyPairSync("ed25519");
@@ -140,7 +140,7 @@ test("R50-UPD: download verifies size/hash/signature and crash mid-download retu
   const sig = sign(null, payload, privateKey);
   const dest = mkdtempSync(join(tmpdir(), "penglai-upd-dl-"));
   const out = await downloadVerifiedPayload({
-    url: "https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.1/Penglai_0.5.1_macos_aarch64.dmg",
+    url: "https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.2/Penglai_0.5.2_macos_aarch64.dmg",
     destDir: dest,
     expectedSha256: sha,
     expectedSize: payload.length,
@@ -154,7 +154,7 @@ test("R50-UPD: download verifies size/hash/signature and crash mid-download retu
   assert.throws(() => drainOwnedServices({ dshRunning: true, asrBusy: false, ttsBusy: false, indexerBusy: false, companionArmed: false }), /busy/);
 });
 
-test("R50-DIST: packaged identity is Penglai 0.5.1 and Windows NSIS stays current-user", async () => {
+test("R50-DIST: packaged identity is Penglai 0.5.2 and Windows NSIS stays current-user", async () => {
   const {
     assertPenglaiAppIdentity,
     assertWindowsNsisContract,
@@ -176,7 +176,7 @@ test("R50-DIST: packaged identity is Penglai 0.5.1 and Windows NSIS stays curren
   const facts = parseInfoPlistIdentity(rewritten);
   assertPenglaiAppIdentity(facts);
   assert.equal(facts.executable, "Penglai");
-  assert.equal(facts.shortVersion, "0.5.1");
+  assert.equal(facts.shortVersion, "0.5.2");
   assert.match(rewritten, /penglai\.icns/);
   assert.match(rewritten, /<string>13\.0<\/string>/);
   assertWindowsNsisContract({

--- a/packages/runtime/src/plugin-catalog.ts
+++ b/packages/runtime/src/plugin-catalog.ts
@@ -70,7 +70,7 @@ export interface EmbeddedPluginManifest {
 
 const TARGETS = [...PRODUCT_PLUGIN_TARGETS];
 const common = {
-  version: "0.5.1",
+  version: "0.5.2",
   dsh: { exact: PINNED_PLUGIN_DSH },
   platforms: TARGETS,
   source: "bundled-first-party" as const,
@@ -84,7 +84,7 @@ export const FIRST_PARTY_PLUGIN_METADATA: readonly PluginCatalogMetadata[] =
     {
       ...common,
       id: "@penglai/plugin-center",
-      packageFile: "penglai-plugin-center-0.5.1.tgz",
+      packageFile: "penglai-plugin-center-0.5.2.tgz",
       capabilities: ["settings-ui", "catalog", "profile-transaction"],
       permissions: ["profile-write"],
       defaultEnabled: true,
@@ -94,7 +94,7 @@ export const FIRST_PARTY_PLUGIN_METADATA: readonly PluginCatalogMetadata[] =
     {
       ...common,
       id: "@penglai/im",
-      packageFile: "penglai-im-0.5.1.tgz",
+      packageFile: "penglai-im-0.5.2.tgz",
       capabilities: ["settings-ui", "im-weixin", "im-feishu", "private-voice"],
       permissions: ["credentials-service", "local-database", "outbound-network"],
       defaultEnabled: false,
@@ -104,7 +104,7 @@ export const FIRST_PARTY_PLUGIN_METADATA: readonly PluginCatalogMetadata[] =
     {
       ...common,
       id: "@penglai/plugin-reference",
-      packageFile: "penglai-plugin-reference-0.5.1.tgz",
+      packageFile: "penglai-plugin-reference-0.5.2.tgz",
       capabilities: ["platform-proof"],
       permissions: [],
       defaultEnabled: false,
@@ -114,7 +114,7 @@ export const FIRST_PARTY_PLUGIN_METADATA: readonly PluginCatalogMetadata[] =
     {
       ...common,
       id: "@penglai/asr",
-      packageFile: "penglai-asr-0.5.1.tgz",
+      packageFile: "penglai-asr-0.5.2.tgz",
       capabilities: ["settings-ui", "local-asr", "model-manager"],
       permissions: ["microphone", "local-model"],
       defaultEnabled: false,
@@ -124,7 +124,7 @@ export const FIRST_PARTY_PLUGIN_METADATA: readonly PluginCatalogMetadata[] =
     {
       ...common,
       id: "@penglai/moss-tts",
-      packageFile: "penglai-moss-tts-0.5.1.tgz",
+      packageFile: "penglai-moss-tts-0.5.2.tgz",
       capabilities: ["settings-ui", "local-tts", "model-manager"],
       permissions: ["local-model", "audio-output"],
       defaultEnabled: false,
@@ -134,7 +134,7 @@ export const FIRST_PARTY_PLUGIN_METADATA: readonly PluginCatalogMetadata[] =
     {
       ...common,
       id: "@penglai/context",
-      packageFile: "penglai-context-0.5.1.tgz",
+      packageFile: "penglai-context-0.5.2.tgz",
       capabilities: ["authorized-context", "source-cards"],
       permissions: ["local-index", "authorized-files-read"],
       defaultEnabled: false,
@@ -144,7 +144,7 @@ export const FIRST_PARTY_PLUGIN_METADATA: readonly PluginCatalogMetadata[] =
     {
       ...common,
       id: "@penglai/memory",
-      packageFile: "penglai-memory-0.5.1.tgz",
+      packageFile: "penglai-memory-0.5.2.tgz",
       capabilities: ["layered-memory", "official-skill-promotion"],
       permissions: ["local-memory", "official-skill-write"],
       defaultEnabled: false,
@@ -154,7 +154,7 @@ export const FIRST_PARTY_PLUGIN_METADATA: readonly PluginCatalogMetadata[] =
     {
       ...common,
       id: "@penglai/budget",
-      packageFile: "penglai-budget-0.5.1.tgz",
+      packageFile: "penglai-budget-0.5.2.tgz",
       capabilities: ["token-budget", "pre-invocation-gate"],
       permissions: ["token-meter", "model-invocation-gate"],
       defaultEnabled: false,
@@ -164,7 +164,7 @@ export const FIRST_PARTY_PLUGIN_METADATA: readonly PluginCatalogMetadata[] =
     {
       ...common,
       id: "@penglai/companion",
-      packageFile: "penglai-companion-0.5.1.tgz",
+      packageFile: "penglai-companion-0.5.2.tgz",
       capabilities: ["proactive-companion", "schedule-composition"],
       permissions: ["schedule", "dedicated-agent", "im-send"],
       defaultEnabled: false,

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/testkit",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/packaging/electron-fuses.json
+++ b/packaging/electron-fuses.json
@@ -1,5 +1,5 @@
 {
-  "policy": "0.5.1-unpacked-app",
+  "policy": "0.5.2-unpacked-app",
   "runAsNode": false,
   "enableNodeOptionsEnvironmentVariable": false,
   "enableNodeCliInspectArguments": false,

--- a/profile-seed/web/package.json
+++ b/profile-seed/web/package.json
@@ -2,15 +2,15 @@
   "name": "dsh-profile-web",
   "private": true,
   "dependencies": {
-    "@penglai/plugin-center": "0.5.1",
-    "@penglai/im": "0.5.1",
-    "@penglai/asr": "0.5.1",
-    "@penglai/moss-tts": "0.5.1",
-    "@penglai/context": "0.5.1",
-    "@penglai/memory": "0.5.1",
-    "@penglai/budget": "0.5.1",
-    "@penglai/companion": "0.5.1",
-    "@penglai/plugin-reference": "0.5.1"
+    "@penglai/plugin-center": "0.5.2",
+    "@penglai/im": "0.5.2",
+    "@penglai/asr": "0.5.2",
+    "@penglai/moss-tts": "0.5.2",
+    "@penglai/context": "0.5.2",
+    "@penglai/memory": "0.5.2",
+    "@penglai/budget": "0.5.2",
+    "@penglai/companion": "0.5.2",
+    "@penglai/plugin-reference": "0.5.2"
   },
   "dsh": {
     "profile": {

--- a/release-contract.json
+++ b/release-contract.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "product": "Penglai",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "candidateKind": "public-community-release",
   "trustTier": "community-verified",
   "generationId": "penglai-dsh-v0.5",
@@ -12,34 +12,34 @@
   "updaterChannel": "desktop-v0.5",
   "updaterPublicKeyId": "penglai-updater-d706d4f5cf1da7a57b74c068",
   "updaterPublicKeyHex": "d706d4f5cf1da7a57b74c068dd9eb4b7d7f655609c8ef097fd86fb22376bf9ee",
-  "updaterManifestUrl": "https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.1/update-manifest-v1.json",
-  "updaterManifestSignatureUrl": "https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.1/update-manifest-v1.json.sig",
+  "updaterManifestUrl": "https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.2/update-manifest-v1.json",
+  "updaterManifestSignatureUrl": "https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.2/update-manifest-v1.json.sig",
   "updaterAllowedAssetHosts": ["github.com"],
   "canonicalMaker": "penglai-controlled-pipeline",
   "publication": {
     "repo": "kevinchennewbee/PenglaiAgent",
-    "tag": "v0.5.1",
-    "release": "v0.5.1",
-    "channel": "stable-v0.5.1"
+    "tag": "v0.5.2",
+    "release": "v0.5.2",
+    "channel": "stable-v0.5.2"
   },
   "targets": [
     {
       "key": "darwin-aarch64",
       "platform": "darwin",
       "arch": "arm64",
-      "installer": "Penglai_0.5.1_macos_aarch64.dmg"
+      "installer": "Penglai_0.5.2_macos_aarch64.dmg"
     },
     {
       "key": "darwin-x86_64",
       "platform": "darwin",
       "arch": "x64",
-      "installer": "Penglai_0.5.1_macos_x64.dmg"
+      "installer": "Penglai_0.5.2_macos_x64.dmg"
     },
     {
       "key": "win32-x86_64",
       "platform": "win32",
       "arch": "x64",
-      "installer": "Penglai_0.5.1_windows_x64_setup.exe"
+      "installer": "Penglai_0.5.2_windows_x64_setup.exe"
     }
   ],
   "runtimeInputs": [
@@ -93,9 +93,9 @@
     }
   ],
   "exactAssets": [
-    "Penglai_0.5.1_macos_aarch64.dmg",
-    "Penglai_0.5.1_macos_x64.dmg",
-    "Penglai_0.5.1_windows_x64_setup.exe",
+    "Penglai_0.5.2_macos_aarch64.dmg",
+    "Penglai_0.5.2_macos_x64.dmg",
+    "Penglai_0.5.2_windows_x64_setup.exe",
     "update-manifest-v1.json",
     "update-manifest-v1.json.sig",
     "release-manifest.json",

--- a/release-info.json
+++ b/release-info.json
@@ -1,6 +1,6 @@
 {
   "productName": "Penglai",
-  "productVersion": "0.5.1",
+  "productVersion": "0.5.2",
   "buildNumber": 0,
   "candidateOrdinal": 0,
   "candidateKind": "public-community-release",
@@ -16,19 +16,19 @@
       "key": "darwin-aarch64",
       "platform": "darwin",
       "arch": "arm64",
-      "installer": "Penglai_0.5.1_macos_aarch64.dmg"
+      "installer": "Penglai_0.5.2_macos_aarch64.dmg"
     },
     {
       "key": "darwin-x86_64",
       "platform": "darwin",
       "arch": "x64",
-      "installer": "Penglai_0.5.1_macos_x64.dmg"
+      "installer": "Penglai_0.5.2_macos_x64.dmg"
     },
     {
       "key": "win32-x86_64",
       "platform": "win32",
       "arch": "x64",
-      "installer": "Penglai_0.5.1_windows_x64_setup.exe"
+      "installer": "Penglai_0.5.2_windows_x64_setup.exe"
     }
   ],
   "electron": "43.4.0",
@@ -43,9 +43,9 @@
   "authenticode": false,
   "publication": {
     "repo": "kevinchennewbee/PenglaiAgent",
-    "tag": "v0.5.1",
-    "release": "v0.5.1",
-    "channel": "stable-v0.5.1"
+    "tag": "v0.5.2",
+    "release": "v0.5.2",
+    "channel": "stable-v0.5.2"
   },
   "pnpm": "10.14.0"
 }

--- a/scripts/build-local-dmg.mjs
+++ b/scripts/build-local-dmg.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Community-verified macOS DMG for Penglai 0.5.1.
+ * Community-verified macOS DMG for Penglai 0.5.2.
  * Follows PenglaiAgent v0.4.1: complete ad-hoc app seal, codesign strict
  * verification, ordinary UDZO DMG, hdiutil verify. Not Developer ID, not notarized.
  */
@@ -74,14 +74,14 @@ const targetArg = process.argv.includes("--target")
   : process.env.PENGLAI_PACK_TARGET;
 const TARGETS = {
   "darwin-arm64": {
-    out: "dist/Penglai-v0.5.1-arm64",
-    dmg: "dist/Penglai_0.5.1_macos_aarch64.dmg",
-    from: "dist/Penglai-v0.5.1-arm64-from-dmg",
+    out: "dist/Penglai-v0.5.2-arm64",
+    dmg: "dist/Penglai_0.5.2_macos_aarch64.dmg",
+    from: "dist/Penglai-v0.5.2-arm64-from-dmg",
   },
   "darwin-x64": {
-    out: "dist/Penglai-v0.5.1-x64",
-    dmg: "dist/Penglai_0.5.1_macos_x64.dmg",
-    from: "dist/Penglai-v0.5.1-x64-from-dmg",
+    out: "dist/Penglai-v0.5.2-x64",
+    dmg: "dist/Penglai_0.5.2_macos_x64.dmg",
+    from: "dist/Penglai-v0.5.2-x64-from-dmg",
   },
 };
 if (!targetArg || !TARGETS[targetArg]) {
@@ -207,7 +207,7 @@ const dirty =
 const hash = sha256(dmgPath);
 const info = {
   productName: "Penglai",
-  productVersion: "0.5.1",
+  productVersion: "0.5.2",
   name: targetSpec.dmg
     .split("/")
     .pop()

--- a/scripts/bundle-desktop.mjs
+++ b/scripts/bundle-desktop.mjs
@@ -39,6 +39,6 @@ const staticSrc = join(ROOT, "apps/desktop/static");
 if (existsSync(staticSrc)) cpSync(staticSrc, join(outDir, "static"), { recursive: true });
 writeFileSync(
   join(outDir, "package.json"),
-  JSON.stringify({ name: "penglai", version: "0.5.1", type: "module", main: "electron-main.js" }, null, 2),
+  JSON.stringify({ name: "penglai", version: "0.5.2", type: "module", main: "electron-main.js" }, null, 2),
 );
 console.log("bundle-desktop", outDir);

--- a/scripts/e2e-installed.mjs
+++ b/scripts/e2e-installed.mjs
@@ -146,7 +146,7 @@ if (!harnessApp) {
     reason: "exact DMG refused debug flags; UI walk requires a separate harness build",
     refuseCode,
     installer: expectedInstaller,
-    productVersion: "0.5.1",
+    productVersion: "0.5.2",
   });
 }
 const debugPort = await freePort();
@@ -228,7 +228,7 @@ const official = walk?.official ?? {};
 const http = official.http ?? { status: 0, ok: false, official: false };
 if (http.status === 401) http.officialProxy = true;
 const first = {
-  productVersion: "0.5.1",
+  productVersion: "0.5.2",
   pid: launched.child.pid,
   recovery: Boolean(walk?.last?.recovery),
   sourceRead: false,
@@ -289,7 +289,7 @@ const fail = (reason, extra = {}) => {
   const rec = {
     command: "test:e2e:installed",
     verdict: "FAIL",
-    productVersion: "0.5.1",
+    productVersion: "0.5.2",
     fromExactDmg: true,
     installer: expectedInstaller,
     installerSha256: installed.installerSha256,
@@ -342,7 +342,7 @@ const canPass =
 const rec = {
   command: "test:e2e:installed",
   verdict: canPass ? "PASS" : "INCOMPLETE",
-  productVersion: "0.5.1",
+  productVersion: "0.5.2",
   fromExactDmg: true,
   installer: expectedInstaller,
   installerSha256: installed.installerSha256,

--- a/scripts/failure-baseline.mjs
+++ b/scripts/failure-baseline.mjs
@@ -146,14 +146,14 @@ async function probeStaleAlpha() {
 function probeVersions() {
   const root = readJson("package.json");
   const info = readJson("release-info.json");
-  const ok = root.version === "0.5.1" && info.productVersion === "0.5.1";
+  const ok = root.version === "0.5.2" && info.productVersion === "0.5.2";
   if (!ok) {
-    return result("FB-VERSIONS", "REPRODUCED", "workspace/release-info not 0.5.1", {
+    return result("FB-VERSIONS", "REPRODUCED", "workspace/release-info not 0.5.2", {
       packageVersion: root.version,
       productVersion: info.productVersion,
     });
   }
-  return result("FB-VERSIONS", "CLOSED", "root and release-info are 0.5.1", { version: root.version });
+  return result("FB-VERSIONS", "CLOSED", "root and release-info are 0.5.2", { version: root.version });
 }
 
 async function probeAggregator() {
@@ -185,9 +185,9 @@ function probePublication() {
   const pub = info.publication ?? {};
   const ok =
     pub.repo === "kevinchennewbee/PenglaiAgent" &&
-    pub.tag === "v0.5.1" &&
-    pub.release === "v0.5.1" &&
-    pub.channel === "stable-v0.5.1";
+    pub.tag === "v0.5.2" &&
+    pub.release === "v0.5.2" &&
+    pub.channel === "stable-v0.5.2";
   if (!ok) {
     return result("FB-PUBLICATION", "REPRODUCED", "publication fields do not match the owner-authorized destination", { pub });
   }
@@ -340,7 +340,7 @@ const dir = join(ROOT, "evidence", "generated");
 mkdirSync(dir, { recursive: true });
 writeFileSync(
   join(dir, "failure-baseline.json"),
-  JSON.stringify({ schema: 3, version: "0.5.1", probes: out, mustClose: MUST_CLOSE }, null, 2),
+  JSON.stringify({ schema: 3, version: "0.5.2", probes: out, mustClose: MUST_CLOSE }, null, 2),
 );
 console.log(
   "failure-baseline",

--- a/scripts/lib/closure-credential.mjs
+++ b/scripts/lib/closure-credential.mjs
@@ -61,7 +61,7 @@ export function inspectClosureCredential({ staging, candidateSha, expectedTarget
   } catch {
     return { verdict: "FAIL", reason: "runtime manifest is malformed" };
   }
-  if (manifest.target !== expectedTarget || manifest.release !== "0.5.1" || manifest.dsh !== "0.1.1-rc.1") {
+  if (manifest.target !== expectedTarget || manifest.release !== "0.5.2" || manifest.dsh !== "0.1.1-rc.1") {
     return { verdict: "FAIL", reason: "runtime manifest identity mismatch" };
   }
   if (!Array.isArray(manifest.files) || manifest.files.length === 0) {

--- a/scripts/lib/installed-app.mjs
+++ b/scripts/lib/installed-app.mjs
@@ -6,8 +6,8 @@ import { tmpdir } from "node:os";
 import { ROOT } from "./repo.mjs";
 import { installerForTarget } from "./release-targets.mjs";
 
-export const ARM64_DMG = join(ROOT, "dist/Penglai_0.5.1_macos_aarch64.dmg");
-export const ARM64_INSTALLER = "Penglai_0.5.1_macos_aarch64.dmg";
+export const ARM64_DMG = join(ROOT, "dist/Penglai_0.5.2_macos_aarch64.dmg");
+export const ARM64_INSTALLER = "Penglai_0.5.2_macos_aarch64.dmg";
 
 export function leftoversByCommand(needle) {
   if (process.platform === "win32") {
@@ -129,7 +129,7 @@ export function readInstalledAppIdentity(app, target) {
 export function assertInstalledPenglaiIdentity(app, target) {
   const facts = readInstalledAppIdentity(app, target);
   if (facts.executable !== "Penglai") return { ok: false, reason: `executable ${facts.executable || "<empty>"}` };
-  if (facts.shortVersion !== "0.5.1" || facts.version !== "0.5.1") {
+  if (facts.shortVersion !== "0.5.2" || facts.version !== "0.5.2") {
     return { ok: false, reason: `version ${facts.shortVersion}/${facts.version}` };
   }
   if (facts.bundleId !== "com.penglai.dsh") return { ok: false, reason: `bundle ${facts.bundleId || "<empty>"}` };

--- a/scripts/lib/packaged-candidate.mjs
+++ b/scripts/lib/packaged-candidate.mjs
@@ -7,18 +7,18 @@ import { CLOSURE_CREDENTIAL_SCHEMA } from "./closure-credential.mjs";
 export const PACKAGED_TARGETS = Object.freeze({
   "darwin-aarch64": Object.freeze({
     buildTarget: "darwin-arm64",
-    appRelative: "dist/Penglai-v0.5.1-arm64-from-dmg/Penglai.app",
-    dmgRelative: "dist/Penglai_0.5.1_macos_aarch64.dmg",
+    appRelative: "dist/Penglai-v0.5.2-arm64-from-dmg/Penglai.app",
+    dmgRelative: "dist/Penglai_0.5.2_macos_aarch64.dmg",
   }),
   "darwin-x86_64": Object.freeze({
     buildTarget: "darwin-x64",
-    appRelative: "dist/Penglai-v0.5.1-x64-from-dmg/Penglai.app",
-    dmgRelative: "dist/Penglai_0.5.1_macos_x64.dmg",
+    appRelative: "dist/Penglai-v0.5.2-x64-from-dmg/Penglai.app",
+    dmgRelative: "dist/Penglai_0.5.2_macos_x64.dmg",
   }),
   "win32-x86_64": Object.freeze({
     buildTarget: "win32-x64",
-    appRelative: "dist/Penglai-v0.5.1-win32-x64/Penglai",
-    dmgRelative: "dist/Penglai_0.5.1_windows_x64_setup.exe",
+    appRelative: "dist/Penglai-v0.5.2-win32-x64/Penglai",
+    dmgRelative: "dist/Penglai_0.5.2_windows_x64_setup.exe",
   }),
 });
 
@@ -107,7 +107,7 @@ export function inspectPackagedCandidate({
   }
   if (
     release.productName !== "Penglai" ||
-    release.productVersion !== "0.5.1" ||
+    release.productVersion !== "0.5.2" ||
     release.generationId !== "penglai-dsh-v0.5" ||
     release.trustTier !== "community-verified" ||
     release.targetPlatform !== spec.buildTarget
@@ -137,7 +137,7 @@ export function inspectPackagedCandidate({
     };
   }
   if (
-    manifest.release !== "0.5.1" ||
+    manifest.release !== "0.5.2" ||
     manifest.target !== expectedTarget ||
     manifest.dsh !== release.dsh ||
     !Array.isArray(manifest.files) ||

--- a/scripts/lib/release-targets.mjs
+++ b/scripts/lib/release-targets.mjs
@@ -1,9 +1,9 @@
 export const RELEASE_TARGETS = Object.freeze(["darwin-aarch64", "darwin-x86_64", "win32-x86_64"]);
 
 export const TARGET_INSTALLERS = Object.freeze({
-  "darwin-aarch64": "Penglai_0.5.1_macos_aarch64.dmg",
-  "darwin-x86_64": "Penglai_0.5.1_macos_x64.dmg",
-  "win32-x86_64": "Penglai_0.5.1_windows_x64_setup.exe",
+  "darwin-aarch64": "Penglai_0.5.2_macos_aarch64.dmg",
+  "darwin-x86_64": "Penglai_0.5.2_macos_x64.dmg",
+  "win32-x86_64": "Penglai_0.5.2_windows_x64_setup.exe",
 });
 
 export function assertReleaseTarget(target) {

--- a/scripts/nsis/Penglai.nsi
+++ b/scripts/nsis/Penglai.nsi
@@ -1,13 +1,13 @@
-; Penglai 0.5.1 current-user NSIS Setup.
+; Penglai 0.5.2 current-user NSIS Setup.
 ; Cross-compiled / compiled only on Windows x64. This source is the contract
 ; for install identity, bilingual UI, default-preserve userData, and
 ; capability-bound complete delete. Native PASS is reserved for win-x64.
 
 !ifndef PENGLAI_VERSION
-  !define PENGLAI_VERSION "0.5.1"
+  !define PENGLAI_VERSION "0.5.2"
 !endif
 !ifndef PENGLAI_OUTFILE
-  !define PENGLAI_OUTFILE "Penglai_0.5.1_windows_x64_setup.exe"
+  !define PENGLAI_OUTFILE "Penglai_0.5.2_windows_x64_setup.exe"
 !endif
 
 Unicode true
@@ -62,7 +62,7 @@ LangString DESC_Desktop ${LANG_ENGLISH} "Desktop shortcut"
 
 Function .onInit
   ${IfNot} ${RunningX64}
-    MessageBox MB_ICONSTOP "Penglai 0.5.1 requires 64-bit Windows."
+    MessageBox MB_ICONSTOP "Penglai 0.5.2 requires 64-bit Windows."
     Abort
   ${EndIf}
   ReadRegStr $0 HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_ID}" "DisplayVersion"

--- a/scripts/nsis/license.rtf
+++ b/scripts/nsis/license.rtf
@@ -1,7 +1,7 @@
 {\rtf1\ansi\ansicpg1252\deff0
 {\fonttbl{\f0 Times New Roman;}}
 \fs24
-Penglai 0.5.1 is community-verified, ad-hoc sealed, and not Authenticode signed.
+Penglai 0.5.2 is community-verified, ad-hoc sealed, and not Authenticode signed.
 Install for the current user only. User data stays under %LOCALAPPDATA%\\Penglai\\0.5
 unless you later confirm a complete-delete capability.
 \par

--- a/scripts/package-mac.mjs
+++ b/scripts/package-mac.mjs
@@ -20,14 +20,14 @@ const targetArg = process.argv.includes("--target")
   : process.env.PENGLAI_PACK_TARGET;
 const TARGETS = {
   "darwin-arm64": {
-    out: "dist/Penglai-v0.5.1-arm64",
-    zip: "dist/Penglai-v0.5.1-arm64.zip",
+    out: "dist/Penglai-v0.5.2-arm64",
+    zip: "dist/Penglai-v0.5.2-arm64.zip",
     triple: "darwin-arm64",
     runtimeTarget: "darwin-aarch64",
   },
   "darwin-x64": {
-    out: "dist/Penglai-v0.5.1-x64",
-    zip: "dist/Penglai-v0.5.1-x64.zip",
+    out: "dist/Penglai-v0.5.2-x64",
+    zip: "dist/Penglai-v0.5.2-x64.zip",
     triple: "darwin-x64",
     runtimeTarget: "darwin-x86_64",
   },
@@ -208,12 +208,12 @@ if (existsSync(framework)) {
 }
 writeFileSync(
   join(outRoot, "README-UNSIGNED.txt"),
-  "Penglai 0.5.1 community release. trustTier=community-verified. Ad-hoc signed, not notarized. Gatekeeper may warn; do not disable system security.\n",
+  "Penglai 0.5.2 community release. trustTier=community-verified. Ad-hoc signed, not notarized. Gatekeeper may warn; do not disable system security.\n",
 );
 
 const info = {
   productName: "Penglai",
-  productVersion: "0.5.1",
+  productVersion: "0.5.2",
   name: targetSpec.out.split("/").pop(),
   buildNumber: 0,
   candidateOrdinal: 0,

--- a/scripts/package-windows-nsis.mjs
+++ b/scripts/package-windows-nsis.mjs
@@ -8,7 +8,7 @@ import { ROOT } from "./lib/repo.mjs";
 import { stagingForTarget } from "./lib/closure-credential.mjs";
 
 const contract = {
-  installer: "Penglai_0.5.1_windows_x64_setup.exe",
+  installer: "Penglai_0.5.2_windows_x64_setup.exe",
   currentUser: true,
   languages: ["zh", "en"],
   refuseDowngrade: true,
@@ -74,7 +74,7 @@ if (!existsSync(out)) {
   console.error("package-windows-nsis FAIL: setup missing after makensis");
   process.exit(1);
 }
-const installedRoot = resolve(ROOT, "dist", "Penglai-v0.5.1-win32-x64");
+const installedRoot = resolve(ROOT, "dist", "Penglai-v0.5.2-win32-x64");
 const installedApp = join(installedRoot, "Penglai");
 const installedRelative = relative(resolve(ROOT, "dist"), installedRoot);
 if (!installedRelative || installedRelative === ".." || installedRelative.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute(installedRelative)) {

--- a/scripts/package-windows-payload.mjs
+++ b/scripts/package-windows-payload.mjs
@@ -117,7 +117,7 @@ if (native) {
     join(resources, "release-info.json"),
     `${JSON.stringify({
       productName: "Penglai",
-      productVersion: "0.5.1",
+      productVersion: "0.5.2",
       buildNumber: 0,
       candidateOrdinal: 0,
       candidateKind: "public-community-release",

--- a/scripts/sbom.mjs
+++ b/scripts/sbom.mjs
@@ -79,10 +79,10 @@ const sbom = {
   specVersion: "1.5",
   version: 1,
   metadata: {
-    component: { type: "application", name: "Penglai", version: "0.5.1" },
-    tools: [{ name: "penglai-sbom", version: "0.5.1" }],
+    component: { type: "application", name: "Penglai", version: "0.5.2" },
+    tools: [{ name: "penglai-sbom", version: "0.5.2" }],
   },
-  release: "0.5.1",
+  release: "0.5.2",
   lockfileSha256: createHash("sha256").update(lock).digest("hex"),
   componentCount: components.length,
   components,

--- a/scripts/soak-installed.mjs
+++ b/scripts/soak-installed.mjs
@@ -56,7 +56,7 @@ const expectedInstaller = installerForTarget(expectedTarget);
 if (process.env.PENGLAI_SOAK_ALLOW_LONG !== "1") {
   finish("INCOMPLETE", {
     command: "test:soak:installed",
-    productVersion: "0.5.1",
+    productVersion: "0.5.2",
     requestedHours: hoursWanted,
     sourceSha: git.head,
     reason:
@@ -344,7 +344,7 @@ const leftover = leftoversByCommand(installedDsh).filter((line) => line.includes
 const elapsedHours = (Date.now() - started) / 3600_000;
 const rec = {
   command: "test:soak:installed",
-  productVersion: "0.5.1",
+  productVersion: "0.5.2",
   hours: elapsedHours,
   requestedHours: hoursWanted,
   samples,

--- a/scripts/stamp-windows-exe.mjs
+++ b/scripts/stamp-windows-exe.mjs
@@ -67,12 +67,12 @@ for (const version of versions) {
     version.setStringValues(language, {
       CompanyName: "Penglai",
       FileDescription: "Penglai",
-      FileVersion: "0.5.1.0",
+      FileVersion: "0.5.2.0",
       InternalName: "Penglai",
       LegalCopyright: "Penglai contributors",
       OriginalFilename: "Penglai.exe",
       ProductName: "Penglai",
-      ProductVersion: "0.5.1.0",
+      ProductVersion: "0.5.2.0",
     });
   }
   version.outputToResourceEntries(resources.entries);

--- a/scripts/u3-first-party-plugins.mjs
+++ b/scripts/u3-first-party-plugins.mjs
@@ -250,7 +250,7 @@ const commonOk = phases.every(
 const activeOk = activePhases.every(
   (phase) =>
     phase.rows.every((row) => row.present && row.enabled && row.phase === "active") &&
-    phase.packages.every((pkg) => pkg.present && pkg.version === "0.5.1"),
+    phase.packages.every((pkg) => pkg.present && pkg.version === "0.5.2"),
 );
 const disabledOk = disabledPhases.every((phase) =>
   phase.rows.every((row) => row.present && !row.enabled && row.phase === null),

--- a/scripts/verify-asr-real.ts
+++ b/scripts/verify-asr-real.ts
@@ -32,7 +32,7 @@ async function fetchFixture(): Promise<Buffer> {
   for (let hop = 0; hop <= 5; hop += 1) {
     const response = await fetch(url, {
       redirect: "manual",
-      headers: { "User-Agent": "Penglai/0.5.1 ASR real verifier" },
+      headers: { "User-Agent": "Penglai/0.5.2 ASR real verifier" },
       signal: AbortSignal.timeout(60_000),
     });
     if ([301, 302, 303, 307, 308].includes(response.status)) {

--- a/scripts/verify-contracts.mjs
+++ b/scripts/verify-contracts.mjs
@@ -109,12 +109,17 @@ if (readme.includes("official DSH 0.1.0-rc.8") || readme.includes("官方 DSH 0.
   process.exit(1);
 }
 if (/Apple Silicon \/ macOS 13\+ only for this candidate/.test(readme) || /本候选仅 Apple Silicon/.test(readme)) {
-  console.error("README still claims 0.5.1 is Apple Silicon only");
+  console.error("README still claims the current release is Apple Silicon only");
   process.exit(1);
 }
 const notes051 = readFileSync(join(ROOT, "docs/RELEASE_NOTES_0.5.1.md"), "utf8");
 if (notes051.includes("0.1.0-rc.8")) {
   console.error("RELEASE_NOTES_0.5.1 still pins rc.8");
+  process.exit(1);
+}
+const notes052 = readFileSync(join(ROOT, "docs/RELEASE_NOTES_0.5.2.md"), "utf8");
+if (!notes052.includes("0.5.1 users") || !notes052.includes("Penglai → Update")) {
+  console.error("RELEASE_NOTES_0.5.2 does not describe the signed 0.5.1 assisted update");
   process.exit(1);
 }
 const findings = readFileSync(join(ROOT, "docs/0.5.1/FINDINGS.md"), "utf8");
@@ -127,4 +132,4 @@ if (!ensure.includes("--target") || ensure.includes("this script has no --arch")
   console.error("ensure-electron is still host-only");
   process.exit(1);
 }
-console.log("verify:contracts ok", PINNED_DSH, "lark 1.73.0", "audio codecs 3.7.1/0.2.0", "release-contract 0.5.1");
+console.log("verify:contracts ok", PINNED_DSH, "lark 1.73.0", "audio codecs 3.7.1/0.2.0", "release-contract 0.5.2");

--- a/scripts/verify-installed.mjs
+++ b/scripts/verify-installed.mjs
@@ -59,14 +59,14 @@ const path = existsSync(join(evidenceDir, evidenceName("installed-e2e", target))
     ? join(evidenceDir, "installed-e2e.json")
     : join(evidenceDir, evidenceName("installed-e2e", target));
 if (!existsSync(path)) {
-  finish("INCOMPLETE", { command: "verify:installed", reason: `no 0.5.1 installed evidence for ${target}`, target });
+  finish("INCOMPLETE", { command: "verify:installed", reason: `no 0.5.2 installed evidence for ${target}`, target });
 }
 const rec = JSON.parse(readFileSync(path, "utf8"));
 const blob = JSON.stringify(rec);
 if (/0\.2\.0-alpha|usable-fixture|sourceRead":true|Penglai-v0\.2\.0/.test(blob)) {
   finish("STALE", { command: "verify:installed", reason: "installed evidence is stale alpha or test-endpoint based" });
 }
-if (rec.productVersion !== "0.5.1" || rec.verdict !== "PASS") {
+if (rec.productVersion !== "0.5.2" || rec.verdict !== "PASS") {
   finish("INCOMPLETE", { command: "verify:installed", reason: "0.5 installed suite not PASS", target });
 }
 const expectedInstaller = installerForTarget(target);

--- a/scripts/verify-live-plugin-catalog.mjs
+++ b/scripts/verify-live-plugin-catalog.mjs
@@ -34,7 +34,7 @@ const shared = {
   cacheRoot: join(root, "cas"),
   trustPath: join(root, "trust-state.json"),
   lastGoodPath: join(root, "last-good-catalog.json"),
-  penglaiVersion: "0.5.1",
+  penglaiVersion: "0.5.2",
   dshExact: "0.1.1-rc.1",
   target: "darwin-aarch64",
   fetchImpl: authenticatedGithubApiFetch,

--- a/scripts/verify-live.mjs
+++ b/scripts/verify-live.mjs
@@ -8,7 +8,7 @@ if (!existsSync(path)) {
   finish("INCOMPLETE", { command: "verify:live", reason: "no 0.5 live evidence" });
 }
 const rec = JSON.parse(readFileSync(path, "utf8"));
-if (rec.productVersion !== "0.5.1") {
-  finish("STALE", { command: "verify:live", reason: "live evidence is not 0.5.1" });
+if (rec.productVersion !== "0.5.2") {
+  finish("STALE", { command: "verify:live", reason: "live evidence is not 0.5.2" });
 }
 finish("INCOMPLETE", { command: "verify:live", reason: "final live is reserved for RC15" });

--- a/scripts/verify-release-keys.mjs
+++ b/scripts/verify-release-keys.mjs
@@ -40,7 +40,7 @@ const pluginMatch =
 if (!updaterMatch || !pluginMatch) {
   finish("FAIL", {
     command: "verify:release-keys",
-    reason: "on-disk public keys do not match embedded 0.5.1 trust roots",
+    reason: "on-disk public keys do not match embedded 0.5.2 trust roots",
     updaterMatch,
     pluginMatch,
   });

--- a/scripts/verify-signing.mjs
+++ b/scripts/verify-signing.mjs
@@ -57,7 +57,7 @@ if (!adhoc) {
   process.exit(1);
 }
 
-const summary = ["Penglai 0.5.1 community-verified ad-hoc contract", `app=${app}`, `sourceSha=${packaged.release.sourceSha}`, `target=${expectedTarget}`, "codesign --verify --deep --strict --verbose=2: PASS", "signatureKind=adhoc", "developerIdSigned=false", "notarized=false", "authenticode=false", display.text.trim()].join("\n");
+const summary = ["Penglai 0.5.2 community-verified ad-hoc contract", `app=${app}`, `sourceSha=${packaged.release.sourceSha}`, `target=${expectedTarget}`, "codesign --verify --deep --strict --verbose=2: PASS", "signatureKind=adhoc", "developerIdSigned=false", "notarized=false", "authenticode=false", display.text.trim()].join("\n");
 mkdirSync(join(ROOT, "dist"), { recursive: true });
 writeFileSync(join(ROOT, "dist/codesign-verification.txt"), `${summary}\n`);
 finish("PASS", {

--- a/scripts/verify-soak.mjs
+++ b/scripts/verify-soak.mjs
@@ -15,7 +15,7 @@ const rec = JSON.parse(readFileSync(path, "utf8"));
 if (/0\.2\.0-alpha|ba5ba3dd|c19e393e/.test(JSON.stringify(rec))) {
   finish("STALE", { command: "verify:soak", reason: "soak evidence bound to stale alpha source/artifact" });
 }
-if (rec.productVersion !== "0.5.1" || rec.hours < 2) {
+if (rec.productVersion !== "0.5.2" || rec.hours < 2) {
   finish("INCOMPLETE", { command: "verify:soak", reason: "exact 0.5 two-hour soak not present" });
 }
 const current = existsSync(dmgPath) ? JSON.parse(readFileSync(dmgPath, "utf8")) : null;

--- a/scripts/verify-versions.mjs
+++ b/scripts/verify-versions.mjs
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { ROOT } from "./lib/repo.mjs";
 import { finish } from "./lib/exit-contract.mjs";
 
-const EXPECT = "0.5.1";
+const EXPECT = "0.5.2";
 const pkgs = [join(ROOT, "package.json"), join(ROOT, "apps/desktop/package.json")];
 for (const name of readdirSync(join(ROOT, "packages"))) {
   pkgs.push(join(ROOT, "packages", name, "package.json"));


### PR DESCRIPTION
## Outcome

Prepares Penglai 0.5.2 as a focused DSH rc.1 onboarding and assisted-update reliability release.

## Fixes

- read rc.1 workspace, session, zstd, and nested credential evidence at the final wizard gate
- persist Back navigation by rewinding the server ledger and dependent facts
- distinguish completion-evidence failures from workspace-jail failures
- recover first-Turn authentication failures back to credential entry
- freeze 0.5.2 identity and three native installer targets while retaining DSH 0.1.1-rc.1

## Verified locally

- unit: 423 PASS
- contract: 62 PASS
- integration: 21 PASS
- desktop e2e: 68 PASS
- security: 15 PASS
- typecheck/build/contracts/dependencies/versions/identity PASS
- clean-room public export: 522 files PASS
- live 0.5.1 DSH evidence reproduced the bug: API test and first official Turn succeeded, but the old final gate rejected rc.1 storage; the fixed gate accepts the same redacted evidence

## Release boundary

No temporary API key is present in Git. Native Apple Silicon, Intel Mac, and Windows x64 installers must be built from the merged clean main SHA. The public 0.5.1 -> 0.5.2 updater drill remains a post-publication hard gate before README/website claims are advanced.