### PR TITLE
fix: make 0.5.2 release signing entrypoints executable

### DIFF
--- a/packages/plugin-registry/src/signing-entrypoints.test.ts
+++ b/packages/plugin-registry/src/signing-entrypoints.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+test("release signing entrypoints resolve from a source checkout", () => {
+  const root = process.cwd();
+  const home = mkdtempSync(join(tmpdir(), "penglai-signing-entrypoints-"));
+  try {
+    const keyDir = join(home, "Library", "Application Support", "PenglaiReleaseKeys");
+    mkdirSync(keyDir, { recursive: true });
+    const privatePem = generateKeyPairSync("ed25519").privateKey.export({
+      type: "pkcs8",
+      format: "pem",
+    });
+    writeFileSync(join(keyDir, "updater-ed25519-private.pem"), privatePem);
+    writeFileSync(join(keyDir, "plugin-catalog-ed25519-private.pem"), privatePem);
+
+    const cases = [
+      { script: "scripts/sign-update-manifest.mjs", input: "update-manifest-v1.json", bytes: "{}\n" },
+      { script: "scripts/sign-catalog.mjs", input: "catalog.json", bytes: "{}\n" },
+      { script: "scripts/sign-plugin-artifact.mjs", input: "plugin.tgz", bytes: "archive" },
+    ];
+    for (const item of cases) {
+      const input = join(home, item.input);
+      writeFileSync(input, item.bytes);
+      const result = spawnSync(process.execPath, ["--import", "tsx", item.script, input], {
+        cwd: root,
+        env: { ...process.env, HOME: home },
+        encoding: "utf8",
+      });
+      assert.equal(result.status, 0, `${item.script}: ${result.stderr}`);
+      assert.equal(readFileSync(`${input}.sig`).length, 64, item.script);
+    }
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/scripts/sign-catalog.mjs
+++ b/scripts/sign-catalog.mjs
@@ -10,8 +10,11 @@ if (!jsonPath) {
   console.error("usage: node scripts/sign-catalog.mjs <catalog.json>");
   process.exit(2);
 }
-const { canonicalizeBytes, privateKeyFromPem, signBytes } = await import(
-  pathToFileURL(join(ROOT, "packages/plugin-registry/src/index.ts")).href
+const { canonicalizeBytes } = await import(
+  pathToFileURL(join(ROOT, "packages/plugin-registry/src/canonical-json.ts")).href
+);
+const { privateKeyFromPem, signBytes } = await import(
+  pathToFileURL(join(ROOT, "packages/plugin-registry/src/signature.ts")).href
 );
 const json = JSON.parse(readFileSync(jsonPath, "utf8"));
 const signature = signBytes(canonicalizeBytes(json), privateKeyFromPem(readFileSync(keys, "utf8")));

--- a/scripts/sign-plugin-artifact.mjs
+++ b/scripts/sign-plugin-artifact.mjs
@@ -17,7 +17,7 @@ if (!artifactPath || !artifactPath.endsWith(".tgz")) {
   process.exit(2);
 }
 const { privateKeyFromPem, signBytes } = await import(
-  pathToFileURL(join(ROOT, "packages/plugin-registry/src/index.ts")).href
+  pathToFileURL(join(ROOT, "packages/plugin-registry/src/signature.ts")).href
 );
 const signature = signBytes(
   readFileSync(artifactPath),

--- a/scripts/sign-update-manifest.mjs
+++ b/scripts/sign-update-manifest.mjs
@@ -10,8 +10,11 @@ if (!jsonPath) {
   console.error("usage: node scripts/sign-update-manifest.mjs <update-manifest-v1.json>");
   process.exit(2);
 }
+// Import the leaf module directly. Importing src/index.ts makes Node resolve the
+// index's emitted .js specifiers from inside src/, which does not exist in a
+// source checkout even when tsx is registered.
 const { privateKeyFromPem, signBytes } = await import(
-  pathToFileURL(join(ROOT, "packages/plugin-registry/src/index.ts")).href
+  pathToFileURL(join(ROOT, "packages/plugin-registry/src/signature.ts")).href
 );
 const bytes = readFileSync(jsonPath);
 const signature = signBytes(bytes, privateKeyFromPem(readFileSync(keys, "utf8")));


### PR DESCRIPTION
## What\n- import source leaf modules instead of the TypeScript barrel from all three release signers\n- add a real child-process regression that generates temporary Ed25519 keys and exercises catalog, plugin artifact, and update-manifest signing\n\n## Why\nThe documented Node 22 signing command failed in a clean source checkout because `src/index.ts` contains emitted `.js` specifiers that do not exist under `src/`.\n\n## Evidence\n- `pnpm format:check`\n- `pnpm test:unit` (424/424)\n- `pnpm verify:contracts`\n- `pnpm test:security` (15/15)\n- `pnpm audit:secrets`\n- real `pnpm sign:update-manifest <manifest>` completed with a 64-byte detached signature