### PR TITLE
fix: show 0.5.2 in packaged welcome notice

### DIFF
--- a/overlays/dsh-0.1.1-rc.1/manifest.json
+++ b/overlays/dsh-0.1.1-rc.1/manifest.json
@@ -22,7 +22,7 @@
       "relative": "node_modules/@deepseek-ai/dsh-client-ui-settings-models/lib/client.js",
       "upstreamSha256": "c3b9a2d2d074c600c10553a4b15e294082f5851dd4a834d06ddb268b310d18de",
       "upstream": "upstream/dsh-client-ui-settings-models.client.js",
-      "patchedSha256": "861ed613961efab2293ad74692bf26fff4b57f76e68a42faefa1053234e32ba0",
+      "patchedSha256": "a333f3e3c0bab986d8384a0c1d8b74873872fc201dd74ac912af979a249d2955",
       "patched": "patched/dsh-client-ui-settings-models.client.js"
     },
     {

--- a/overlays/dsh-0.1.1-rc.1/patched/dsh-client-ui-settings-models.client.js
+++ b/overlays/dsh-0.1.1-rc.1/patched/dsh-client-ui-settings-models.client.js
@@ -2343,17 +2343,17 @@ window.__ModuleLoader__.load({
 		* Bump only when the notice changes materially and every user should see it
 		* again. The acknowledgement is compared for exact equality.
 		*/
-		const WELCOME_NOTICE_VERSION = "penglai-0.5.1.0";
+		const WELCOME_NOTICE_VERSION = "penglai-0.5.2.0";
 		/** The complete editable internal-testing notice in both supported GUI locales. */
 		const WELCOME_NOTICE_COPY = {
 			zh: {
 				title: "欢迎使用蓬莱",
-				body: "欢迎使用蓬莱 0.5.1。对话、工作区、模型和插件都在这一个窗口里完成。\n\nAPI 密钥和即时通讯凭据只保存在本机私有 YAML 文件，不会上传到蓬莱云。本版属于 community-verified：macOS 使用 ad-hoc 签名且未公证；请不要关闭系统安全提示。关于页保留引擎版本和开源归属。",
+				body: "欢迎使用蓬莱 0.5.2。对话、工作区、模型和插件都在这一个窗口里完成。\n\nAPI 密钥和即时通讯凭据只保存在本机私有 YAML 文件，不会上传到蓬莱云。本版属于 community-verified：macOS 使用 ad-hoc 签名且未公证；请不要关闭系统安全提示。关于页保留引擎版本和开源归属。",
 				continueLabel: "开始使用"
 			},
 			en: {
 				title: "Welcome to Penglai",
-				body: "Welcome to Penglai 0.5.1. Chat, workspaces, models, and plugins all live in this window.\n\nAPI keys and messaging credentials stay in an app-private local YAML file on this computer and are not uploaded to a Penglai cloud. This build is community-verified: macOS is ad-hoc signed and not notarized. Do not turn off system security warnings. About preserves engine version and open-source attribution.",
+				body: "Welcome to Penglai 0.5.2. Chat, workspaces, models, and plugins all live in this window.\n\nAPI keys and messaging credentials stay in an app-private local YAML file on this computer and are not uploaded to a Penglai cloud. This build is community-verified: macOS is ad-hoc signed and not notarized. Do not turn off system security warnings. About preserves engine version and open-source attribution.",
 				continueLabel: "Get started"
 			}
 		};

--- a/packages/runtime/src/overlay.test.ts
+++ b/packages/runtime/src/overlay.test.ts
@@ -78,6 +78,11 @@ test("R2I-BRAND-010/011 overlay applies only on exact upstream hash", async () =
     readFileSync(join(dir, htmlRel), "utf8"),
     /penglai-brand\/title\.js/,
   );
+  const welcomeSource = readFileSync(join(dir, welcomeRel), "utf8");
+  assert.match(welcomeSource, /penglai-0\.5\.2\.0/);
+  assert.match(welcomeSource, /欢迎使用蓬莱 0\.5\.2/);
+  assert.match(welcomeSource, /Welcome to Penglai 0\.5\.2/);
+  assert.doesNotMatch(welcomeSource, /欢迎使用蓬莱 0\.5\.1|Welcome to Penglai 0\.5\.1/);
   const hero = readFileSync(join(dir, heroRel), "utf8");
   assert.match(hero, /conversation\.hero\.brand\.mark/);
   assert.doesNotMatch(hero, /data-penglai-hero-wordmark/);
@@ -126,7 +131,7 @@ test("R2I-BRAND-010/011 overlay applies only on exact upstream hash", async () =
   const welcome = readFileSync(join(dir, welcomeRel), "utf8");
   assert.match(welcome, /欢迎使用蓬莱/);
   assert.match(welcome, /Welcome to Penglai/);
-  assert.match(welcome, /penglai-0\.5\.1\.0/);
+  assert.match(welcome, /penglai-0\.5\.2\.0/);
   assert.match(welcome, /YAML/);
   assert.doesNotMatch(welcome, /内测声明/);
   assert.doesNotMatch(welcome, /official DSH Web/);


### PR DESCRIPTION
## Summary
- update the packaged DSH welcome notice to Penglai 0.5.2 in both locales
- bump the durable acknowledgement key so upgraded users see the corrected notice
- pin the new overlay hash and guard against stale 0.5.1 copy

## Verification
- node --test --import tsx packages/runtime/src/overlay.test.ts
- pnpm verify:contracts
- git diff --check

Found by installed Apple Silicon candidate testing after the full onboarding flow reached the official DSH UI.