### PR TITLE
Penglai 0.5.3: close assisted update recovery

### DIFF
--- a/.github/workflows/native-release-candidate.yml
+++ b/.github/workflows/native-release-candidate.yml
@@ -74,6 +74,10 @@ jobs:
           pnpm verify:contracts
       - name: Build exact native installer
         run: pnpm ${{ matrix.package }}
+      - name: Verify packaged Electron fuses
+        env:
+          PENGLAI_TARGET: ${{ matrix.target }}
+        run: pnpm verify:fuses
       - name: Installed welcome and process smoke
         env:
           PENGLAI_TARGET: ${{ matrix.target }}
@@ -134,6 +138,10 @@ jobs:
         run: |
           call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           pnpm package:windows
+      - name: Verify packaged Electron fuses
+        env:
+          PENGLAI_TARGET: win32-x86_64
+        run: pnpm verify:fuses
       - name: Installed welcome and process smoke
         shell: pwsh
         env:

--- a/.github/workflows/native-release-candidate.yml
+++ b/.github/workflows/native-release-candidate.yml
@@ -1,4 +1,4 @@
-name: Native 0.5.2 release candidate
+name: Native 0.5.3 release candidate
 
 on:
   workflow_dispatch:
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: native-0.5.2-${{ github.ref }}
+  group: native-0.5.3-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -41,11 +41,11 @@ jobs:
           - runner: macos-15
             target: darwin-aarch64
             package: package:dmg:arm
-            installer: Penglai_0.5.2_macos_aarch64.dmg
+            installer: Penglai_0.5.3_macos_aarch64.dmg
           - runner: macos-15-intel
             target: darwin-x86_64
             package: package:dmg:intel
-            installer: Penglai_0.5.2_macos_x64.dmg
+            installer: Penglai_0.5.3_macos_x64.dmg
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     steps:
@@ -88,7 +88,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: penglai-0.5.2-${{ matrix.target }}
+          name: penglai-0.5.3-${{ matrix.target }}
           if-no-files-found: error
           retention-days: 14
           path: |
@@ -150,11 +150,11 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: penglai-0.5.2-win32-x86_64
+          name: penglai-0.5.3-win32-x86_64
           if-no-files-found: error
           retention-days: 14
           path: |
-            dist/Penglai_0.5.2_windows_x64_setup.exe
+            dist/Penglai_0.5.3_windows_x64_setup.exe
             evidence/generated/local-installer-win32-x86_64.json
             evidence/generated/u3-welcome-smoke.json
             evidence/generated/u3-first-party-plugins.json

--- a/PRODUCT_CONSTITUTION.md
+++ b/PRODUCT_CONSTITUTION.md
@@ -1,6 +1,6 @@
 # 蓬莱产品宪法
 
-> 生效日期：2026-08-16；2026-08-20 经 Owner 明确修订 0.5.0 首发平台与公开授权；2026-08-21 修订 0.5.1 为 DSH `0.1.1-rc.1` 三端社区验证发行版；2026-08-22 授权 0.5.2 修复首次引导并验收 0.5.1 → 0.5.2 辅助更新。本文是仓库内最高产品约束。用户最新明确指令高于本文；方向改变时必须先同步本文和决策日志，再开始编码。
+> 生效日期：2026-08-16；2026-08-20 经 Owner 明确修订 0.5.0 首发平台与公开授权；2026-08-21 修订 0.5.1 为 DSH `0.1.1-rc.1` 三端社区验证发行版；2026-08-22 发布 0.5.2 后，公开升级演练发现可选 IM 被错误列为 post-verify 硬条件，随后授权 0.5.3 修复并重新验收 0.5.1 → 0.5.3 辅助更新。本文是仓库内最高产品约束。用户最新明确指令高于本文；方向改变时必须先同步本文和决策日志，再开始编码。
 
 ## 一句话定义
 
@@ -23,7 +23,7 @@
 9. **安装包必须自带可运行产品。** 干净 Mac/Windows 不应预装 Node、pnpm、Python、系统 ffmpeg 或 `dsh`。包内固定目标平台运行时、完整 DSH 闭包、profile seed、第一方插件（含语音 native/WASM engines）、许可证、SBOM 与完整性清单；生产禁止静默回退系统 PATH。大型 ASR/TTS 权重可在用户明确操作后按 immutable manifest/hash 按需下载，不得成为 DSH 启动依赖。
 10. **二次开发不得删减 DSH。** Penglai 可以替换产品名、字标、欢迎/引导文案和默认组合，并增加 Center/IM；但 official DSH 的浅色、深色、跟随系统动态主题、中英文切换、Models、Workspace、Session、工具、审批和设置能力必须保留。中文是 fresh install 默认值，不是删除 English。
 11. **安装、升级、卸载是产品能力。** 0.5.0 必须提供 fresh install、首次引导、0.5 系列后续升级、失败恢复和完整卸载/数据管理；升级或卸载不得误删用户 Workspace、旧版本数据或未明确选择的数据类别。
-12. **公开发布只消费精确验收资产。** 0.5.0 已发布边界仍是单一 Apple Silicon DMG。0.5.1 及 0.5.2 声明三个 target：`darwin-aarch64`、`darwin-x86_64`、`win32-x86_64`，必须来自同一 source SHA。缺对应原生 runner 的 Intel/Windows 只能写 `BLOCKED`/`NOT_RUN`，不得写成 native PASS。公开 Release 必须上传验收过的同一 bytes，不能重建偷换。
+12. **公开发布只消费精确验收资产。** 0.5.0 已发布边界仍是单一 Apple Silicon DMG。0.5.1、0.5.2 及 0.5.3 声明三个 target：`darwin-aarch64`、`darwin-x86_64`、`win32-x86_64`，必须来自同一 source SHA。缺对应原生 runner 的 Intel/Windows 只能写 `BLOCKED`/`NOT_RUN`，不得写成 native PASS。公开 Release 必须上传验收过的同一 bytes，不能重建偷换。
 
 插件生态分三层：DSH official core plugins 原样保留；Penglai 原生插件由蓬莱维护并经 Center 事务管理（0.5.0 内置 Center、IM、SenseVoice ASR、MOSS-TTS-Nano、个人上下文、分层记忆、预算与主动陪伴）；社区插件未来只有在来源审核、签名/完整性、权限、兼容、隔离、迁移和回滚门完整后才可加入受控 catalog，绝不等同于任意 npm/Git 安装。
 
@@ -39,8 +39,8 @@
 
 ## 当前发行边界
 
-- 当前目标是 **Penglai v0.5.2** — 以官方 DSH `0.1.1-rc.1` 为唯一核心的三端引导可靠性热修复。机器可读身份只来自 `packages/release-identity/src/pins.ts` 与 `release-contract.json`。
-- 三个 target key 全仓统一：`darwin-aarch64`、`darwin-x86_64`、`win32-x86_64`。用户安装包分别为 `Penglai_0.5.2_macos_aarch64.dmg`、`Penglai_0.5.2_macos_x64.dmg`、`Penglai_0.5.2_windows_x64_setup.exe`。禁止把 ARM Electron 改名成 Intel 包；禁止把 Windows 预检或交叉编译写成 native PASS。
+- 当前目标是 **Penglai v0.5.3** — 以官方 DSH `0.1.1-rc.1` 为唯一核心的三端引导可靠性热修复。机器可读身份只来自 `packages/release-identity/src/pins.ts` 与 `release-contract.json`。
+- 三个 target key 全仓统一：`darwin-aarch64`、`darwin-x86_64`、`win32-x86_64`。用户安装包分别为 `Penglai_0.5.3_macos_aarch64.dmg`、`Penglai_0.5.3_macos_x64.dmg`、`Penglai_0.5.3_windows_x64_setup.exe`。禁止把 ARM Electron 改名成 Intel 包；禁止把 Windows 预检或交叉编译写成 native PASS。
 - 0.5.0 已发布的 Apple Silicon 客户端只能手动覆盖安装到 0.5.1；0.5.1 之后同平台才走 PUDP。不得声称 0.5.0 可一键升级。Intel/Windows 在 0.5.0 没有客户端，视为全新安装。
 - PPDP 是 0.5.1 产品能力，不是未来 TODO：签名目录、受限 GitHub 资产下载、默认禁用、主进程 Owner capability、DSH loader/profile 事务、inventory 回读。
 - 本地语音与第一方插件合同不变：`@penglai/asr`、`@penglai/moss-tts` 必须进入真实 DSH loader/Center，并服务 DSH Web、微信私聊语音和飞书私聊语音。两渠道仍不支持群聊、图片、普通文件、视频或富卡片。`@penglai/context`、`@penglai/memory`、`@penglai/budget`、`@penglai/companion` 同样纳入；Goal/Todo/Skills/MCP/Web/Attachments/Schedule/TokenMeter 使用 official DSH。
@@ -48,7 +48,7 @@
 - 0.4.1 到 0.5.0 是明确的架构代际切换：不提供自动升级，不导入旧会话、凭据或配置，不删除旧数据。0.5.0 使用隔离的数据根 `Penglai/0.5`。0.5.1 必须提供 rc.8 → rc.1 的显式、可回滚数据迁移。
 - community trust tier 不变：macOS ad-hoc / not notarized；Windows 无 Authenticode/SmartScreen 声誉。安装包及更新/插件清单仍须有 SHA-256、SBOM/notices，并诚实提示系统信誉警告。Penglai 自己的 Ed25519 更新/插件签名必须使用。
 - GitHub Actions 与 required CodeQL 当前可用，但不能替代安装包验收。Apple Silicon 本机可产生 darwin-aarch64 候选；Intel 与 Windows 的 native PASS 必须来自对应原生 runner。交叉构建或 Rosetta 只能作为补充证据。
-- Owner 已明确授权完成 0.5.2 修复、三端构建、发布与 0.5.1 → 0.5.2 实际升级验收。仍不得在门禁失败时发布，也不得把本机临时 API key 上传到 GitHub 或写入 evidence。
+- Owner 已明确授权完成 0.5.3 修复、三端构建、发布与 0.5.1 → 0.5.3 实际升级验收。仍不得在门禁失败时发布，也不得把本机临时 API key 上传到 GitHub 或写入 evidence。
 
 ## 反偏航自检
 
@@ -70,7 +70,7 @@
 - 飞书是否用假二维码或用户 OAuth Device Flow 冒充一键扫码，或把官方 `app/registration` 落地页 URL 直接当图片地址？
 - 品牌或中文 overlay 是否隐藏、破坏了 DSH 原有主题、语言、模型、会话、工作区、工具、审批或设置能力？
 - 升级/卸载是否可能静默迁移或删除 0.4.1 数据、用户 Workspace 或未选择的数据类别？
-- 是否把 ad-hoc 安装包写成已公证，或把缺少原生 runner 的 Intel/Windows 写成 0.5.2 已支持？
+- 是否把 ad-hoc 安装包写成已公证，或把缺少原生 runner 的 Intel/Windows 写成 0.5.3 已支持？
 - 是否把下载目录、renderer `confirmed: true` 或未进入 DSH inventory 的包写成插件已启用？
 
 只要存在一个“是”，该候选就不是本产品定义下的蓬莱。

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Penglai Center is a real DSH host/client plugin inside the official DSH settings
 
 Penglai includes PPDP/1, the Penglai Plugin Distribution Protocol. The client can discover versioned GitHub Releases from the public [Penglai Plugin Registry](https://github.com/kevinchennewbee/PenglaiPluginRegistry), verify a Penglai Ed25519 signature and each archive hash, install a package in the disabled state, ask for permission confirmation, and roll back a failed activation.
 
-The first signed catalog is live as the immutable [`plugin-catalog-v1.000001`](https://github.com/kevinchennewbee/PenglaiPluginRegistry/releases/tag/plugin-catalog-v1.000001) Release. The production client has refreshed it from GitHub, verified the catalog and pilot archive, installed the pilot disabled, and recovered the signed last-good catalog offline. Future reviewed DSH plugins can be published in a new catalog sequence without rebuilding the Penglai desktop application.
+The current signed catalog is the immutable [`plugin-catalog-v1.000002`](https://github.com/kevinchennewbee/PenglaiPluginRegistry/releases/tag/plugin-catalog-v1.000002) Release. It keeps the Pilot and adds `@penglai/office-reader` 0.1.0 for bounded, read-only DOCX/XLSX/PPTX extraction. The production client has refreshed it from GitHub, verified both signatures, staged the archive under app-private data, installed it disabled, and recovered the signed last-good catalog offline. Future reviewed DSH plugins can be published in a new catalog sequence without rebuilding the Penglai desktop application.
 
 Penglai Center does not accept arbitrary npm packages, Git repositories, or download URLs. A DSH plugin runs with the local DSH process permissions. Catalog permission fields explain what was reviewed and what the user is confirming; they are not an operating-system sandbox.
 
@@ -251,7 +251,7 @@ Penglai Center 是 official DSH settings 里的真实 host/client 插件。insta
 
 蓬莱包含 PPDP/1，也就是蓬莱插件发行协议。客户端从公开的 [Penglai Plugin Registry](https://github.com/kevinchennewbee/PenglaiPluginRegistry) 查找按版本发布的 GitHub Release，验证蓬莱 Ed25519 签名和每个 tar 包的 SHA。插件先以 disabled 状态安装，用户确认权限后再启用；启用失败会回滚。
 
-第一份签名 catalog 已经作为不可变的 [`plugin-catalog-v1.000001`](https://github.com/kevinchennewbee/PenglaiPluginRegistry/releases/tag/plugin-catalog-v1.000001) Release 发布。生产客户端已经真实完成 GitHub 刷新、catalog 与试点 tar 包验签、disabled 安装，以及断网后的 signed last-good 恢复。以后加入经过审核的 DSH 插件，只需要发布新的 catalog sequence，不需要为了改列表重做桌面客户端。
+当前签名 catalog 是不可变的 [`plugin-catalog-v1.000002`](https://github.com/kevinchennewbee/PenglaiPluginRegistry/releases/tag/plugin-catalog-v1.000002) Release。它保留试航插件，并新增 `@penglai/office-reader` 0.1.0，用于有界、只读地提取 DOCX、XLSX、PPTX。生产客户端已经真实完成 GitHub 刷新、两层验签、用户私有目录 staging、默认关闭安装，以及断网后的 signed last-good 恢复。以后加入经过审核的 DSH 插件，只需要发布新的 catalog sequence，不需要为了改列表重做桌面客户端。
 
 插件中心不接受任意 npm、Git 仓库或下载 URL。DSH 插件与本机 DSH 进程共享权限。catalog 里的 permission 用来说明审核内容和用户正在确认什么，不是操作系统沙箱。
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
   <img src="https://raw.githubusercontent.com/kevinchennewbee/PenglaiAgent/212dd84/.github/assets/banner-v1.png" width="100%" alt="Penglai, an AI island emerging from the mist">
 </p>
 
-<p align="center"><sub>The original Penglai project banner, preserved as part of the project's visual history. The product screenshots below come from the released 0.5.1 installer.</sub></p>
+<p align="center"><sub>The original Penglai project banner, preserved as part of the project's visual history.</sub></p>
 
 <h1 align="center">Penglai · 蓬莱</h1>
 
 <p align="center"><strong>Bring the agent out of the terminal and into the computer you already use.</strong></p>
 
 <p align="center">
-  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.1"><img src="https://img.shields.io/badge/release-0.5.1-2563eb?style=flat-square" alt="Current release 0.5.1"></a>
-  <a href="https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/32507017696"><img src="https://img.shields.io/badge/native%20verification-3%2F3%20PASS-16a34a?style=flat-square" alt="Three native targets verified"></a>
+  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.2"><img src="https://img.shields.io/badge/release-0.5.2-2563eb?style=flat-square" alt="Current release 0.5.2"></a>
+  <a href="https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/32546255748"><img src="https://img.shields.io/badge/native%20verification-3%2F3%20PASS-16a34a?style=flat-square" alt="Three native targets verified"></a>
   <a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://img.shields.io/badge/DSH-0.1.1--rc.1-7c3aed?style=flat-square" alt="DeepSeek Harness 0.1.1-rc.1"></a>
-  <a href="docs/PUBLICATION_0.5.1.md"><img src="https://img.shields.io/badge/desktop-macOS%20arm64%20%7C%20x64%20%7C%20Windows%20x64-0f766e?style=flat-square" alt="Three desktop targets"></a>
+  <a href="docs/PUBLICATION_0.5.2.md"><img src="https://img.shields.io/badge/desktop-macOS%20arm64%20%7C%20x64%20%7C%20Windows%20x64-0f766e?style=flat-square" alt="Three desktop targets"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-16a34a?style=flat-square" alt="MIT License"></a>
 </p>
 
@@ -20,20 +20,12 @@
   <a href="#english">English</a> ·
   <a href="#中文">中文</a> ·
   <a href="https://penglai.pages.dev">Website</a> ·
-  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.1">Current download</a> ·
-  <a href="docs/RELEASE_NOTES_0.5.1.md">0.5.1 notes</a> ·
+  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.2">Current download</a> ·
+  <a href="docs/RELEASE_NOTES_0.5.2.md">0.5.2 notes</a> ·
   <a href="SECURITY.md">Security</a>
 </p>
 
-> Penglai 0.5.1 is released for Apple Silicon, Intel Mac, and Windows x64. All three native jobs installed and exercised the exact published packages from source `6ec35c8...`. The images below were captured again from the released Apple Silicon DMG, not from 0.5.0 or a source dev server.
-
-<p align="center">
-  <img src=".github/assets/0.5.1/welcome.png" width="32%" alt="Penglai 0.5.1 welcome and appearance step">
-  <img src=".github/assets/0.5.1/models.png" width="32%" alt="Penglai 0.5.1 official DeepSeek model selection">
-  <img src=".github/assets/0.5.1/api-key.png" width="32%" alt="Penglai 0.5.1 local API key step with an empty field">
-</p>
-
-<p align="center"><sub>Released 0.5.1 DMG, Apple Silicon, DSH 0.1.1-rc.1. <a href="docs/0.5.1/SCREENSHOTS.md">Capture provenance</a>.</sub></p>
+> Penglai 0.5.2 is released for Apple Silicon, Intel Mac, and Windows x64. All three native jobs installed and exercised the exact packages from source `2273c42...`. A later public 0.5.1 upgrade drill found an update-ledger defect when the optional IM plugin stayed disabled. The installed application still ran, but the update page reported recovery required. The immutable 0.5.2 files have not been replaced; [the correction is documented here](docs/RELEASE_NOTES_0.5.2.md), and the fix is in the 0.5.3 source line.
 
 <a id="english"></a>
 
@@ -61,15 +53,15 @@ This repository is also a record of human and AI collaboration. AI coding tools 
 
 Penglai 0.5.0 was a clean architectural reset around official DSH `0.1.0-rc.8`. It shipped one Apple Silicon DMG on 20 August 2026.
 
-Penglai 0.5.1 was released on 22 August 2026. It updates the core to official DSH `0.1.1-rc.1` and ships three installers from one source commit:
+Penglai 0.5.2 was released on 22 August 2026. It keeps official DSH `0.1.1-rc.1`, repairs the first-run path found during installed testing, and ships three installers from one source commit:
 
-| Platform | 0.5.1 installer | Native result |
+| Platform | 0.5.2 installer | Native result |
 | --- | --- | --- |
-| Apple Silicon, macOS 13+ | [`Penglai_0.5.1_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.1/Penglai_0.5.1_macos_aarch64.dmg) | PASS |
-| Intel Mac | [`Penglai_0.5.1_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.1/Penglai_0.5.1_macos_x64.dmg) | PASS |
-| Windows x64 | [`Penglai_0.5.1_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.1/Penglai_0.5.1_windows_x64_setup.exe) | PASS |
+| Apple Silicon, macOS 13+ | [`Penglai_0.5.2_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.2/Penglai_0.5.2_macos_aarch64.dmg) | PASS |
+| Intel Mac | [`Penglai_0.5.2_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.2/Penglai_0.5.2_macos_x64.dmg) | PASS |
+| Windows x64 | [`Penglai_0.5.2_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.2/Penglai_0.5.2_windows_x64_setup.exe) | PASS |
 
-The source tree passes its format, type, build, unit, contract, integration, desktop E2E, dependency, license, secret, and CodeQL checks. [Native run 32507017696](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/32507017696) separately built, installed, launched, and checked the exact three packages on matching native hosts. Source checks and installed evidence remain separate claims.
+The source tree passes its format, type, build, unit, contract, integration, desktop E2E, dependency, license, secret, and CodeQL checks. [Native run 32546255748](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/32546255748) separately built, installed, launched, and checked the exact three packages on matching native hosts. Source checks and installed evidence remain separate claims.
 
 ## One DSH core, optional Penglai plugins
 
@@ -85,13 +77,13 @@ A fresh profile starts with DSH and Penglai Center. The other Penglai plugins ar
 | `@penglai/budget` | local usage limits based on the official DSH TokenMeter and model route |
 | `@penglai/companion` | opt-in scheduled messages with quiet hours, daily limits, and channel binding |
 
-All seven packages passed the 0.5.1 source suite against DSH rc.1. The exact packaged app on all three native targets then observed every plugin through four runtime phases: fresh default-disabled, all enabled, all enabled after DSH restart, and all disabled after a second restart. Each phase used the official DSH HTTP/WebSocket surface and loader inventory and left no owned process behind. This proves the shipped seven-plugin set across those phases; it does not turn every future plugin or every external service into a tested claim.
+All seven packages passed the 0.5.2 source suite against DSH rc.1. The exact packaged app on all three native targets then observed every plugin through four runtime phases: fresh default-disabled, all enabled, all enabled after DSH restart, and all disabled after a second restart. Each phase used the official DSH HTTP/WebSocket surface and loader inventory and left no owned process behind. This proves the shipped seven-plugin set across those phases; it does not turn every future plugin or every external service into a tested claim.
 
 ## Plugin Center
 
 Penglai Center is a real DSH host/client plugin inside the official DSH settings interface. Installed and active states come from the DSH loader inventory, not from a UI preference or a downloaded filename.
 
-Version 0.5.1 adds PPDP/1, the Penglai Plugin Distribution Protocol. The client can discover versioned GitHub Releases from the public [Penglai Plugin Registry](https://github.com/kevinchennewbee/PenglaiPluginRegistry), verify a Penglai Ed25519 signature and each archive hash, install a package in the disabled state, ask for permission confirmation, and roll back a failed activation.
+Penglai includes PPDP/1, the Penglai Plugin Distribution Protocol. The client can discover versioned GitHub Releases from the public [Penglai Plugin Registry](https://github.com/kevinchennewbee/PenglaiPluginRegistry), verify a Penglai Ed25519 signature and each archive hash, install a package in the disabled state, ask for permission confirmation, and roll back a failed activation.
 
 The first signed catalog is live as the immutable [`plugin-catalog-v1.000001`](https://github.com/kevinchennewbee/PenglaiPluginRegistry/releases/tag/plugin-catalog-v1.000001) Release. The production client has refreshed it from GitHub, verified the catalog and pilot archive, installed the pilot disabled, and recovered the signed last-good catalog offline. Future reviewed DSH plugins can be published in a new catalog sequence without rebuilding the Penglai desktop application.
 
@@ -101,15 +93,15 @@ Penglai Center does not accept arbitrary npm packages, Git repositories, or down
 
 Penglai uses the official DSH model directory, adapters, and local YAML credentials service. It does not keep a separate provider registry or API key store.
 
-The setup flow covers privacy, language and appearance, provider credentials, the official model list, a real API test, Workspace selection, and the first official Turn. DeepSeek's rc.1 adapter includes `deepseek-v4-flash-vision-exp` with text and image input. The 0.5.1 source verifies model discovery and `image_url` attachment serialization; a real installed call with a user-provided key remains a release gate.
+The setup flow covers privacy, language and appearance, provider credentials, the official model list, a real API test, Workspace selection, and the first official Turn. DeepSeek's rc.1 adapter includes `deepseek-v4-flash-vision-exp` with text and image input. For 0.5.2, an installed Apple Silicon package completed a fresh provider setup, two real API tests, Workspace creation, a first official Turn, and entry into the official DSH interface. The temporary credential used for that acceptance is not part of the repository or Release.
 
 ## Install and upgrade
 
-Download the appropriate package from the immutable [Penglai 0.5.1 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.1) and compare it with the published `SHA256SUMS` before installing.
+Download the appropriate package from the immutable [Penglai 0.5.2 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.2) and compare it with the published `SHA256SUMS` before installing.
 
-Penglai 0.5.0 cannot update itself to 0.5.1. Apple Silicon users will install 0.5.1 manually over the existing application; data under the isolated `Penglai/0.5` generation is preserved. Intel Mac and Windows x64 are new installations because 0.5.0 never shipped those packages.
+Penglai 0.5.0 cannot update itself in-app and needs a manual same-platform overlay. Penglai 0.5.1 can discover, download, hash-check, signature-check, and hand off later releases from **Settings → Penglai → Update**. The immutable 0.5.2 package installs and runs, but that path can leave its update ledger in recovery when optional IM remains disabled. Users should install the corrective 0.5.3 package instead. If the 0.5.1 Workspace bug prevents reaching Settings, manually overlay the same-platform package. These paths preserve data under the isolated `Penglai/0.5` generation and external Workspaces.
 
-Penglai 0.5.1 contains PUDP/1, a signed and versioned application-update protocol for later same-platform releases. It uses immutable tagged assets and `update-manifest-v1.json`, never a mutable `latest.json`. Updates require verification and user confirmation. They are not silent.
+Penglai 0.5.1 and later contain PUDP/1, a signed and versioned application-update protocol for later same-platform releases. It uses immutable tagged assets and `update-manifest-v1.json`, never a mutable `latest.json`. Updates require verification and user confirmation. They are not silent. Discovery currently uses GitHub's unauthenticated Releases API, so a shared network that exhausts GitHub's anonymous rate limit must wait for the reset or use the immutable Release page for a manual same-platform overlay.
 
 ## Local data and trust
 
@@ -148,6 +140,8 @@ Penglai has changed architecture more than once. The old versions remain in Git 
 | 0.4 | a TypeScript Host, Pi runtime, Tauri desktop, durable tasks, evidence, and personal context |
 | 0.5.0 | a clean Electron distribution with official DSH as the only agent and Web UI core |
 | 0.5.1 | DSH rc.1, three release targets, signed plugin distribution, and a signed future update path |
+| 0.5.2 | installed first-run repairs and real provider/Turn acceptance; a later upgrade drill exposed the optional-IM post-verification defect |
+| 0.5.3 | update closeout: optional plugins no longer block commit, and a newer manual overlay can clear the superseded 0.5.2 recovery state without inventing a signed ledger |
 
 The useful product ideas can return as DSH plugins. Old databases, credentials, sessions, and execution engines do not automatically cross an architectural generation.
 
@@ -177,7 +171,7 @@ pnpm package:dmg:intel     # native Intel Mac
 pnpm package:windows       # native Windows x64 with MSVC and NSIS
 ```
 
-A successful source build is not release evidence. See [0.5.1 publication contract](docs/PUBLICATION_0.5.1.md), [acceptance registry](docs/ACCEPTANCE.md), and [contributing guide](CONTRIBUTING.md).
+A successful source build is not release evidence. See the [0.5.3 publication contract](docs/PUBLICATION_0.5.3.md), [acceptance registry](docs/ACCEPTANCE.md), and [contributing guide](CONTRIBUTING.md).
 
 ## People, tools, and acknowledgements
 
@@ -225,15 +219,15 @@ Agent loop、模型、工具、审批、Workspace、Session、Turn 和主界面�
 
 Penglai 0.5.0 围绕官方 DSH `0.1.0-rc.8` 重做了整个架构。2026 年 8 月 20 日发布的安装包只有一份 Apple Silicon DMG。
 
-Penglai 0.5.1 已于 2026 年 8 月 22 日发布。它把核心更新到官方 DSH `0.1.1-rc.1`，同一份源码发布三个安装包：
+Penglai 0.5.2 已于 2026 年 8 月 22 日发布。它继续使用官方 DSH `0.1.1-rc.1`，修复真实安装验收发现的首次引导问题，并由同一份源码发布三个安装包：
 
-| 平台 | 0.5.1 安装包 | 原生验收 |
+| 平台 | 0.5.2 安装包 | 原生验收 |
 | --- | --- | --- |
-| Apple Silicon，macOS 13+ | [`Penglai_0.5.1_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.1/Penglai_0.5.1_macos_aarch64.dmg) | PASS |
-| Intel Mac | [`Penglai_0.5.1_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.1/Penglai_0.5.1_macos_x64.dmg) | PASS |
-| Windows x64 | [`Penglai_0.5.1_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.1/Penglai_0.5.1_windows_x64_setup.exe) | PASS |
+| Apple Silicon，macOS 13+ | [`Penglai_0.5.2_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.2/Penglai_0.5.2_macos_aarch64.dmg) | PASS |
+| Intel Mac | [`Penglai_0.5.2_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.2/Penglai_0.5.2_macos_x64.dmg) | PASS |
+| Windows x64 | [`Penglai_0.5.2_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.2/Penglai_0.5.2_windows_x64_setup.exe) | PASS |
 
-源码已经通过格式、类型、构建、单元、契约、集成、桌面 E2E、依赖、许可证、秘密扫描和 CodeQL。[原生运行 32507017696](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/32507017696) 又在对应原生机器上分别构建、安装、启动并检查了三份最终安装包。源码门禁与真实安装证据仍然是两种不同的事实。
+源码已经通过格式、类型、构建、单元、契约、集成、桌面 E2E、依赖、许可证、秘密扫描和 CodeQL。[原生运行 32546255748](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/32546255748) 又在对应原生机器上分别构建、安装、启动并检查了三份最终安装包。源码门禁与真实安装证据仍然是两种不同的事实。
 
 ## 一个 DSH 核心，七个可选插件
 
@@ -249,13 +243,13 @@ Penglai 0.5.1 已于 2026 年 8 月 22 日发布。它把核心更新到官方 D
 | `@penglai/budget` | 根据 official DSH TokenMeter 与模型 route 统计和限制本地用量 |
 | `@penglai/companion` | 默认关闭的定时陪伴，带安静时段、每日上限和渠道绑定 |
 
-七个插件都通过了 DSH rc.1 下的 0.5.1 源码套件。随后，三端最终安装包又分别观察了四个运行阶段：首次启动默认停用、全部启用、重启 DSH 后仍全部启用、全部停用并再次重启。每一阶段都读取 official DSH HTTP/WebSocket 和 loader inventory，并确认没有残留的受管进程。这证明本次随包发布的七插件在这些阶段兼容，不等于替未来插件或所有外部服务做保证。
+七个插件都通过了 DSH rc.1 下的 0.5.2 源码套件。随后，三端最终安装包又分别观察了四个运行阶段：首次启动默认停用、全部启用、重启 DSH 后仍全部启用、全部停用并再次重启。每一阶段都读取 official DSH HTTP/WebSocket 和 loader inventory，并确认没有残留的受管进程。这证明本次随包发布的七插件在这些阶段兼容，不等于替未来插件或所有外部服务做保证。
 
 ## 插件中心怎么更新
 
 Penglai Center 是 official DSH settings 里的真实 host/client 插件。installed 和 active 状态只认 DSH loader inventory，不认 UI 里的开关文字，也不认下载目录里有没有一个文件。
 
-0.5.1 加入 PPDP/1，也就是蓬莱插件发行协议。客户端从公开的 [Penglai Plugin Registry](https://github.com/kevinchennewbee/PenglaiPluginRegistry) 查找按版本发布的 GitHub Release，验证蓬莱 Ed25519 签名和每个 tar 包的 SHA。插件先以 disabled 状态安装，用户确认权限后再启用；启用失败会回滚。
+蓬莱包含 PPDP/1，也就是蓬莱插件发行协议。客户端从公开的 [Penglai Plugin Registry](https://github.com/kevinchennewbee/PenglaiPluginRegistry) 查找按版本发布的 GitHub Release，验证蓬莱 Ed25519 签名和每个 tar 包的 SHA。插件先以 disabled 状态安装，用户确认权限后再启用；启用失败会回滚。
 
 第一份签名 catalog 已经作为不可变的 [`plugin-catalog-v1.000001`](https://github.com/kevinchennewbee/PenglaiPluginRegistry/releases/tag/plugin-catalog-v1.000001) Release 发布。生产客户端已经真实完成 GitHub 刷新、catalog 与试点 tar 包验签、disabled 安装，以及断网后的 signed last-good 恢复。以后加入经过审核的 DSH 插件，只需要发布新的 catalog sequence，不需要为了改列表重做桌面客户端。
 
@@ -265,15 +259,15 @@ Penglai Center 是 official DSH settings 里的真实 host/client 插件。insta
 
 蓬莱使用 official DSH 的模型目录、adapter 和本地 YAML credentials service，不维护第二份 provider 列表或 API Key 仓库。
 
-首次引导包括隐私、语言和外观、provider 凭据、official model list、真实 API test、Workspace 和第一条 official Turn。DSH rc.1 的 DeepSeek adapter 已包含 `deepseek-v4-flash-vision-exp`，支持文本与图片输入。0.5.1 源码已经验证模型发现和 `image_url` 图片附件序列化；使用用户 Key 的真实安装调用仍是发布门禁。
+首次引导包括隐私、语言和外观、provider 凭据、official model list、真实 API test、Workspace 和第一条 official Turn。DSH rc.1 的 DeepSeek adapter 已包含 `deepseek-v4-flash-vision-exp`，支持文本与图片输入。0.5.2 的 Apple Silicon 安装包已经完成全新 provider 配置、两次真实 API test、Workspace 创建、第一条 official Turn，并进入 official DSH 主界面。验收使用的临时凭据不在仓库或 Release 中。
 
 ## 安装与升级
 
-请从不可变的 [Penglai 0.5.1 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.1) 下载对应平台安装包，并用其中的 `SHA256SUMS` 核对文件。
+请从不可变的 [Penglai 0.5.2 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.2) 下载对应平台安装包，并用其中的 `SHA256SUMS` 核对文件。
 
-0.5.0 不能在应用内直接升级到 0.5.1。Apple Silicon 用户需要手动覆盖安装，隔离在 `Penglai/0.5` 下的数据会保留。0.5.0 没有 Intel 与 Windows 客户端，这两个平台安装 0.5.1 属于全新安装。
+0.5.0 不能在应用内直接升级，需要手动覆盖同平台的新版本。0.5.1 可以在 **设置 → 蓬莱 → 更新** 中发现、下载、校验 SHA、验签并交给系统安装器。不可变的 0.5.2 安装包能安装和运行，但当可选 IM 保持关闭时，这条升级路径可能把更新账本留在 recovery 状态；请改用修复该问题的 0.5.3。如果 0.5.1 的 Workspace 误判让用户进不了设置页，请手动覆盖同平台安装包。数据仍保留在 `Penglai/0.5` 隔离目录及外置 Workspace。
 
-0.5.1 包含 PUDP/1，为后续同平台版本提供签名、按版本发布的辅助更新。它读取 immutable tag 下的 `update-manifest-v1.json`，不用可变的 `latest.json`。更新必须先校验，再由用户确认，不会静默替换应用。
+0.5.1 及之后版本包含 PUDP/1，为后续同平台版本提供签名、按版本发布的辅助更新。它读取 immutable tag 下的 `update-manifest-v1.json`，不用可变的 `latest.json`。更新必须先校验，再由用户确认，不会静默替换应用。发现阶段目前使用 GitHub 匿名 Releases API；如果共享网络耗尽匿名额度，需要等 GitHub 重置，或从不可变 Release 页面下载同平台安装包手动覆盖。
 
 ## 本地数据与信任边界
 
@@ -312,6 +306,8 @@ Penglai Desktop (Electron)
 | 0.4 | TypeScript Host、Pi runtime、Tauri 桌面、持久任务、证据和个人上下文 |
 | 0.5.0 | 以 official DSH 为唯一 Agent 与 Web UI 核心的 Electron 发行版 |
 | 0.5.1 | DSH rc.1、三个发行目标、签名插件目录和后续签名更新路径 |
+| 0.5.2 | 真实安装首次引导修复和真实 provider/Turn 验收；后续升级演练发现可选 IM 错误参与 post-verify |
+| 0.5.3 | 修复升级收尾：可选插件不再阻断 commit；真实安装更高版本后，可以纠正旧的 0.5.2 recovery 状态，但不会伪造签名升级账本 |
 
 有价值的产品想法可以重新做成 DSH 插件。旧数据库、凭据、会话和执行引擎不会自动跨架构继承。
 
@@ -341,7 +337,7 @@ pnpm package:dmg:intel     # Intel Mac
 pnpm package:windows       # Windows x64，需要 MSVC 与 NSIS
 ```
 
-源码构建成功不算发布证据。发布流程见 [0.5.1 公开发布合同](docs/PUBLICATION_0.5.1.md)、[验收清单](docs/ACCEPTANCE.md)与[贡献指南](CONTRIBUTING.md)。
+源码构建成功不算发布证据。发布流程见 [0.5.3 公开发布合同](docs/PUBLICATION_0.5.3.md)、[验收清单](docs/ACCEPTANCE.md)与[贡献指南](CONTRIBUTING.md)。
 
 ## 人、工具与致谢
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/desktop",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "main": "dist/electron-main.js",

--- a/apps/desktop/src/desktop.test.ts
+++ b/apps/desktop/src/desktop.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import { UNSIGNED_NOTICE, createDesktopRuntime } from "./main.js";
 import { assertIpcName } from "./preload.js";
@@ -78,6 +79,13 @@ test("startup failure can load the recovery page instead of a blank window", asy
   assert.match(main, /officialVendorConsoleDecision/);
   assert.match(main, /shell\.openExternal/);
   assert.match(main, /setWindowOpenHandler\(\(\{ url \}\) =>/);
+});
+
+test("startup failure tears down owned services before rendering recovery", () => {
+  const source = readFileSync(new URL("./electron-main.ts", import.meta.url), "utf8");
+  const failProbe = source.slice(source.indexOf("const failProbe"), source.indexOf("const failProbe") + 900);
+  assert.match(failProbe, /await stopOwnedServices\(\)/);
+  assert.ok(failProbe.indexOf("await stopOwnedServices()") < failProbe.indexOf("win.loadFile(recovery)"));
 });
 
 test("control shell documents the community trust boundary", async () => {

--- a/apps/desktop/src/electron-main.ts
+++ b/apps/desktop/src/electron-main.ts
@@ -844,7 +844,6 @@ async function main(): Promise<void> {
         profileReady: report.profile.exists,
         pluginsReady: inventory.ok,
         dshHealthy: live.state === "healthy",
-        imHealthy: inventory.im,
         installerCancelled: pendingUpdate.version !== releaseContract.version,
       });
     }

--- a/apps/desktop/src/electron-main.ts
+++ b/apps/desktop/src/electron-main.ts
@@ -390,6 +390,11 @@ async function main(): Promise<void> {
 
   const failProbe = async (reason: string, extra: Record<string, unknown> = {}): Promise<void> => {
     const safe = sanitizeStartupReason(reason);
+    try {
+      await stopOwnedServices();
+    } catch {
+      /* recovery UI must still render after best-effort ownership teardown */
+    }
     const recovery = recoveryPage;
     if (existsSync(recovery)) {
       await win.loadFile(recovery);

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -2,7 +2,7 @@ import { DshSupervisor } from "./supervisor.js";
 
 export const APP_NAME = "Penglai";
 export const UNSIGNED_NOTICE =
-  "Penglai 0.5.2 community release. trustTier=community-verified. macOS ad-hoc, not notarized. Windows no Authenticode. Gatekeeper/SmartScreen may warn. Do not disable system security. DSH plugins share the local DSH process. Updates require user confirmation and are never installed silently.";
+  "Penglai 0.5.3 community release. trustTier=community-verified. macOS ad-hoc, not notarized. Windows no Authenticode. Gatekeeper/SmartScreen may warn. Do not disable system security. DSH plugins share the local DSH process. Updates require user confirmation and are never installed silently.";
 
 export function createDesktopRuntime() {
   const supervisor = new DshSupervisor();

--- a/docs/0.5.3/RELEASE_RUNBOOK.md
+++ b/docs/0.5.3/RELEASE_RUNBOOK.md
@@ -1,0 +1,13 @@
+# Penglai 0.5.3 three-target release runbook
+
+1. From a clean `main` equal to `origin/main`, run every source, contract, security, identity, dependency, export, secret, and release-key gate.
+2. Prove the regression at coordinator level: default-disabled IM commits after all core facts pass; failed core facts remain closed; a newer manual overlay reconciles a superseded 0.5.2 recovery journal without writing a false signed ledger.
+3. On the local Apple Silicon host, install the exact candidate over the retained affected 0.5.2 profile and verify the stale recovery state becomes current. Separately exercise the candidate with the retained completed 0.5.1 data and verify official DSH Web, Workspace, and onboarding facts remain usable.
+4. On native Apple Silicon, Intel Mac, and Windows x64 runners, build the exact installer named in `release-contract.json`; run installed welcome/process and the four-phase seven-plugin compatibility check against that installer.
+5. Collect the three installer bytes without rebuilding. Create `release-manifest.json`, SBOM, notices, public-export manifest, and detached installer signatures. Create and sign `update-manifest-v1.json` with `minimumSourceVersion: 0.5.1`.
+6. Create draft Release `v0.5.3`, upload exactly ten assets, and verify names, sizes, hashes, signatures, source SHA, public-export tree, release-manifest binding, and target architectures. Publish immutable only after every pre-publication gate is green.
+7. Restore the untouched public 0.5.1 Apple Silicon app and completed data. Through its own updater, discover, download, verify, confirm, and install public 0.5.3. Verify installed version, official DSH Web, preserved Workspace/onboarding facts, default-disabled optional plugins, and a `COMMITTED` ledger.
+8. Run remote immutable read-back. Only then update README and the bilingual website with the final links, hashes, run evidence, correction notice, and screenshots from the released 0.5.3 application.
+9. Remove the temporary provider credential from live data and every exact test backup, clear in-memory copies, run the final secret/privacy scan, and ask the owner to revoke the credential.
+
+Any failed hard gate stops publication. Cross-build, source-only, draft, or simulated evidence cannot be reported as public native installed PASS.

--- a/docs/ACCEPTANCE.md
+++ b/docs/ACCEPTANCE.md
@@ -1,8 +1,8 @@
-# Penglai 0.5.2 三端公开版验收合同
+# Penglai 0.5.3 三端公开版验收合同
 
 ## 1. 判定对象与结论
 
-唯一验收对象是一个 exact private `Penglai 0.5.2` release set：同一 clean private source、同一 deterministic public-export tree、Apple Silicon DMG、Intel Mac DMG、Windows x64 Setup、配套 manifests/SBOM/notices、三个目标各自的 native installed/soak evidence 和集中真实 live evidence。三个安装包必须来自同一 source SHA；交叉构建只能作为预检，不能替代对应原生 runner。
+唯一验收对象是一个 exact private `Penglai 0.5.3` release set：同一 clean private source、同一 deterministic public-export tree、Apple Silicon DMG、Intel Mac DMG、Windows x64 Setup、配套 manifests/SBOM/notices、三个目标各自的 native installed/soak evidence 和集中真实 live evidence。三个安装包必须来自同一 source SHA；交叉构建只能作为预检，不能替代对应原生 runner。
 
 允许结论：
 
@@ -14,12 +14,12 @@
 
 ## 2. Evidence 规则
 
-以下每一行都是 Hard。registry由本文机器动态解析；0.5.2 将 Intel Mac 与 Windows x64 纳入正式发行，预期共 **256** 个唯一`R50-*` ID。实现必须动态解析，不能把计数写成散落的完成映射。每个ID必须指向真实runner的具体assertion，包含candidate/source/export/target/artifact/runner native/时间/exit/result digest。不能通过文件名、字符串存在或一个smoke扇出PASS。
+以下每一行都是 Hard。registry由本文机器动态解析；0.5.3 将 Intel Mac 与 Windows x64 纳入正式发行，预期共 **256** 个唯一`R50-*` ID。实现必须动态解析，不能把计数写成散落的完成映射。每个ID必须指向真实runner的具体assertion，包含candidate/source/export/target/artifact/runner native/时间/exit/result digest。不能通过文件名、字符串存在或一个smoke扇出PASS。
 
 平台标记：
 
 - `all`：平台类门禁展开为全部三个目标；非平台类门禁只执行一次源码/聚合检查。
-- `mac-arm`、`mac-x64`、`win-x64`：分别绑定三个 exact native artifact，均参与 0.5.2 PASS。
+- `mac-arm`、`mac-x64`、`win-x64`：分别绑定三个 exact native artifact，均参与 0.5.3 PASS。
 - `live`：真实账户最后集中执行。
 - `aggregate`：release-set/public-export聚合。
 
@@ -29,14 +29,14 @@
 
 | ID | 要求 | Runner |
 | --- | --- | --- |
-| `R50-TRUTH-001` | root/workspace/desktop/profile/plugin/release contract版本全部为0.5.2 | contract/all |
+| `R50-TRUTH-001` | root/workspace/desktop/profile/plugin/release contract版本全部为0.5.3 | contract/all |
 | `R50-TRUTH-002` | candidateKind、trustTier、generation、三个target与三个exact filename一致 | contract/all |
 | `R50-TRUTH-003` | 旧alpha artifact/evidence/READY全部STALE并被verifier拒绝 | failure/all |
 | `R50-TRUTH-004` | UNFROZEN identity不得携带artifact/signature/live/READY | unit/all |
 | `R50-TRUTH-005` | private工作流只有main，无branch/worktree/PR/tag，push为fast-forward | git/aggregate |
 | `R50-TRUTH-006` | candidate freeze时HEAD=origin/main且dirty=false | git/aggregate |
 | `R50-TRUTH-007` | 任一子门FAIL/INCOMPLETE/STALE都使verify:release non-zero | fault/all |
-| `R50-TRUTH-008` | repo=`kevinchennewbee/PenglaiAgent`、tag/release=`v0.5.2`，且发布前updater channel保持未发布 | manifest/aggregate |
+| `R50-TRUTH-008` | repo=`kevinchennewbee/PenglaiAgent`、tag/release=`v0.5.3`，且发布前updater channel保持未发布 | manifest/aggregate |
 
 ### B. DSH唯一核心与 capability parity（8）
 
@@ -61,7 +61,7 @@
 | `R50-UI-004` |light/dark/system三态覆盖全部Penglai UI | visual/all |
 | `R50-UI-005` |system主题运行时变化即时响应并持久 | installed/all |
 | `R50-UI-006` |品牌overlay不阻断DSH导航、Models、Workspace、Session、设置 | parity/all |
-| `R50-UI-007` |About显示0.5.2、DSH/target/trust/data/license准确 | installed/all |
+| `R50-UI-007` |About显示0.5.3、DSH/target/trust/data/license准确 | installed/all |
 | `R50-UI-008` |UI/README不出现已公证、Authenticode或silent auto-update误述 | content/aggregate |
 
 ### D. 首次引导、多API、Workspace与Turn（12）
@@ -232,10 +232,10 @@
 | `R50-UPD-006` |UI显示版本/notes/size/trust/status并明确用户确认 | installed/all |
 | `R50-UPD-007` |安装前drain DSH/IM并建立backup/journal | integration/all |
 | `R50-UPD-008` |macOS打开已验DMG、Windows打开已验Setup，无静默绕过 | installed/all |
-| `R50-UPD-009` |新版本post-verify成功commit，失败rollback/recovery | chaos+installed/all |
+| `R50-UPD-009` |新版本 post-verify 只要求核心 runtime/profile/required-plugin/DSH 健康；IM 等可选插件保持默认停用也必须 commit。失败则 rollback/recovery；只有真实安装了更高版本才可把旧 `RECOVERY_REQUIRED` 账本纠正为 current，且不得伪造签名升级 ledger | chaos+installed/all |
 | `R50-UPD-010` |每个update state crash可重放，inbox/outbox不丢不双发 | chaos/all |
 | `R50-UPD-011` |fixture key/server/test payload不进入production artifact | artifact/all |
-| `R50-UPD-012` |三个native target的0.5.2→test-next valid/failure suites PASS，且 Apple Silicon 公开版0.5.1→公开版0.5.2实装升级 PASS | installed/all |
+| `R50-UPD-012` |三个native target的0.5.3→test-next valid/failure suites PASS，且 Apple Silicon 公开版0.5.1→公开版0.5.3实装升级 PASS | installed/all |
 
 ### O. 卸载、数据管理与legacy隔离（10）
 
@@ -430,4 +430,4 @@
 - 任一平台使用cross/translated/emulated结果冒充native，或Release缺少/多出未验收的三端安装包。
 - verifier INCOMPLETE却exit 0、Hard ID硬编码PASS、旧SHA/evidence复用。
 - ad-hoc候选被称为已公证、Developer ID或系统信任。
-- 未经 Owner 明确授权修改开源仓库或发布0.5.2。
+- 未经 Owner 明确授权修改开源仓库或发布0.5.3。

--- a/docs/PLATFORM_MATRIX.md
+++ b/docs/PLATFORM_MATRIX.md
@@ -1,16 +1,16 @@
-# Penglai 0.5.2 三端平台矩阵
+# Penglai 0.5.3 三端平台矩阵
 
 ## 1. 固定矩阵
 
-0.5.2 声明三个 desktop target。每个 target 的“支持”必须同时包含正确 closure、可安装产物、installed E2E 和 native smoke。缺 runner 时该行是 `BLOCKED`，不是 PASS。
+0.5.3 声明三个 desktop target。每个 target 的“支持”必须同时包含正确 closure、可安装产物、installed E2E 和 native smoke。缺 runner 时该行是 `BLOCKED`，不是 PASS。
 
 | key | OS/arch | 用户安装包 | embedded Node | Electron | final runner |
 | --- | --- | --- | --- | --- | --- |
-| `darwin-aarch64` | macOS 13+ / Apple Silicon | `Penglai_0.5.2_macos_aarch64.dmg` | `node-v22.22.2-darwin-arm64` | pinned darwin-arm64 | Apple Silicon Mac |
-| `darwin-x86_64` | macOS 13+ / Intel | `Penglai_0.5.2_macos_x64.dmg` | `node-v22.22.2-darwin-x64` | pinned darwin-x64 | Intel Mac（Rosetta 不能替代） |
-| `win32-x86_64` | Windows 10+ / x64 | `Penglai_0.5.2_windows_x64_setup.exe` | `node-v22.22.2-win-x64` | pinned win32-x64 | Windows x64 native runner |
+| `darwin-aarch64` | macOS 13+ / Apple Silicon | `Penglai_0.5.3_macos_aarch64.dmg` | `node-v22.22.2-darwin-arm64` | pinned darwin-arm64 | Apple Silicon Mac |
+| `darwin-x86_64` | macOS 13+ / Intel | `Penglai_0.5.3_macos_x64.dmg` | `node-v22.22.2-darwin-x64` | pinned darwin-x64 | Intel Mac（Rosetta 不能替代） |
+| `win32-x86_64` | Windows 10+ / x64 | `Penglai_0.5.3_windows_x64_setup.exe` | `node-v22.22.2-win-x64` | pinned win32-x64 | Windows x64 native runner |
 
-0.5.0 已发布资产仍只有 Apple Silicon DMG。0.5.2 不得把 ARM Electron 改名成 x64，也不得把 Windows 预检写成 native PASS。
+0.5.0 已发布资产仍只有 Apple Silicon DMG。0.5.3 不得把 ARM Electron 改名成 x64，也不得把 Windows 预检写成 native PASS。
 
 `release-info.json` / `MINIMUM_MACOS` / Info.plist `LSMinimumSystemVersion` 一律 `13.0`。打包脚本会把 Electron 默认的 `14.0` 改写为 `13.0`，不得再分叉。
 
@@ -24,7 +24,7 @@ Grok 必须新增单一 `release-contract.json`（具体路径由实现固定）
 {
   "schemaVersion": 1,
   "product": "Penglai",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "candidateKind": "public-community-release",
   "trustTier": "community-verified",
   "electronVersion": "43.4.0",
@@ -35,7 +35,7 @@ Grok 必须新增单一 `release-contract.json`（具体路径由实现固定）
       "key": "darwin-aarch64",
       "platform": "darwin",
       "arch": "arm64",
-      "installer": "Penglai_0.5.2_macos_aarch64.dmg"
+      "installer": "Penglai_0.5.3_macos_aarch64.dmg"
     }
   ]
 }
@@ -134,14 +134,14 @@ Windows 必须用 job object 或等价受测进程树监管，不能只 kill 父
 
 ## 7. 打包器选择门
 
-0.5.2 使用三端受控 pipeline；每个平台仍必须遵守：
+0.5.3 使用三端受控 pipeline；每个平台仍必须遵守：
 
 - Windows后续格式预定为current-user NSIS；Squirrel只可作为官方更新机制研究，不能静默替换用户确认的NSIS Setup。
 - 可以采用electron-builder/NSIS、Forge packager加受控NSIS maker，或继续受控自研pipeline，但必须解释为何更适合，并钉死依赖、下载、checksum、license、hook和安全面。
 - 不允许同时维持两套 canonical maker；旧 `package-mac.mjs` 若保留只能作为被新 contract 调用的实现细节或 historical tool。
 - 选择不得改变 Electron + DSH 产品架构，也不得为了打包迁移回 Tauri 0.4.1。
 
-0.5.2 必须分别在 Apple Silicon、Intel Mac 与 Windows x64 原生 runner 真实生成并验收对应安装包；staging、交叉编译与 Rosetta 不能升级为本版支持声明。
+0.5.3 必须分别在 Apple Silicon、Intel Mac 与 Windows x64 原生 runner 真实生成并验收对应安装包；staging、交叉编译与 Rosetta 不能升级为本版支持声明。
 
 ## 8. 本地 runner 协议
 
@@ -177,7 +177,7 @@ evidence bundle 是内容寻址 tar/zip，包含 runner JSON/JUnit、artifact ha
 12. 执行默认卸载与完整数据删除两条路径，确认 Workspace、授权源目录、legacy data 与未选 local voices/memory 不动。
 13. 只有 feature freeze、短门和 exact artifact 均通过后才开始 offline/sleep/wake/crash/restart/2h soak。
 
-`darwin-aarch64` 在当前机器全量执行。Rosetta 的 x64 结果仍只能标记 `translated=true`，Windows ARM emulation 只能标记 `emulated=true`；二者都不能反向改写 0.5.2 支持矩阵。
+`darwin-aarch64` 在当前机器全量执行。Rosetta 的 x64 结果仍只能标记 `translated=true`，Windows ARM emulation 只能标记 `emulated=true`；二者都不能反向改写 0.5.3 支持矩阵。
 
 ## 10. 平台出错即停的条件
 

--- a/docs/PLUGIN_CENTER.md
+++ b/docs/PLUGIN_CENTER.md
@@ -4,7 +4,7 @@
 
 Plugin Center 是 official DSH Web 的 host/client plugin，UI 注册在 `settings.plugins.tab`。它不是 Electron 外壳里的第二商店，也不是一个只写 `desired.json` 的状态页。
 
-## 2. 0.5.0 catalog
+## 2. 0.5.x 内置 catalog
 
 只允许 app 内签入并离线验证的包：
 
@@ -28,7 +28,13 @@ Plugin Center 是 official DSH Web 的 host/client plugin，UI 注册在 `settin
 - `penglai-first-party`：0.5真实交付ASR/MOSS-TTS/Context/Memory/Budget/Companion；以后蓬莱原生能力也只有完整实现和验收后才进入 catalog。
 - `community-reviewed`：未来优质社区插件，必须经过来源与许可证审核、作者/package identity、签名或受信 checksum、权限、DSH range、平台/ABI、sandbox、安全测试、migration 和 rollback。
 
-0.5.0 的数据模型、来源 badge 和 policy engine 要为后两类留正确扩展点，但本版不联网检索插件、不接受任意 npm/Git/URL、不展示空卡。语音模型下载是已签入插件的固定数据资产管理，不等于远程安装插件代码。
+内置 catalog 不接受任意 npm/Git/URL，也不展示空卡。语音模型下载是已签入插件的固定数据资产管理，不等于远程安装插件代码。
+
+## 2.2 签名远程 catalog
+
+0.5.1 起，Center 只从公开仓库 `kevinchennewbee/PenglaiPluginRegistry` 的不可变 GitHub Release 发现远程插件。目录 JSON 与每个 tar 包分别使用内置 Ed25519 信任根验签；sequence 只能前进，断网时只读已验签的 last-good。远程包默认关闭，用户确认权限后才安装；包先写入用户私有的 `Penglai/0.5/plugins/packages`，不得修改应用内置插件目录。
+
+当前不可变目录是 `plugin-catalog-v1.000002`。其中 `@penglai/office-reader` 0.1.0 只读提取 DOCX/XLSX/PPTX，声明 `workspace.read`，无网络、原生代码、安装脚本或宏执行。它不是完整 Office 编辑套件，公式只报告不计算，布局、图表和图片不冒充已还原。以后发布兼容的新目录 sequence 不需要重做 Penglai 客户端。
 
 安装包离线携带这些 tarball 是为了让普通用户无需联网取代码即可选择扩展，不代表它们已安装。完成 BYOK 后 official DSH 必须独立可用；fresh profile 只安装 Center，其他扩展在用户点击“安装并启用”后才校验、写入、加载。任一可选插件 absent/disabled/unconfigured 都不得阻断 DSH core、已安装 IM 的 text 链或无关插件。
 

--- a/docs/PUBLICATION_0.5.2.md
+++ b/docs/PUBLICATION_0.5.2.md
@@ -1,5 +1,7 @@
 # PenglaiAgent 0.5.2 publication contract
 
+> **Post-release audit result:** the public update drill contradicted this contract after immutable publication. Installation reached 0.5.2 and DSH started, but the ledger ended in `RECOVERY_REQUIRED / POST_VERIFY_FAILED` because optional IM was disabled. The immutable Release is retained as published; 0.5.3 carries the fix and the completed replacement gate. Statements below describe the intended 0.5.2 gate and must not be read as evidence that it passed.
+
 0.5.2 is a three-target hotfix release of official DSH `0.1.1-rc.1`. Publication is authorized only after the merged clean `main` SHA produces native-verified Apple Silicon, Intel Mac, and Windows x64 installers and the exact release set is signed, published immutable, and read back from GitHub.
 
 The required installers are:

--- a/docs/PUBLICATION_0.5.3.md
+++ b/docs/PUBLICATION_0.5.3.md
@@ -1,0 +1,20 @@
+# PenglaiAgent 0.5.3 publication contract
+
+0.5.3 is a three-target update-closeout hotfix on official DSH `0.1.1-rc.1`. Publication is authorized only after one clean merged `main` SHA produces native-verified Apple Silicon, Intel Mac, and Windows x64 installers and the exact release set is signed, published immutable, and read back from GitHub.
+
+The required installers are:
+
+- `Penglai_0.5.3_macos_aarch64.dmg`
+- `Penglai_0.5.3_macos_x64.dmg`
+- `Penglai_0.5.3_windows_x64_setup.exe`
+
+Hard evidence includes the complete source suites, clean public export, native installer architecture and identity, installed welcome/process smoke, the four-phase seven-plugin compatibility gate, detached installer signatures, signed update manifest, exact asset hashes, and immutable remote read-back. A cross-build cannot replace an Intel or Windows native runner.
+
+The update-specific gates are:
+
+1. post-verification commits when IM and all other optional Penglai plugins remain disabled but the required DSH credentials and Penglai Center inventory is healthy;
+2. any failed runtime-integrity, profile, required-plugin, or DSH-health fact still fails closed;
+3. installing 0.5.3 over a profile left in 0.5.2 `RECOVERY_REQUIRED / POST_VERIFY_FAILED` reconciles the superseded journal without fabricating a signed 0.5.3 ledger;
+4. after publication, an untouched public 0.5.1 client discovers the highest stable 0.5.3 Release, downloads and verifies the matching asset, requires explicit confirmation, preserves data and Workspace, launches 0.5.3, and writes a `COMMITTED` ledger.
+
+The temporary provider key used for Apple Silicon onboarding acceptance must never enter source, screenshots, evidence, CI, GitHub, or the final local profile. macOS remains ad-hoc and not notarized. Windows remains without Authenticode. README and website claims must name these limits and must not promote source-only evidence into installed or native proof.

--- a/docs/PUBLICATION_MANIFEST_0.5.2.md
+++ b/docs/PUBLICATION_MANIFEST_0.5.2.md
@@ -1,6 +1,8 @@
 # PUBLICATION_MANIFEST 0.5.2
 
-Status: `UNFROZEN`
+Status: `PUBLISHED_WITH_POST_VERIFY_DEFECT`
+
+The immutable v0.5.2 bytes are preserved. A real public 0.5.1 assisted-update drill installed and launched 0.5.2 but ended in `RECOVERY_REQUIRED / POST_VERIFY_FAILED` because the optional IM plugin was incorrectly required by post-verification. See `RELEASE_NOTES_0.5.2.md` and the 0.5.3 replacement contract.
 
 | Field | Value |
 | --- | --- |

--- a/docs/PUBLICATION_MANIFEST_0.5.3.md
+++ b/docs/PUBLICATION_MANIFEST_0.5.3.md
@@ -1,0 +1,26 @@
+# PUBLICATION_MANIFEST 0.5.3
+
+Status: `UNFROZEN`
+
+| Field | Value |
+| --- | --- |
+| productVersion | `0.5.3` |
+| DSH | `0.1.1-rc.1` |
+| trustTier | `community-verified` |
+| source SHA | `UNFROZEN` |
+| publicExportTreeSha256 | `UNFROZEN` |
+| repository | `kevinchennewbee/PenglaiAgent` |
+| tag / Release | `v0.5.3` |
+| publication channel | `stable-v0.5.3` |
+
+| Target | Exact installer | Native result | SHA-256 |
+| --- | --- | --- | --- |
+| Apple Silicon | `Penglai_0.5.3_macos_aarch64.dmg` | NOT_RUN | UNFROZEN |
+| Intel Mac | `Penglai_0.5.3_macos_x64.dmg` | NOT_RUN | UNFROZEN |
+| Windows x64 | `Penglai_0.5.3_windows_x64_setup.exe` | NOT_RUN | UNFROZEN |
+
+The immutable Release must contain exactly those three installers plus `update-manifest-v1.json`, `update-manifest-v1.json.sig`, `release-manifest.json`, `SBOM.cdx.json`, `THIRD_PARTY_NOTICES.txt`, `SHA256SUMS`, and `public-export-manifest.json`.
+
+The update manifest must declare version `0.5.3`, release tag `v0.5.3`, all three exact target assets, and minimum source version `0.5.1`. It must bind each asset's GitHub asset ID, size, SHA-256, detached signature, source identity, public-export tree, and release-manifest digest.
+
+This file may move from `UNFROZEN` only after the exact merged-main bytes and native evidence are known. It must not predict hashes or PASS results.

--- a/docs/RELEASE_NOTES_0.5.2.md
+++ b/docs/RELEASE_NOTES_0.5.2.md
@@ -1,5 +1,7 @@
 # Penglai 0.5.2
 
+> **Post-release correction:** the immutable 0.5.2 application installs and runs, but an assisted 0.5.1 → 0.5.2 update can record `POST_VERIFY_FAILED` after installation when the optional Penglai IM plugin is left disabled. The updater incorrectly treated that optional plugin as a post-install hard gate. The published 0.5.2 bytes have not been replaced. Use 0.5.3 or later; if 0.5.2 already shows recovery required, manually overlay the same-platform newer package once.
+
 Penglai 0.5.2 is a focused onboarding and update-reliability release. It keeps official DeepSeek Harness `0.1.1-rc.1` as the only core and ships the same three community-verified targets: `darwin-aarch64`, `darwin-x86_64`, and `win32-x86_64`.
 
 ## Fixed
@@ -11,7 +13,7 @@ Penglai 0.5.2 is a focused onboarding and update-reliability release. It keeps o
 
 ## Upgrade
 
-Penglai 0.5.1 users can open **Penglai → Update**, choose **Check for updates**, download the signed 0.5.2 installer, and confirm the normal system installer. The updater enumerates stable immutable GitHub Releases, verifies the Penglai Ed25519 signature and exact installer hash, and never installs silently. User data under the `Penglai/0.5` generation and external Workspaces are preserved.
+Penglai 0.5.1 can discover, verify, download, and hand off the signed 0.5.2 installer, but the post-install ledger defect described above prevents 0.5.2 from being the recommended target. Install the highest later stable release instead. User data under the `Penglai/0.5` generation and external Workspaces are preserved.
 
 Penglai 0.5.0 still requires a manual 0.5.2 overlay on Apple Silicon because 0.5.0 did not contain this production update trust path. Intel Mac and Windows x64 users can install 0.5.2 directly.
 

--- a/docs/RELEASE_NOTES_0.5.3.md
+++ b/docs/RELEASE_NOTES_0.5.3.md
@@ -8,6 +8,7 @@ Penglai 0.5.3 is an update-closeout hotfix. It keeps official DeepSeek Harness `
 - A later manual overlay can reconcile a stale `RECOVERY_REQUIRED` journal from an older failed post-verification attempt. It records the installed newer version as current without inventing a signed update ledger, then allows future update checks again.
 - Signed remote plugin archives now stage under the app-private `Penglai/0.5/plugins/packages` tree. The application-bundled plugin directory remains read-only, and remote install/update rechecks package identity and SHA-256 before an atomic stage.
 - Windows packaging now writes and verifies the same Electron fuse policy as macOS: RunAsNode, `NODE_OPTIONS`, and CLI inspect are disabled in the packaged `Penglai.exe`. All three native release jobs inspect the final packaged binary.
+- Startup recovery now tears down the owned proxy and DSH process before showing the local recovery page. App-private persistence and memory directories are created owner-only, and budget reservation cleanup treats `%` and `_` in official session ids literally instead of as SQL wildcards.
 - Regression coverage proves both the default-disabled IM path and recovery of a superseded 0.5.2 journal.
 
 ## Office Reader plugin

--- a/docs/RELEASE_NOTES_0.5.3.md
+++ b/docs/RELEASE_NOTES_0.5.3.md
@@ -1,0 +1,28 @@
+# Penglai 0.5.3
+
+Penglai 0.5.3 is an update-closeout hotfix. It keeps official DeepSeek Harness `0.1.1-rc.1` as the only core and ships `darwin-aarch64`, `darwin-x86_64`, and `win32-x86_64` packages from one source commit.
+
+## Fixed
+
+- Upgrade post-verification no longer requires the optional Penglai IM plugin to be enabled. The hard gate now matches the product contract: embedded runtime integrity, profile readiness, required DSH credentials and Penglai Center inventory, and a healthy DSH process must pass; optional plugins may remain disabled.
+- A later manual overlay can reconcile a stale `RECOVERY_REQUIRED` journal from an older failed post-verification attempt. It records the installed newer version as current without inventing a signed update ledger, then allows future update checks again.
+- Regression coverage proves both the default-disabled IM path and recovery of a superseded 0.5.2 journal.
+
+## 0.5.2 correction
+
+The immutable 0.5.2 packages install and run, but a 0.5.1 → 0.5.2 assisted update can finish installation and then record `POST_VERIFY_FAILED` when Penglai IM is left at its default disabled state. The 0.5.2 bytes are immutable and have not been replaced. Users in that state should manually overlay 0.5.3; 0.5.3 recognizes that the failed 0.5.2 journal has been superseded and restores the update page to a usable current state.
+
+## Upgrade paths
+
+- **0.5.1 users:** use **Settings → Penglai → Update** to install the highest stable release, or manually overlay 0.5.3 if the 0.5.1 Workspace bug prevents reaching Settings.
+- **0.5.2 installed directly:** use the same update page normally.
+- **0.5.2 showing recovery required after an assisted update:** manually overlay the same-platform 0.5.3 package once.
+- **0.5.0:** manually overlay 0.5.3; 0.5.0 has no production updater trust path.
+
+All paths preserve the `Penglai/0.5` data generation and external Workspaces. The updater verifies the Penglai Ed25519 signature and exact installer hash; there is no silent auto-update. Discovery uses GitHub's anonymous Releases API, so a shared network that exhausts GitHub's anonymous rate limit must wait for the reset or use the immutable Release page for the manual overlay. Normal uninstall preserves application data unless the user separately confirms an exact deletion plan.
+
+## Trust and platform limits
+
+This remains a `community-verified` release. macOS packages are ad-hoc signed and not notarized; Windows is not Authenticode signed. Gatekeeper or SmartScreen may warn. Do not disable system security.
+
+The Plugin Center remains independent of desktop releases: another compatible, Penglai-signed catalog generation or DSH plugin archive can be published through the public [Penglai Plugin Registry](https://github.com/kevinchennewbee/PenglaiPluginRegistry) without rebuilding the client.

--- a/docs/RELEASE_NOTES_0.5.3.md
+++ b/docs/RELEASE_NOTES_0.5.3.md
@@ -6,7 +6,13 @@ Penglai 0.5.3 is an update-closeout hotfix. It keeps official DeepSeek Harness `
 
 - Upgrade post-verification no longer requires the optional Penglai IM plugin to be enabled. The hard gate now matches the product contract: embedded runtime integrity, profile readiness, required DSH credentials and Penglai Center inventory, and a healthy DSH process must pass; optional plugins may remain disabled.
 - A later manual overlay can reconcile a stale `RECOVERY_REQUIRED` journal from an older failed post-verification attempt. It records the installed newer version as current without inventing a signed update ledger, then allows future update checks again.
+- Signed remote plugin archives now stage under the app-private `Penglai/0.5/plugins/packages` tree. The application-bundled plugin directory remains read-only, and remote install/update rechecks package identity and SHA-256 before an atomic stage.
+- Windows packaging now writes and verifies the same Electron fuse policy as macOS: RunAsNode, `NODE_OPTIONS`, and CLI inspect are disabled in the packaged `Penglai.exe`. All three native release jobs inspect the final packaged binary.
 - Regression coverage proves both the default-disabled IM path and recovery of a superseded 0.5.2 journal.
+
+## Office Reader plugin
+
+The immutable signed catalog [`plugin-catalog-v1.000002`](https://github.com/kevinchennewbee/PenglaiPluginRegistry/releases/tag/plugin-catalog-v1.000002) adds `@penglai/office-reader` 0.1.0. It is a deliberately read-only first release: bounded text and cell extraction for DOCX, XLSX, and PPTX through the official DSH filesystem, with no network, native code, install scripts, or macro execution. It remains disabled until the owner confirms `workspace.read` in Plugin Center. Publishing later compatible catalog sequences does not require another desktop release.
 
 ## 0.5.2 correction
 
@@ -25,4 +31,4 @@ All paths preserve the `Penglai/0.5` data generation and external Workspaces. Th
 
 This remains a `community-verified` release. macOS packages are ad-hoc signed and not notarized; Windows is not Authenticode signed. Gatekeeper or SmartScreen may warn. Do not disable system security.
 
-The Plugin Center remains independent of desktop releases: another compatible, Penglai-signed catalog generation or DSH plugin archive can be published through the public [Penglai Plugin Registry](https://github.com/kevinchennewbee/PenglaiPluginRegistry) without rebuilding the client.
+The Plugin Center remains independent of desktop releases: another compatible, Penglai-signed catalog generation or DSH plugin archive can be published through the public [Penglai Plugin Registry](https://github.com/kevinchennewbee/PenglaiPluginRegistry) without rebuilding the client. Catalog 2 has passed production-path GitHub refresh, catalog and package signature verification, app-private staging, disabled-by-default installation, and offline last-good recovery.

--- a/docs/UPDATE_UNINSTALL.md
+++ b/docs/UPDATE_UNINSTALL.md
@@ -4,8 +4,8 @@
 
 本合同覆盖：
 
-- 0.5.2 在 Apple Silicon、Intel Mac 与 Windows x64 的 fresh install、首次启动与恢复。
-- 公开版 0.5.1 → 0.5.2 的更新发现、签名验证、用户确认和 assisted install。
+- 0.5.3 在 Apple Silicon、Intel Mac 与 Windows x64 的 fresh install、首次启动与恢复。
+- 公开版 0.5.1 → 0.5.3 的更新发现、签名验证、用户确认和 assisted install。
 - profile/plugin/IM schema 的事务迁移与失败恢复。
 - Windows 原生卸载器和 macOS 应用内卸载准备/数据管理。
 - 0.4.1 旧架构的只读检测与 clean-generation 提示。
@@ -89,7 +89,7 @@ NOT_STARTED
 {
   "schemaVersion": 1,
   "channel": "desktop-v0.5",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "publishedAt": "...",
   "minimumVersion": "0.5.0",
   "notesUrl": "...",
@@ -157,7 +157,7 @@ Electron官方说明macOS autoUpdater需要已签名app。当前0.5 community ca
 
 - loopback-only update server。
 - ephemeral test signing key；private fixture key 只在测试临时目录生成，不提交。
-- `0.5.2-test.N` payload，包含可识别版本但不含产品 secret。
+- `0.5.3-test.N` payload，包含可识别版本但不含产品 secret。
 - valid、tampered payload、wrong key、wrong arch、rollback、same version、truncated download、disconnect/resume、disk full、installer cancel、crash between every journal transition。
 
 fixture 不能通过 `/penglai/usable-fixture` 暴露给 production renderer。test-only entry 必须在 build-time test target 中编译隔离，release bundle scanner 证明不存在。

--- a/overlays/dsh-0.1.1-rc.1/manifest.json
+++ b/overlays/dsh-0.1.1-rc.1/manifest.json
@@ -22,7 +22,7 @@
       "relative": "node_modules/@deepseek-ai/dsh-client-ui-settings-models/lib/client.js",
       "upstreamSha256": "c3b9a2d2d074c600c10553a4b15e294082f5851dd4a834d06ddb268b310d18de",
       "upstream": "upstream/dsh-client-ui-settings-models.client.js",
-      "patchedSha256": "a333f3e3c0bab986d8384a0c1d8b74873872fc201dd74ac912af979a249d2955",
+      "patchedSha256": "3eb8138c8e2342e6d69ec217a7e6d09d14f12f6fbfb59d3810435ecdd8a04ec6",
       "patched": "patched/dsh-client-ui-settings-models.client.js"
     },
     {

--- a/overlays/dsh-0.1.1-rc.1/patched/dsh-client-ui-settings-models.client.js
+++ b/overlays/dsh-0.1.1-rc.1/patched/dsh-client-ui-settings-models.client.js
@@ -2343,17 +2343,17 @@ window.__ModuleLoader__.load({
 		* Bump only when the notice changes materially and every user should see it
 		* again. The acknowledgement is compared for exact equality.
 		*/
-		const WELCOME_NOTICE_VERSION = "penglai-0.5.2.0";
+		const WELCOME_NOTICE_VERSION = "penglai-0.5.3.0";
 		/** The complete editable internal-testing notice in both supported GUI locales. */
 		const WELCOME_NOTICE_COPY = {
 			zh: {
 				title: "欢迎使用蓬莱",
-				body: "欢迎使用蓬莱 0.5.2。对话、工作区、模型和插件都在这一个窗口里完成。\n\nAPI 密钥和即时通讯凭据只保存在本机私有 YAML 文件，不会上传到蓬莱云。本版属于 community-verified：macOS 使用 ad-hoc 签名且未公证；请不要关闭系统安全提示。关于页保留引擎版本和开源归属。",
+				body: "欢迎使用蓬莱 0.5.3。对话、工作区、模型和插件都在这一个窗口里完成。\n\nAPI 密钥和即时通讯凭据只保存在本机私有 YAML 文件，不会上传到蓬莱云。本版属于 community-verified：macOS 使用 ad-hoc 签名且未公证；请不要关闭系统安全提示。关于页保留引擎版本和开源归属。",
 				continueLabel: "开始使用"
 			},
 			en: {
 				title: "Welcome to Penglai",
-				body: "Welcome to Penglai 0.5.2. Chat, workspaces, models, and plugins all live in this window.\n\nAPI keys and messaging credentials stay in an app-private local YAML file on this computer and are not uploaded to a Penglai cloud. This build is community-verified: macOS is ad-hoc signed and not notarized. Do not turn off system security warnings. About preserves engine version and open-source attribution.",
+				body: "Welcome to Penglai 0.5.3. Chat, workspaces, models, and plugins all live in this window.\n\nAPI keys and messaging credentials stay in an app-private local YAML file on this computer and are not uploaded to a Penglai cloud. This build is community-verified: macOS is ad-hoc signed and not notarized. Do not turn off system security warnings. About preserves engine version and open-source attribution.",
 				continueLabel: "Get started"
 			}
 		};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "penglai-v2",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.14.0",

--- a/packages/asr/package.json
+++ b/packages/asr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/asr",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/asr/src/models.ts
+++ b/packages/asr/src/models.ts
@@ -599,7 +599,7 @@ export class AsrModelManager {
       existing = info.size;
     }
     const headers: Record<string, string> = {
-      "User-Agent": "Penglai/0.5.2 model-manager",
+      "User-Agent": "Penglai/0.5.3 model-manager",
     };
     if (existing) headers.Range = `bytes=${existing}-`;
     const response = await this.fetchPinned(file.url, headers, signal);

--- a/packages/audio-codecs/package.json
+++ b/packages/audio-codecs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/audio-codecs",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/audio-codecs/src/index.ts
+++ b/packages/audio-codecs/src/index.ts
@@ -292,7 +292,7 @@ function opusHead(preSkip: number): Buffer {
 }
 
 function opusTags(): Buffer {
-  const vendor = Buffer.from("Penglai 0.5.2", "utf8");
+  const vendor = Buffer.from("Penglai 0.5.3", "utf8");
   const out = Buffer.alloc(8 + 4 + vendor.length + 4);
   out.write("OpusTags", 0);
   out.writeUInt32LE(vendor.length, 8);

--- a/packages/budget/package.json
+++ b/packages/budget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/budget",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/budget/src/ledger-release.test.ts
+++ b/packages/budget/src/ledger-release.test.ts
@@ -21,3 +21,23 @@ test("P51-BUDGET-001 releaseTurn audits reservations instead of forgetting them"
   const kept = ledger.db.prepare("SELECT COUNT(*) AS c FROM budget_releases").get() as { c: number };
   assert.equal(Number(kept.c), 1);
 });
+
+test("releaseTurn treats percent and underscore in session ids literally", () => {
+  const dir = mkdtempSync(join(tmpdir(), "penglai-budget-rel-literal-"));
+  const ledger = new BudgetLedger(join(dir, "ledger.sqlite3"));
+  const now = Date.now();
+  for (const reservationKey of ["s%:1:1", "safe:1:1", "s_:1:1", "solo:1:1"]) {
+    ledger.admit(
+      {
+        reservationKey,
+        estimatedTokens: 1,
+        identity: { provider: "deepseek", model: "chat" },
+      },
+      now,
+    );
+  }
+  assert.equal(ledger.releaseTurn("s%", 1), 1);
+  assert.equal(ledger.releaseTurn("s_", 1), 1);
+  const remaining = ledger.db.prepare("SELECT reservation_key FROM budget_reservations ORDER BY reservation_key").all() as Array<{ reservation_key: string }>;
+  assert.deepEqual(remaining.map((row) => row.reservation_key), ["safe:1:1", "solo:1:1"]);
+});

--- a/packages/budget/src/ledger.ts
+++ b/packages/budget/src/ledger.ts
@@ -372,9 +372,9 @@ export class BudgetLedger {
     return this.inTransaction(() => {
       const rows = this.db
         .prepare(
-          "SELECT reservation_key AS reservationKey, day, workspace_id AS workspaceId, provider, model, estimated_tokens AS estimatedTokens FROM budget_reservations WHERE reservation_key LIKE ?",
+          "SELECT reservation_key AS reservationKey, day, workspace_id AS workspaceId, provider, model, estimated_tokens AS estimatedTokens FROM budget_reservations WHERE substr(reservation_key,1,?)=?",
         )
-        .all(`${prefix}%`) as Array<{
+        .all(prefix.length, prefix) as Array<{
         reservationKey: string;
         day: string;
         workspaceId: string | null;

--- a/packages/channel-feishu/package.json
+++ b/packages/channel-feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/channel-feishu",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/channel-mock/package.json
+++ b/packages/channel-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/channel-mock",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/channel-weixin/package.json
+++ b/packages/channel-weixin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/channel-weixin",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/channel-weixin/src/protocol.ts
+++ b/packages/channel-weixin/src/protocol.ts
@@ -6,7 +6,7 @@ export const ILINK_BASE = "https://ilinkai.weixin.qq.com";
 export const ILINK_CDN_BASE = "https://novac2c.cdn.weixin.qq.com/c2c";
 export const DEFAULT_ILINK_BOT_TYPE = "3";
 export const ILINK_APP_ID = "bot";
-export const ILINK_BOT_AGENT = "Penglai/0.5.2";
+export const ILINK_BOT_AGENT = "Penglai/0.5.3";
 /** Exact Tencent channel package pinned by docs/compatibility/WEIXIN_R2.md. */
 export const ILINK_CHANNEL_VERSION = "2.4.6";
 /** 0x00MMNNPP, matching Tencent's buildClientVersion("2.4.6"). */

--- a/packages/channel-weixin/src/weixin.test.ts
+++ b/packages/channel-weixin/src/weixin.test.ts
@@ -300,7 +300,7 @@ test("ilink client maps endpoints and never logs token", async () => {
   assert.ok(seen.every((s) => s.clientVersion === "132102"));
   for (const request of seen.filter((s) => s.body)) {
     const body = JSON.parse(request.body!) as { base_info?: { channel_version?: string; bot_agent?: string } };
-    assert.deepEqual(body.base_info, { channel_version: "2.4.6", bot_agent: "Penglai/0.5.2" });
+    assert.deepEqual(body.base_info, { channel_version: "2.4.6", bot_agent: "Penglai/0.5.3" });
     assert.match(Buffer.from(request.wechatUin!, "base64").toString("utf8"), /^\d+$/);
   }
 });

--- a/packages/companion/package.json
+++ b/packages/companion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/companion",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/context",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/contracts",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/contracts/src/i18n.ts
+++ b/packages/contracts/src/i18n.ts
@@ -9,7 +9,7 @@ export const PENGLAI_I18N = {
     asrTitle: "蓬莱语音识别",
     ttsTitle: "蓬莱语音合成",
     aboutTitle: "关于蓬莱",
-    aboutVersion: "版本 0.5.2",
+    aboutVersion: "版本 0.5.3",
     aboutDsh: "核心：DeepSeek Harness 0.1.1-rc.1",
     aboutTrust: "社区验证发行：macOS ad-hoc 未公证，Windows 无 Authenticode。不是静默自动更新。DSH 插件与本地 DSH 进程共享权限；蓬莱只分发逐版本审核并签名的插件。权限字段不是操作系统沙箱。",
     aboutData: "数据位于本机 Penglai/0.5，密钥写入 app-private YAML。",
@@ -39,7 +39,7 @@ export const PENGLAI_I18N = {
     updateTitle: "更新",
     uninstallTitle: "存储与卸载",
     pluginSharedProcess: "DSH 插件与本地 DSH 进程共享权限；权限列表用于审核与确认，不是沙箱。",
-    pluginNoArbitraryInstall: "0.5.2 只安装蓬莱签名目录中的插件，不提供任意 URL、npm 或 Git 安装。",
+    pluginNoArbitraryInstall: "0.5.3 只安装蓬莱签名目录中的插件，不提供任意 URL、npm 或 Git 安装。",
   },
   en: {
     appName: "Penglai",
@@ -49,7 +49,7 @@ export const PENGLAI_I18N = {
     asrTitle: "Penglai Speech Recognition",
     ttsTitle: "Penglai Speech Synthesis",
     aboutTitle: "About Penglai",
-    aboutVersion: "Version 0.5.2",
+    aboutVersion: "Version 0.5.3",
     aboutDsh: "Core: DeepSeek Harness 0.1.1-rc.1",
     aboutTrust: "Community-verified: macOS ad-hoc not notarized, Windows no Authenticode. This is not silent auto-update. DSH plugins share the local DSH process; Penglai only distributes version-reviewed signed plugins. Permission fields are not an OS sandbox.",
     aboutData: "Data stays in local Penglai/0.5. Secrets use app-private YAML.",
@@ -80,7 +80,7 @@ export const PENGLAI_I18N = {
     updateTitle: "Updates",
     uninstallTitle: "Storage and uninstall",
     pluginSharedProcess: "DSH plugins share the local DSH process. Permission lists are for review and confirmation, not a sandbox.",
-    pluginNoArbitraryInstall: "0.5.2 installs only plugins from the Penglai-signed catalog. Arbitrary URL, npm, or Git install is not offered.",
+    pluginNoArbitraryInstall: "0.5.3 installs only plugins from the Penglai-signed catalog. Arbitrary URL, npm, or Git install is not offered.",
   },
 } as const;
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -3,7 +3,7 @@ export * from "./i18n.js";
 export * from "./typert.js";
 
 export const SCHEMA_VERSION = 11;
-export const RELEASE = "0.5.2";
+export const RELEASE = "0.5.3";
 
 export const CONFIG = Object.freeze({
   pairingTtlMs: 5 * 60_000,

--- a/packages/dsh-bridge/package.json
+++ b/packages/dsh-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/dsh-bridge",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/im/package.json
+++ b/packages/im/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/im",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/local-control/package.json
+++ b/packages/local-control/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/local-control",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/local-control/src/index.ts
+++ b/packages/local-control/src/index.ts
@@ -64,7 +64,7 @@ export async function startControlServer(
         return;
       }
       if (req.url === "/health") {
-        res.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify({ ok: true, release: "0.5.2" }));
+        res.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify({ ok: true, release: "0.5.3" }));
         return;
       }
       const hdr = String(req.headers["x-penglai-token"] ?? "");

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/memory",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/memory/src/service.ts
+++ b/packages/memory/src/service.ts
@@ -64,7 +64,7 @@ export function createMemoryService(store?: MemoryStore): MemoryService {
     const rows = new Map<number, MemoryWrite & { id: number }>();
     return {
       name: "@penglai/memory",
-      version: "0.5.2",
+      version: "0.5.3",
       assertReadable,
       modelCannotWriteGlobal,
       write(input) {
@@ -109,7 +109,7 @@ export function createMemoryService(store?: MemoryStore): MemoryService {
   }
   const service: MemoryService = {
     name: "@penglai/memory",
-    version: "0.5.2",
+    version: "0.5.3",
     assertReadable,
     modelCannotWriteGlobal,
     write(input, receipt = "manual") {

--- a/packages/memory/src/store.ts
+++ b/packages/memory/src/store.ts
@@ -42,7 +42,7 @@ export class MemoryStore {
   readonly db: DatabaseSync;
 
   constructor(path: string) {
-    mkdirSync(dirname(path), { recursive: true });
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
     this.db = new DatabaseSync(path);
     this.migrate();
   }

--- a/packages/moss-tts/package.json
+++ b/packages/moss-tts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/moss-tts",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/moss-tts/src/models.ts
+++ b/packages/moss-tts/src/models.ts
@@ -535,7 +535,7 @@ export class TtsModelManager {
       }
       existing = info.size;
     }
-    const headers: Record<string, string> = { "User-Agent": "Penglai/0.5.2 model-manager" };
+    const headers: Record<string, string> = { "User-Agent": "Penglai/0.5.3 model-manager" };
     const validator = op.validators?.[file.path];
     if (existing) {
       headers.Range = `bytes=${existing}-`;

--- a/packages/persistence/package.json
+++ b/packages/persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/persistence",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/persistence/src/index.ts
+++ b/packages/persistence/src/index.ts
@@ -249,7 +249,7 @@ export class Store {
   readonly db: DatabaseSync;
   private closed = false;
   constructor(readonly path: string) {
-    if (path !== ":memory:") mkdirSync(dirname(path), { recursive: true });
+    if (path !== ":memory:") mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
     this.db = new DatabaseSync(path);
     this.db.exec("PRAGMA journal_mode = WAL;");
     this.db.exec("PRAGMA foreign_keys = ON;");

--- a/packages/plugin-center/package.json
+++ b/packages/plugin-center/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/plugin-center",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/plugin-center/src/center.test.ts
+++ b/packages/plugin-center/src/center.test.ts
@@ -644,7 +644,7 @@ test("R50-CENTER-006 desired enabled cannot impersonate loaded/active", () => {
   const host = hostWith({ list: () => [] });
   host.setDesired("@penglai/im", true);
   const im = host.reconcile().find((r) => r.id === "@penglai/im");
-  assert.equal(im?.desired, "0.5.2");
+  assert.equal(im?.desired, "0.5.3");
   assert.equal(im?.loaded, false);
   assert.equal(im?.actual, "failed");
   assert.equal(im?.healthy, false);

--- a/packages/plugin-center/src/index.ts
+++ b/packages/plugin-center/src/index.ts
@@ -518,6 +518,7 @@ export function apply(ctx: {
   const dir = join(userData, "plugins");
   const inventory = ctx.pluginInventory;
   const profileDir = join(userData, "dsh-home", "profiles", "web");
+  const registryPackagesDir = join(userData, "plugins", "packages");
   const pluginsDir = process.env.PENGLAI_PLUGINS_DIR;
   if (!pluginsDir) {
     throw new PenglaiError(
@@ -642,12 +643,8 @@ export function apply(ctx: {
     profileDir,
     txDir,
     pluginsDir,
+    registryPackagesDir,
     userDataRoot: userData,
-    async stagePackage(pkg) {
-      const bytes = readFileSync(pkg.path);
-      const catalogName = `${pkg.id.replace("@", "").replaceAll("/", "-")}-${pkg.version}.tgz`;
-      writeFileSync(join(pluginsDir, catalogName), bytes, { mode: 0o600 });
-    },
   });
   const welcomeAck = (): boolean => {
     try {

--- a/packages/plugin-center/src/onboarding-wizard.test.ts
+++ b/packages/plugin-center/src/onboarding-wizard.test.ts
@@ -307,7 +307,7 @@ test("completeWelcome writes penglai welcomeNoticeVersion then advances welcome-
   assert.deepEqual(ops, [
     { ns: "ui-onboarding", path: ["welcomeNoticeVersion"], value: PENGLAI_WELCOME_NOTICE_VERSION },
   ]);
-  assert.equal(PENGLAI_WELCOME_NOTICE_VERSION, "penglai-0.5.2.0");
+  assert.equal(PENGLAI_WELCOME_NOTICE_VERSION, "penglai-0.5.3.0");
   const again = await impl.completeWelcome();
   assert.equal(again.current, "appearance-locale-v1");
   assert.equal(ops.length, 2);

--- a/packages/plugin-center/src/onboarding.ts
+++ b/packages/plugin-center/src/onboarding.ts
@@ -73,7 +73,7 @@ export const OFFICIAL_THEME_SETTINGS_NS = "ui-theme" as const;
 export const OFFICIAL_SETTINGS_PREFERENCE_FIELD = "preference" as const;
 export const OFFICIAL_WELCOME_SETTINGS_NS = "ui-onboarding" as const;
 export const OFFICIAL_WELCOME_ACK_FIELD = "welcomeNoticeVersion" as const;
-export const PENGLAI_WELCOME_NOTICE_VERSION = "penglai-0.5.2.0" as const;
+export const PENGLAI_WELCOME_NOTICE_VERSION = "penglai-0.5.3.0" as const;
 
 export const ONBOARDING_STEPS = [
   "welcome-v1",

--- a/packages/plugin-center/src/remotes-security.test.ts
+++ b/packages/plugin-center/src/remotes-security.test.ts
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import test from "node:test";
 import { join } from "node:path";
@@ -12,14 +19,22 @@ const TEST_CATALOG: PluginCatalogEntry[] = R2_CATALOG.map((entry) => ({
   ...entry,
   sha256: "a".repeat(64),
   target: "darwin-arm64",
-  hasClient: ["@penglai/plugin-center", "@penglai/im", "@penglai/asr", "@penglai/moss-tts"].includes(entry.id),
+  hasClient: [
+    "@penglai/plugin-center",
+    "@penglai/im",
+    "@penglai/asr",
+    "@penglai/moss-tts",
+  ].includes(entry.id),
 }));
 
 function remoteFor(userDataRoot: string) {
   return createCenterRemote({
     host: {
       reconcile: () => [],
-      desired: () => Object.fromEntries(TEST_CATALOG.map((entry) => [entry.id, entry.defaultEnabled])),
+      desired: () =>
+        Object.fromEntries(
+          TEST_CATALOG.map((entry) => [entry.id, entry.defaultEnabled]),
+        ),
       setDesired: () => undefined,
       entries: () => TEST_CATALOG,
     },
@@ -74,7 +89,10 @@ test("DSH Center remote cannot open installers or plan filesystem deletion", asy
     "update",
   ]);
   await assert.rejects(
-    () => (remote.refreshRegistry as (input?: unknown) => Promise<unknown>)({ url: "https://evil.example/catalog.json" }),
+    () =>
+      (remote.refreshRegistry as (input?: unknown) => Promise<unknown>)({
+        url: "https://evil.example/catalog.json",
+      }),
     /renderer URL|public key|signingKeyId|arbitrary/,
   );
 });
@@ -86,23 +104,62 @@ test("signed remote package stages only in the app-private registry root", () =>
   const sha256 = createHash("sha256").update(bytes).digest("hex");
   writeFileSync(cached, bytes, { mode: 0o600 });
   const entry = {
-    ...TEST_CATALOG[0]!, id: "@penglai/office-reader", version: "0.1.0",
-    packageFile: "penglai-office-reader-0.1.0.tgz", source: "penglai-plugin-registry" as const, sha256,
+    ...TEST_CATALOG[0]!,
+    id: "@penglai/office-reader",
+    version: "0.1.0",
+    packageFile: "penglai-office-reader-0.1.0.tgz",
+    source: "penglai-plugin-registry" as const,
+    sha256,
   };
-  const pkg = { id: entry.id, version: entry.version, sha256, size: bytes.length, path: cached } as never;
+  const pkg = {
+    id: entry.id,
+    version: entry.version,
+    sha256,
+    size: bytes.length,
+    path: cached,
+  } as never;
   const destination = stageRegistryPackage({ pkg, entry, userDataRoot: root });
-  assert.equal(destination, join(root, "plugins", "packages", entry.packageFile));
+  assert.equal(
+    destination,
+    join(root, "plugins", "packages", entry.packageFile),
+  );
   assert.deepEqual(readFileSync(destination), bytes);
-  assert.equal(existsSync(join(root, "bundled-read-only", entry.packageFile)), false);
+  assert.equal(
+    existsSync(join(root, "bundled-read-only", entry.packageFile)),
+    false,
+  );
+  const linkedPackage = join(root, "linked-package.tgz");
+  symlinkSync(cached, linkedPackage);
   assert.throws(
-    () => stageRegistryPackage({ pkg, entry, userDataRoot: root, registryPackagesDir: join(root, "..", "escaped") }),
+    () =>
+      stageRegistryPackage({
+        pkg: { ...pkg, path: linkedPackage },
+        entry,
+        userDataRoot: root,
+      }),
+    /regular cached file/,
+  );
+  assert.throws(
+    () =>
+      stageRegistryPackage({
+        pkg,
+        entry,
+        userDataRoot: root,
+        registryPackagesDir: join(root, "..", "escaped"),
+      }),
     /escaped userData/,
   );
   const linkedRoot = mkdtempSync(join(tmpdir(), "penglai-registry-linked-"));
   mkdirSync(join(root, "linked"), { recursive: true });
   symlinkSync(linkedRoot, join(root, "linked", "packages"));
   assert.throws(
-    () => stageRegistryPackage({ pkg, entry, userDataRoot: root, registryPackagesDir: join(root, "linked", "packages") }),
+    () =>
+      stageRegistryPackage({
+        pkg,
+        entry,
+        userDataRoot: root,
+        registryPackagesDir: join(root, "linked", "packages"),
+      }),
     /symlink|outside userData/,
   );
 });

--- a/packages/plugin-center/src/remotes-security.test.ts
+++ b/packages/plugin-center/src/remotes-security.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import test from "node:test";
 import { join } from "node:path";
-import { createCenterRemote } from "./remotes.js";
+import { createCenterRemote, stageRegistryPackage } from "./remotes.js";
 import { R2_CATALOG } from "./index.js";
 import type { PluginCatalogEntry } from "@penglai/runtime";
 
@@ -73,5 +76,33 @@ test("DSH Center remote cannot open installers or plan filesystem deletion", asy
   await assert.rejects(
     () => (remote.refreshRegistry as (input?: unknown) => Promise<unknown>)({ url: "https://evil.example/catalog.json" }),
     /renderer URL|public key|signingKeyId|arbitrary/,
+  );
+});
+
+test("signed remote package stages only in the app-private registry root", () => {
+  const root = mkdtempSync(join(tmpdir(), "penglai-registry-stage-"));
+  const cached = join(root, "cache.tgz");
+  const bytes = Buffer.from("signed-registry-package");
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  writeFileSync(cached, bytes, { mode: 0o600 });
+  const entry = {
+    ...TEST_CATALOG[0]!, id: "@penglai/office-reader", version: "0.1.0",
+    packageFile: "penglai-office-reader-0.1.0.tgz", source: "penglai-plugin-registry" as const, sha256,
+  };
+  const pkg = { id: entry.id, version: entry.version, sha256, size: bytes.length, path: cached } as never;
+  const destination = stageRegistryPackage({ pkg, entry, userDataRoot: root });
+  assert.equal(destination, join(root, "plugins", "packages", entry.packageFile));
+  assert.deepEqual(readFileSync(destination), bytes);
+  assert.equal(existsSync(join(root, "bundled-read-only", entry.packageFile)), false);
+  assert.throws(
+    () => stageRegistryPackage({ pkg, entry, userDataRoot: root, registryPackagesDir: join(root, "..", "escaped") }),
+    /escaped userData/,
+  );
+  const linkedRoot = mkdtempSync(join(tmpdir(), "penglai-registry-linked-"));
+  mkdirSync(join(root, "linked"), { recursive: true });
+  symlinkSync(linkedRoot, join(root, "linked", "packages"));
+  assert.throws(
+    () => stageRegistryPackage({ pkg, entry, userDataRoot: root, registryPackagesDir: join(root, "linked", "packages") }),
+    /symlink|outside userData/,
   );
 });

--- a/packages/plugin-center/src/remotes.ts
+++ b/packages/plugin-center/src/remotes.ts
@@ -1,5 +1,6 @@
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { createHash, randomUUID } from "node:crypto";
+import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import { Remote, TypertRemoteService } from "@deepseek-ai/dsh-typert-protocol";
 import type { Context } from "@deepseek-ai/cordis";
 import { PenglaiError, t } from "@penglai/contracts";
@@ -153,6 +154,60 @@ function previousEnabledFromJournal(txDir: string, id: string): boolean {
   return raw.previousEnabled;
 }
 
+function isUnder(root: string, candidate: string): boolean {
+  const rel = relative(resolve(root), resolve(candidate));
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function registryPackageRoot(userDataRoot: string, configured: string | undefined): string {
+  const root = configured ?? join(userDataRoot, "plugins", "packages");
+  if (!isAbsolute(root) || !isUnder(userDataRoot, root) || resolve(root) === resolve(userDataRoot)) {
+    throw new PenglaiError("SECURITY_POLICY", "registry package directory escaped userData");
+  }
+  mkdirSync(root, { recursive: true, mode: 0o700 });
+  if (lstatSync(root).isSymbolicLink()) {
+    throw new PenglaiError("SECURITY_POLICY", "registry package directory must not be a symlink");
+  }
+  if (!isUnder(realpathSync(userDataRoot), realpathSync(root))) {
+    throw new PenglaiError("SECURITY_POLICY", "registry package directory resolved outside userData");
+  }
+  return root;
+}
+
+export function stageRegistryPackage(input: {
+  pkg: CachedPackage;
+  entry: PluginCatalogEntry;
+  userDataRoot: string;
+  registryPackagesDir?: string;
+}): string {
+  const root = registryPackageRoot(input.userDataRoot, input.registryPackagesDir);
+  if (input.entry.source !== "penglai-plugin-registry") {
+    throw new PenglaiError("SECURITY_POLICY", "only registry packages may enter the mutable package root");
+  }
+  if (input.pkg.id !== input.entry.id || input.pkg.version !== input.entry.version || input.pkg.sha256 !== input.entry.sha256) {
+    throw new PenglaiError("SECURITY_POLICY", "downloaded package identity mismatch");
+  }
+  if (!existsSync(input.pkg.path) || !lstatSync(input.pkg.path).isFile() || lstatSync(input.pkg.path).isSymbolicLink()) {
+    throw new PenglaiError("SECURITY_POLICY", "downloaded package must be a regular cached file");
+  }
+  const bytes = readFileSync(input.pkg.path);
+  if (createHash("sha256").update(bytes).digest("hex") !== input.entry.sha256) {
+    throw new PenglaiError("SECURITY_POLICY", "downloaded package checksum mismatch");
+  }
+  const destination = join(root, input.entry.packageFile);
+  if (!isUnder(root, destination)) {
+    throw new PenglaiError("SECURITY_POLICY", "registry package escaped mutable package root");
+  }
+  const temp = `${destination}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(temp, bytes, { mode: 0o600, flag: "wx" });
+    renameSync(temp, destination);
+  } finally {
+    rmSync(temp, { force: true });
+  }
+  return destination;
+}
+
 export function createCenterRemote(opts: {
   host: CenterHostLike;
   inventory: { list(): unknown };
@@ -161,10 +216,12 @@ export function createCenterRemote(opts: {
   resourceProbe: (id: string) => ResourceProbe | undefined;
   profileDir: string;
   txDir: string;
+  /** Read-only packages shipped inside the application. */
   pluginsDir: string;
+  /** Mutable, app-private packages downloaded from the signed registry. */
+  registryPackagesDir?: string;
   userDataRoot: string;
   registry?: PluginDistributionClient;
-  stagePackage?: (pkg: CachedPackage) => Promise<void>;
   target?: ProductPluginTarget;
 }): CenterRemote {
   const hostTarget = (): ProductPluginTarget => opts.target ?? runtimePluginTarget();
@@ -200,7 +257,9 @@ export function createCenterRemote(opts: {
       userDataRoot: opts.userDataRoot,
       profileDir: opts.profileDir,
       txDir: opts.txDir,
-      pluginsDir: opts.pluginsDir,
+      pluginsDir: entry.source === "penglai-plugin-registry"
+        ? registryPackageRoot(opts.userDataRoot, opts.registryPackagesDir)
+        : opts.pluginsDir,
       entry,
       action,
       previousEnabled,
@@ -284,8 +343,14 @@ export function createCenterRemote(opts: {
     disable(id: string) {
       return transact(id, "disable");
     },
-    update(id: string, capabilityId?: string) {
+    async update(id: string, capabilityId?: string) {
       requireOwner(id, "plugin-update", capabilityId);
+      const entry = catalogEntry(opts.catalog, id, opts.registry, hostTarget());
+      if (entry.source === "penglai-plugin-registry") {
+        if (!opts.registry) throw new PenglaiError("INVALID_INPUT", "remote plugin registry is not configured");
+        const pkg = await opts.registry.downloadPackage(id, hostTarget());
+        stageRegistryPackage({ pkg, entry, userDataRoot: opts.userDataRoot, ...(opts.registryPackagesDir ? { registryPackagesDir: opts.registryPackagesDir } : {}) });
+      }
       return transact(id, "update");
     },
     async refreshRegistry() {
@@ -319,7 +384,8 @@ export function createCenterRemote(opts: {
       if (!opts.registry) throw new PenglaiError("INVALID_INPUT", "remote plugin registry is not configured");
       requireOwner(id, "plugin-install", capabilityId);
       const pkg = await opts.registry.downloadPackage(id, hostTarget());
-      await opts.stagePackage?.(pkg);
+      const entry = catalogEntry(opts.catalog, id, opts.registry, hostTarget());
+      stageRegistryPackage({ pkg, entry, userDataRoot: opts.userDataRoot, ...(opts.registryPackagesDir ? { registryPackagesDir: opts.registryPackagesDir } : {}) });
       const installed = await transact(id, "install");
       await waitForInventory(opts.inventory, id, false);
       return { id, version: pkg.version, sha256: pkg.sha256, enabled: false, installed: true, phase: installed.phase };

--- a/packages/plugin-center/src/remotes.ts
+++ b/packages/plugin-center/src/remotes.ts
@@ -1,5 +1,18 @@
 import { createHash, randomUUID } from "node:crypto";
-import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { Remote, TypertRemoteService } from "@deepseek-ai/dsh-typert-protocol";
 import type { Context } from "@deepseek-ai/cordis";
@@ -88,7 +101,10 @@ function catalogEntry(
   const remote = registry.entry(id);
   const artifact = selectCatalogArtifact(remote.artifacts, hostTarget);
   if (remote.dsh.exact !== PINNED_PLUGIN_DSH) {
-    throw new PenglaiError("SECURITY_POLICY", `${id} DSH pin is not ${PINNED_PLUGIN_DSH}`);
+    throw new PenglaiError(
+      "SECURITY_POLICY",
+      `${id} DSH pin is not ${PINNED_PLUGIN_DSH}`,
+    );
   }
   return {
     id: remote.id,
@@ -101,7 +117,10 @@ function catalogEntry(
     defaultEnabled: false,
     builtIn: false,
     source: "penglai-plugin-registry",
-    provenanceClass: remote.provenanceClass === "community-reviewed" ? "community-reviewed" : "penglai-first-party",
+    provenanceClass:
+      remote.provenanceClass === "community-reviewed"
+        ? "community-reviewed"
+        : "penglai-first-party",
     license: remote.license,
     migration: remote.migration,
     rollback: "last-good-profile",
@@ -159,17 +178,33 @@ function isUnder(root: string, candidate: string): boolean {
   return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 }
 
-function registryPackageRoot(userDataRoot: string, configured: string | undefined): string {
+function registryPackageRoot(
+  userDataRoot: string,
+  configured: string | undefined,
+): string {
   const root = configured ?? join(userDataRoot, "plugins", "packages");
-  if (!isAbsolute(root) || !isUnder(userDataRoot, root) || resolve(root) === resolve(userDataRoot)) {
-    throw new PenglaiError("SECURITY_POLICY", "registry package directory escaped userData");
+  if (
+    !isAbsolute(root) ||
+    !isUnder(userDataRoot, root) ||
+    resolve(root) === resolve(userDataRoot)
+  ) {
+    throw new PenglaiError(
+      "SECURITY_POLICY",
+      "registry package directory escaped userData",
+    );
   }
   mkdirSync(root, { recursive: true, mode: 0o700 });
   if (lstatSync(root).isSymbolicLink()) {
-    throw new PenglaiError("SECURITY_POLICY", "registry package directory must not be a symlink");
+    throw new PenglaiError(
+      "SECURITY_POLICY",
+      "registry package directory must not be a symlink",
+    );
   }
   if (!isUnder(realpathSync(userDataRoot), realpathSync(root))) {
-    throw new PenglaiError("SECURITY_POLICY", "registry package directory resolved outside userData");
+    throw new PenglaiError(
+      "SECURITY_POLICY",
+      "registry package directory resolved outside userData",
+    );
   }
   return root;
 }
@@ -180,23 +215,69 @@ export function stageRegistryPackage(input: {
   userDataRoot: string;
   registryPackagesDir?: string;
 }): string {
-  const root = registryPackageRoot(input.userDataRoot, input.registryPackagesDir);
+  const root = registryPackageRoot(
+    input.userDataRoot,
+    input.registryPackagesDir,
+  );
   if (input.entry.source !== "penglai-plugin-registry") {
-    throw new PenglaiError("SECURITY_POLICY", "only registry packages may enter the mutable package root");
+    throw new PenglaiError(
+      "SECURITY_POLICY",
+      "only registry packages may enter the mutable package root",
+    );
   }
-  if (input.pkg.id !== input.entry.id || input.pkg.version !== input.entry.version || input.pkg.sha256 !== input.entry.sha256) {
-    throw new PenglaiError("SECURITY_POLICY", "downloaded package identity mismatch");
+  if (
+    input.pkg.id !== input.entry.id ||
+    input.pkg.version !== input.entry.version ||
+    input.pkg.sha256 !== input.entry.sha256
+  ) {
+    throw new PenglaiError(
+      "SECURITY_POLICY",
+      "downloaded package identity mismatch",
+    );
   }
-  if (!existsSync(input.pkg.path) || !lstatSync(input.pkg.path).isFile() || lstatSync(input.pkg.path).isSymbolicLink()) {
-    throw new PenglaiError("SECURITY_POLICY", "downloaded package must be a regular cached file");
+  let packageFd: number | undefined;
+  let bytes: Buffer;
+  try {
+    packageFd = openSync(
+      input.pkg.path,
+      constants.O_RDONLY | constants.O_NOFOLLOW,
+    );
+    const openedStat = fstatSync(packageFd);
+    const pathStat = lstatSync(input.pkg.path);
+    if (
+      !openedStat.isFile() ||
+      pathStat.isSymbolicLink() ||
+      !pathStat.isFile() ||
+      openedStat.dev !== pathStat.dev ||
+      openedStat.ino !== pathStat.ino
+    ) {
+      throw new PenglaiError(
+        "SECURITY_POLICY",
+        "downloaded package must be a regular cached file",
+      );
+    }
+    bytes = readFileSync(packageFd);
+  } catch (error) {
+    if (error instanceof PenglaiError) throw error;
+    throw new PenglaiError(
+      "SECURITY_POLICY",
+      "downloaded package must be a regular cached file",
+    );
+  } finally {
+    if (packageFd !== undefined) closeSync(packageFd);
   }
-  const bytes = readFileSync(input.pkg.path);
   if (createHash("sha256").update(bytes).digest("hex") !== input.entry.sha256) {
-    throw new PenglaiError("SECURITY_POLICY", "downloaded package checksum mismatch");
+    throw new PenglaiError(
+      "SECURITY_POLICY",
+      "downloaded package checksum mismatch",
+    );
   }
   const destination = join(root, input.entry.packageFile);
   if (!isUnder(root, destination)) {
-    throw new PenglaiError("SECURITY_POLICY", "registry package escaped mutable package root");
+    throw new PenglaiError(
+      "SECURITY_POLICY",
+      "registry package escaped mutable package root",
+    );
   }
   const temp = `${destination}.${process.pid}.${randomUUID()}.tmp`;
   try {
@@ -224,9 +305,18 @@ export function createCenterRemote(opts: {
   registry?: PluginDistributionClient;
   target?: ProductPluginTarget;
 }): CenterRemote {
-  const hostTarget = (): ProductPluginTarget => opts.target ?? runtimePluginTarget();
-  const requireOwner = (id: string, action: PluginOwnerAction, capabilityId: string | undefined): void => {
-    if (!capabilityId) throw new PenglaiError("SECURITY_POLICY", "native owner capability is required");
+  const hostTarget = (): ProductPluginTarget =>
+    opts.target ?? runtimePluginTarget();
+  const requireOwner = (
+    id: string,
+    action: PluginOwnerAction,
+    capabilityId: string | undefined,
+  ): void => {
+    if (!capabilityId)
+      throw new PenglaiError(
+        "SECURITY_POLICY",
+        "native owner capability is required",
+      );
     const entry = catalogEntry(opts.catalog, id, opts.registry, hostTarget());
     consumePluginOwnerGrant({
       userDataRoot: opts.userDataRoot,
@@ -237,7 +327,9 @@ export function createCenterRemote(opts: {
       sha256: entry.sha256,
       permissionDigest: pluginPermissionDigest({
         permissions: entry.permissions,
-        ...(entry.networkOrigins ? { networkOrigins: entry.networkOrigins } : {}),
+        ...(entry.networkOrigins
+          ? { networkOrigins: entry.networkOrigins }
+          : {}),
         ...(entry.dataPaths ? { dataPaths: entry.dataPaths } : {}),
         nativeCode: entry.nativeCode === true,
       }),
@@ -249,7 +341,10 @@ export function createCenterRemote(opts: {
   ) => {
     const entry = catalogEntry(opts.catalog, id, opts.registry, hostTarget());
     if (action === "disable" && id === "@penglai/plugin-center") {
-      throw new PenglaiError("SECURITY_POLICY", "required plugin cannot be disabled");
+      throw new PenglaiError(
+        "SECURITY_POLICY",
+        "required plugin cannot be disabled",
+      );
     }
     const previousEnabled = Boolean(opts.host.desired()[id]);
     const probe = opts.resourceProbe(id);
@@ -257,9 +352,10 @@ export function createCenterRemote(opts: {
       userDataRoot: opts.userDataRoot,
       profileDir: opts.profileDir,
       txDir: opts.txDir,
-      pluginsDir: entry.source === "penglai-plugin-registry"
-        ? registryPackageRoot(opts.userDataRoot, opts.registryPackagesDir)
-        : opts.pluginsDir,
+      pluginsDir:
+        entry.source === "penglai-plugin-registry"
+          ? registryPackageRoot(opts.userDataRoot, opts.registryPackagesDir)
+          : opts.pluginsDir,
       entry,
       action,
       previousEnabled,
@@ -296,7 +392,8 @@ export function createCenterRemote(opts: {
         const recon = catalog.find((entry) => entry.id === card.id);
         return {
           ...card,
-          installed: recon?.installed ?? (card.downloaded ? "cached" : "not-installed"),
+          installed:
+            recon?.installed ?? (card.downloaded ? "cached" : "not-installed"),
           loaded: rowLoaded(row),
           enabled: recon
             ? recon.desired !== "disabled"
@@ -328,7 +425,8 @@ export function createCenterRemote(opts: {
               rowLoaded(entry),
           ),
           "plugin-center": rows.some(
-            (entry) => rowMatches(entry, "@penglai/plugin-center") && rowLoaded(entry),
+            (entry) =>
+              rowMatches(entry, "@penglai/plugin-center") && rowLoaded(entry),
           ),
           im: rows.some(
             (entry) => rowMatches(entry, "@penglai/im") && rowLoaded(entry),
@@ -347,15 +445,29 @@ export function createCenterRemote(opts: {
       requireOwner(id, "plugin-update", capabilityId);
       const entry = catalogEntry(opts.catalog, id, opts.registry, hostTarget());
       if (entry.source === "penglai-plugin-registry") {
-        if (!opts.registry) throw new PenglaiError("INVALID_INPUT", "remote plugin registry is not configured");
+        if (!opts.registry)
+          throw new PenglaiError(
+            "INVALID_INPUT",
+            "remote plugin registry is not configured",
+          );
         const pkg = await opts.registry.downloadPackage(id, hostTarget());
-        stageRegistryPackage({ pkg, entry, userDataRoot: opts.userDataRoot, ...(opts.registryPackagesDir ? { registryPackagesDir: opts.registryPackagesDir } : {}) });
+        stageRegistryPackage({
+          pkg,
+          entry,
+          userDataRoot: opts.userDataRoot,
+          ...(opts.registryPackagesDir
+            ? { registryPackagesDir: opts.registryPackagesDir }
+            : {}),
+        });
       }
       return transact(id, "update");
     },
     async refreshRegistry() {
       if (arguments.length > 0) {
-        throw new PenglaiError("SECURITY_POLICY", "production refresh does not accept renderer URL, public key, or signingKeyId");
+        throw new PenglaiError(
+          "SECURITY_POLICY",
+          "production refresh does not accept renderer URL, public key, or signingKeyId",
+        );
       }
       const disclaimer = {
         sandbox: false,
@@ -377,18 +489,40 @@ export function createCenterRemote(opts: {
       };
     },
     async download(id: string) {
-      if (!opts.registry) throw new PenglaiError("INVALID_INPUT", "remote plugin registry is not configured");
+      if (!opts.registry)
+        throw new PenglaiError(
+          "INVALID_INPUT",
+          "remote plugin registry is not configured",
+        );
       return opts.registry.downloadPackage(id);
     },
     async installDisabled(id: string, capabilityId?: string) {
-      if (!opts.registry) throw new PenglaiError("INVALID_INPUT", "remote plugin registry is not configured");
+      if (!opts.registry)
+        throw new PenglaiError(
+          "INVALID_INPUT",
+          "remote plugin registry is not configured",
+        );
       requireOwner(id, "plugin-install", capabilityId);
       const pkg = await opts.registry.downloadPackage(id, hostTarget());
       const entry = catalogEntry(opts.catalog, id, opts.registry, hostTarget());
-      stageRegistryPackage({ pkg, entry, userDataRoot: opts.userDataRoot, ...(opts.registryPackagesDir ? { registryPackagesDir: opts.registryPackagesDir } : {}) });
+      stageRegistryPackage({
+        pkg,
+        entry,
+        userDataRoot: opts.userDataRoot,
+        ...(opts.registryPackagesDir
+          ? { registryPackagesDir: opts.registryPackagesDir }
+          : {}),
+      });
       const installed = await transact(id, "install");
       await waitForInventory(opts.inventory, id, false);
-      return { id, version: pkg.version, sha256: pkg.sha256, enabled: false, installed: true, phase: installed.phase };
+      return {
+        id,
+        version: pkg.version,
+        sha256: pkg.sha256,
+        enabled: false,
+        installed: true,
+        phase: installed.phase,
+      };
     },
     async rollback(id: string) {
       catalogEntry(opts.catalog, id, opts.registry, hostTarget());

--- a/packages/plugin-pilot/package.json
+++ b/packages/plugin-pilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/plugin-pilot",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/plugin-reference/package.json
+++ b/packages/plugin-reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/plugin-reference",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/plugin-registry/package.json
+++ b/packages/plugin-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/plugin-registry",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/release-identity/package.json
+++ b/packages/release-identity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/release-identity",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/release-identity/src/artifact-provenance.test.ts
+++ b/packages/release-identity/src/artifact-provenance.test.ts
@@ -28,7 +28,7 @@ function fixture(
   writeFileSync(join(resources, "runtime/node/bin/node"), "node");
   writeFileSync(join(resources, "runtime/dsh/lib/bin.js"), "dsh");
   const manifest = {
-    release: "0.5.2",
+    release: "0.5.3",
     target: overrides.manifestTarget ?? "darwin-aarch64",
     dsh: "0.1.1-rc.1",
     files: [
@@ -45,7 +45,7 @@ function fixture(
     join(resources, "release-info.json"),
     `${JSON.stringify({
       productName: "Penglai",
-      productVersion: "0.5.2",
+      productVersion: "0.5.3",
       generationId: "penglai-dsh-v0.5",
       trustTier: "community-verified",
       sourceSha: overrides.sourceSha ?? sourceSha,

--- a/packages/release-identity/src/contract.ts
+++ b/packages/release-identity/src/contract.ts
@@ -103,8 +103,8 @@ export function assertCanonicalUpdaterManifestUrl(url: string, signature = false
     throw new PenglaiError("INVALID_INPUT", "invalid updater manifest URL");
   }
   const expectedPath = signature
-    ? "/kevinchennewbee/PenglaiAgent/releases/download/v0.5.2/update-manifest-v1.json.sig"
-    : "/kevinchennewbee/PenglaiAgent/releases/download/v0.5.2/update-manifest-v1.json";
+    ? "/kevinchennewbee/PenglaiAgent/releases/download/v0.5.3/update-manifest-v1.json.sig"
+    : "/kevinchennewbee/PenglaiAgent/releases/download/v0.5.3/update-manifest-v1.json";
   if (
     parsed.protocol !== "https:" ||
     parsed.hostname !== "github.com" ||
@@ -152,9 +152,9 @@ export function assertReleaseContract(raw: unknown): ReleaseContract {
   const pub = raw.publication;
   if (!isRecord(pub)) throw new PenglaiError("INVALID_INPUT", "publication");
   if (pub.repo !== "kevinchennewbee/PenglaiAgent") throw new PenglaiError("SECURITY_POLICY", "publication.repo");
-  if (pub.tag !== "v0.5.2") throw new PenglaiError("SECURITY_POLICY", "publication.tag");
-  if (pub.release !== "v0.5.2") throw new PenglaiError("SECURITY_POLICY", "publication.release");
-  if (pub.channel !== "stable-v0.5.2") throw new PenglaiError("SECURITY_POLICY", "publication.channel");
+  if (pub.tag !== "v0.5.3") throw new PenglaiError("SECURITY_POLICY", "publication.tag");
+  if (pub.release !== "v0.5.3") throw new PenglaiError("SECURITY_POLICY", "publication.release");
+  if (pub.channel !== "stable-v0.5.3") throw new PenglaiError("SECURITY_POLICY", "publication.channel");
   if (!Array.isArray(raw.targets) || raw.targets.length !== RELEASE_TARGETS.length) {
     throw new PenglaiError("INVALID_INPUT", "targets");
   }

--- a/packages/release-identity/src/identity.test.ts
+++ b/packages/release-identity/src/identity.test.ts
@@ -17,16 +17,16 @@ import {
   TRUST_TIER,
 } from "./pins.js";
 
-test("R50-TRUTH-001 identity pins are 0.5.2", () => {
+test("R50-TRUTH-001 identity pins are 0.5.3", () => {
   const id = emptyIdentity("a".repeat(40), false);
   const checked = assertReleaseIdentity(id);
   assert.equal(checked.productVersion, PRODUCT_VERSION);
-  assert.equal(checked.productVersion, "0.5.2");
+  assert.equal(checked.productVersion, "0.5.3");
   recordAssertion({
     acceptanceId: "R50-TRUTH-001",
     runnerId: "release-identity.identity",
-    testId: "identity-pins-0.5.2",
-    assertionId: "productVersion-is-0.5.2",
+    testId: "identity-pins-0.5.3",
+    assertionId: "productVersion-is-0.5.3",
     status: "PASS",
     candidateSourceSha: "a".repeat(40),
     exitCode: 0,
@@ -136,9 +136,9 @@ test("tampered sourceSha is rejected", () => {
 test("R50-TRUTH-008 publication fields match the owner-authorized public target", () => {
   const id = assertReleaseIdentity(emptyIdentity("e".repeat(40), false));
   assert.equal(id.publication.repo, "kevinchennewbee/PenglaiAgent");
-  assert.equal(id.publication.tag, "v0.5.2");
-  assert.equal(id.publication.release, "v0.5.2");
-  assert.equal(id.publication.channel, "stable-v0.5.2");
+  assert.equal(id.publication.tag, "v0.5.3");
+  assert.equal(id.publication.release, "v0.5.3");
+  assert.equal(id.publication.channel, "stable-v0.5.3");
   assert.throws(
     () =>
       assertReleaseIdentity({

--- a/packages/release-identity/src/identity.ts
+++ b/packages/release-identity/src/identity.ts
@@ -126,7 +126,7 @@ function publicationOk(raw: unknown): PublicationBoundary {
 
 function assertTargets(raw: unknown): ReleaseTarget[] {
   if (!Array.isArray(raw) || raw.length !== RELEASE_TARGETS.length) {
-    throw new PenglaiError("INVALID_INPUT", "identity must declare the exact 0.5.2 release targets");
+    throw new PenglaiError("INVALID_INPUT", "identity must declare the exact 0.5.3 release targets");
   }
   const got = raw as ReleaseTarget[];
   for (let i = 0; i < RELEASE_TARGETS.length; i += 1) {

--- a/packages/release-identity/src/installed-evidence.test.ts
+++ b/packages/release-identity/src/installed-evidence.test.ts
@@ -105,8 +105,8 @@ test("installed exact-DMG evidence is attributed only from runner output", () =>
   const path = join(root, "evidence/generated/installed-e2e.json");
   if (!existsSync(path)) return;
   const rec = JSON.parse(readFileSync(path, "utf8"));
-  if (rec.verdict !== "PASS" || rec.fromExactDmg !== true || rec.productVersion !== "0.5.2") return;
-  if (rec.installer !== "Penglai_0.5.2_macos_aarch64.dmg") return;
+  if (rec.verdict !== "PASS" || rec.fromExactDmg !== true || rec.productVersion !== "0.5.3") return;
+  if (rec.installer !== "Penglai_0.5.3_macos_aarch64.dmg") return;
   const sourceSha = declaredSourceSha();
   const app = packagedAppForTarget(root, "darwin-aarch64");
   const packaged = inspectPackagedCandidate({ app, candidateSha: sourceSha, expectedTarget: "darwin-aarch64" });
@@ -135,7 +135,7 @@ test("installed exact-DMG evidence is attributed only from runner output", () =>
     runnerId: "installed",
     testId: "installed-e2e-file-R50-E2E-001",
     assertionId: "exact-dmg-not-staging",
-    details: { safe: "installed-e2e.json came from exact Penglai_0.5.2_macos_aarch64.dmg" },
+    details: { safe: "installed-e2e.json came from exact Penglai_0.5.3_macos_aarch64.dmg" },
   });
   recordAssertion({
     ...common,

--- a/packages/release-identity/src/pins.ts
+++ b/packages/release-identity/src/pins.ts
@@ -1,5 +1,5 @@
 export const PRODUCT_NAME = "Penglai";
-export const PRODUCT_VERSION = "0.5.2";
+export const PRODUCT_VERSION = "0.5.3";
 export const CANDIDATE_KIND = "public-community-release";
 export const TRUST_TIER = "community-verified";
 export const GENERATION_ID = "penglai-dsh-v0.5";
@@ -80,9 +80,9 @@ export const UPDATER_CHANNEL = "desktop-v0.5";
 
 export const PUBLICATION_TARGET = Object.freeze({
   repo: "kevinchennewbee/PenglaiAgent",
-  tag: "v0.5.2",
-  release: "v0.5.2",
-  channel: "stable-v0.5.2",
+  tag: "v0.5.3",
+  release: "v0.5.3",
+  channel: "stable-v0.5.3",
 });
 
 export const RELEASE_TARGETS = [
@@ -90,19 +90,19 @@ export const RELEASE_TARGETS = [
     key: "darwin-aarch64",
     platform: "darwin",
     arch: "arm64",
-    installer: "Penglai_0.5.2_macos_aarch64.dmg",
+    installer: "Penglai_0.5.3_macos_aarch64.dmg",
   },
   {
     key: "darwin-x86_64",
     platform: "darwin",
     arch: "x64",
-    installer: "Penglai_0.5.2_macos_x64.dmg",
+    installer: "Penglai_0.5.3_macos_x64.dmg",
   },
   {
     key: "win32-x86_64",
     platform: "win32",
     arch: "x64",
-    installer: "Penglai_0.5.2_windows_x64_setup.exe",
+    installer: "Penglai_0.5.3_windows_x64_setup.exe",
   },
 ] as const;
 

--- a/packages/release-identity/src/public-docs.test.ts
+++ b/packages/release-identity/src/public-docs.test.ts
@@ -8,7 +8,7 @@ import { declaredSourceSha, recordAssertion } from "./assertion.js";
 const root = join(dirname(fileURLToPath(import.meta.url)), "../../..");
 
 test("R50-PREP-007 release notes state fresh install, trust, upgrade and uninstall", () => {
-  const notes = readFileSync(join(root, "docs/RELEASE_NOTES_0.5.2.md"), "utf8");
+  const notes = readFileSync(join(root, "docs/RELEASE_NOTES_0.5.3.md"), "utf8");
   assert.match(notes, /Penglai → Update/i);
   assert.match(notes, /0\.5\.1/);
   assert.match(notes, /community-verified/);
@@ -26,15 +26,15 @@ test("R50-PREP-007 release notes state fresh install, trust, upgrade and uninsta
     status: "PASS",
     candidateSourceSha: declaredSourceSha(),
     exitCode: 0,
-    details: { safe: "0.5.2 notes state signed 0.5.1 upgrade, three targets, community trust, and update confirmation" },
+    details: { safe: "0.5.3 notes state signed 0.5.1 upgrade, three targets, community trust, and update confirmation" },
   });
 });
 
 test("R50-PREP-008 publication manifest lists the exact three-target release", () => {
-  const md = readFileSync(join(root, "docs/PUBLICATION_MANIFEST_0.5.2.md"), "utf8");
-  assert.match(md, /Penglai_0\.5\.2_macos_aarch64\.dmg/);
-  assert.match(md, /Penglai_0\.5\.2_macos_x64\.dmg/);
-  assert.match(md, /Penglai_0\.5\.2_windows_x64_setup\.exe/);
+  const md = readFileSync(join(root, "docs/PUBLICATION_MANIFEST_0.5.3.md"), "utf8");
+  assert.match(md, /Penglai_0\.5\.3_macos_aarch64\.dmg/);
+  assert.match(md, /Penglai_0\.5\.3_macos_x64\.dmg/);
+  assert.match(md, /Penglai_0\.5\.3_windows_x64_setup\.exe/);
   assert.match(md, /public-export-manifest\.json/);
   assert.match(md, /kevinchennewbee\/PenglaiAgent/);
   assert.match(md, /UNFROZEN/);

--- a/packages/release-identity/src/public-export.test.ts
+++ b/packages/release-identity/src/public-export.test.ts
@@ -133,6 +133,9 @@ test("R50-PREP-005 required public docs are enumerated", () => {
       "docs/PUBLICATION_0.5.2.md",
       "docs/PUBLICATION_MANIFEST_0.5.2.md",
       "docs/RELEASE_NOTES_0.5.2.md",
+      "docs/PUBLICATION_0.5.3.md",
+      "docs/PUBLICATION_MANIFEST_0.5.3.md",
+      "docs/RELEASE_NOTES_0.5.3.md",
     ]),
   );
   recordAssertion({
@@ -203,7 +206,7 @@ test("R50-PREP-010 publication fields match the owner-authorized target", () => 
     status: "PASS",
     candidateSourceSha: declaredSourceSha(),
     exitCode: 0,
-    details: { safe: "public repo, v0.5.2 tag and release are exact; updater channel remains unpublished until freeze" },
+    details: { safe: "public repo, v0.5.3 tag and release are exact; updater channel remains unpublished until freeze" },
   });
 });
 

--- a/packages/release-identity/src/public-export.ts
+++ b/packages/release-identity/src/public-export.ts
@@ -40,6 +40,10 @@ export const PUBLIC_EXPORT_ALLOW = [
   "docs/PUBLICATION_MANIFEST_0.5.2.md",
   "docs/RELEASE_NOTES_0.5.2.md",
   "docs/0.5.2",
+  "docs/PUBLICATION_0.5.3.md",
+  "docs/PUBLICATION_MANIFEST_0.5.3.md",
+  "docs/RELEASE_NOTES_0.5.3.md",
+  "docs/0.5.3",
   "docs/ACCEPTANCE.md",
   "docs/RELEASE_RUNBOOK.md",
   "docs/decisions.md",
@@ -107,6 +111,9 @@ export const REQUIRED_PUBLIC_DOCS = [
   "docs/PUBLICATION_0.5.2.md",
   "docs/PUBLICATION_MANIFEST_0.5.2.md",
   "docs/RELEASE_NOTES_0.5.2.md",
+  "docs/PUBLICATION_0.5.3.md",
+  "docs/PUBLICATION_MANIFEST_0.5.3.md",
+  "docs/RELEASE_NOTES_0.5.3.md",
 ] as const;
 
 export interface ExportFile {
@@ -216,7 +223,7 @@ export function buildPublicationDraft(input: {
       `${PRODUCT_VERSION} declares darwin-aarch64, darwin-x86_64, and win32-x86_64; native PASS requires a matching runner`,
       "community-verified: macOS ad-hoc/not notarized; Windows has no Authenticode",
       "0.5.0 to 0.5.1 is a manual overlay install on Apple Silicon; Intel/Windows are fresh installs",
-      "0.5.1 to 0.5.2 uses signed assisted update after user confirmation; 0.5.0 remains manual",
+      "0.5.1 to 0.5.3 uses signed assisted update after user confirmation; 0.5.0 remains manual",
       `no silent auto-update; ${PRODUCT_VERSION} discovers only later stable immutable PenglaiAgent Releases`,
       "public destination is owner-authorized; execution is verified after publication",
     ],

--- a/packages/release-identity/src/rc0.test.ts
+++ b/packages/release-identity/src/rc0.test.ts
@@ -243,12 +243,12 @@ test("build inputs reject dirty named SHA and HEAD drift", () => {
   );
 });
 
-test("GitHub Actions is AVAILABLE for the 0.5.2 source candidate", () => {
+test("GitHub Actions is AVAILABLE for the 0.5.3 source candidate", () => {
   assert.equal(GITHUB_ACTIONS_STATUS, "AVAILABLE");
 });
 
-test("product version is 0.5.2 and registry count matches the document", () => {
-  assert.equal(PRODUCT_VERSION, "0.5.2");
+test("product version is 0.5.3 and registry count matches the document", () => {
+  assert.equal(PRODUCT_VERSION, "0.5.3");
   const md = readFileSync(join(root, "docs/ACCEPTANCE.md"), "utf8");
   const ids = parseAcceptanceIds(md);
   const entries = assertRegistryConsistent(md);

--- a/packages/routing-core/package.json
+++ b/packages/routing-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/routing-core",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/runtime",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/runtime/src/boot-revoke.ts
+++ b/packages/runtime/src/boot-revoke.ts
@@ -75,7 +75,7 @@ export function quarantineRevokedPlugins(opts: {
     cacheRoot: join(opts.userDataRoot, "plugins", "cas"),
     trustPath,
     lastGoodPath,
-    penglaiVersion: "0.5.2",
+    penglaiVersion: "0.5.3",
     dshExact: PINNED_PLUGIN_DSH,
   });
   const snap = client.snapshot();

--- a/packages/runtime/src/fuses.test.ts
+++ b/packages/runtime/src/fuses.test.ts
@@ -23,9 +23,11 @@ test("R50-SEC-004 fuse wire is read from binary bytes not config strings", () =>
   });
   const after = inspectFuseWire(flipped);
   assert.equal(after.values.runAsNode, false);
+  assert.equal(after.values.enableNodeOptionsEnvironmentVariable, false);
   assert.equal(after.values.enableNodeCliInspectArguments, false);
   assert.doesNotThrow(() => assertRequiredFuses(after.values));
   assert.throws(() => assertRequiredFuses(info.values));
+  assert.throws(() => assertRequiredFuses({ ...after.values, enableNodeOptionsEnvironmentVariable: true }));
 });
 
 test("R50-MAC-005 nine-byte Electron 43 fuse wire keeps onlyLoadAppFromAsar false", () => {

--- a/packages/runtime/src/fuses.ts
+++ b/packages/runtime/src/fuses.ts
@@ -49,6 +49,9 @@ export function applyFuseWire(buf: Buffer, updates: Partial<Record<FuseName, boo
 
 export function assertRequiredFuses(values: FuseInspection["values"]): void {
   if (values.runAsNode !== false) throw new PenglaiError("SECURITY_POLICY", "RunAsNode must be disabled");
+  if (values.enableNodeOptionsEnvironmentVariable !== false) {
+    throw new PenglaiError("SECURITY_POLICY", "NODE_OPTIONS must be disabled");
+  }
   if (values.enableNodeCliInspectArguments !== false) {
     throw new PenglaiError("SECURITY_POLICY", "Node CLI inspect must be disabled");
   }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -49,7 +49,7 @@ export * from "./windows-host.js";
 export * from "./packaging.js";
 export * from "./fuses.js";
 
-export const PENGLAI_VERSION = "0.5.2";
+export const PENGLAI_VERSION = "0.5.3";
 export const PINNED_DSH = "0.1.1-rc.1";
 export const PINNED_NODE = "22.22.2";
 export const PINNED_ELECTRON = "43.4.0";

--- a/packages/runtime/src/leftover.test.ts
+++ b/packages/runtime/src/leftover.test.ts
@@ -75,7 +75,7 @@ test("R50-REL-006/007 a11y contract covers live region, QR alt, contrast, and zo
 
 test("R50-UPD-008/009/010 verified installer and crash replay", () => {
   const root = mkdtempSync(join(tmpdir(), "penglai-update-handoff-"));
-  const path = join(root, "Penglai_0.5.2_macos_aarch64.dmg");
+  const path = join(root, "Penglai_0.5.3_macos_aarch64.dmg");
   const payload = Buffer.from("signed-installer");
   writeFileSync(path, payload);
   const { publicKey, privateKey } = generateKeyPairSync("ed25519");
@@ -140,7 +140,7 @@ test("R50-UPD: download verifies size/hash/signature and crash mid-download retu
   const sig = sign(null, payload, privateKey);
   const dest = mkdtempSync(join(tmpdir(), "penglai-upd-dl-"));
   const out = await downloadVerifiedPayload({
-    url: "https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.2/Penglai_0.5.2_macos_aarch64.dmg",
+    url: "https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.3/Penglai_0.5.3_macos_aarch64.dmg",
     destDir: dest,
     expectedSha256: sha,
     expectedSize: payload.length,
@@ -154,7 +154,7 @@ test("R50-UPD: download verifies size/hash/signature and crash mid-download retu
   assert.throws(() => drainOwnedServices({ dshRunning: true, asrBusy: false, ttsBusy: false, indexerBusy: false, companionArmed: false }), /busy/);
 });
 
-test("R50-DIST: packaged identity is Penglai 0.5.2 and Windows NSIS stays current-user", async () => {
+test("R50-DIST: packaged identity is Penglai 0.5.3 and Windows NSIS stays current-user", async () => {
   const {
     assertPenglaiAppIdentity,
     assertWindowsNsisContract,
@@ -176,7 +176,7 @@ test("R50-DIST: packaged identity is Penglai 0.5.2 and Windows NSIS stays curren
   const facts = parseInfoPlistIdentity(rewritten);
   assertPenglaiAppIdentity(facts);
   assert.equal(facts.executable, "Penglai");
-  assert.equal(facts.shortVersion, "0.5.2");
+  assert.equal(facts.shortVersion, "0.5.3");
   assert.match(rewritten, /penglai\.icns/);
   assert.match(rewritten, /<string>13\.0<\/string>/);
   assertWindowsNsisContract({

--- a/packages/runtime/src/overlay.test.ts
+++ b/packages/runtime/src/overlay.test.ts
@@ -79,10 +79,13 @@ test("R2I-BRAND-010/011 overlay applies only on exact upstream hash", async () =
     /penglai-brand\/title\.js/,
   );
   const welcomeSource = readFileSync(join(dir, welcomeRel), "utf8");
-  assert.match(welcomeSource, /penglai-0\.5\.2\.0/);
-  assert.match(welcomeSource, /欢迎使用蓬莱 0\.5\.2/);
-  assert.match(welcomeSource, /Welcome to Penglai 0\.5\.2/);
-  assert.doesNotMatch(welcomeSource, /欢迎使用蓬莱 0\.5\.1|Welcome to Penglai 0\.5\.1/);
+  assert.match(welcomeSource, /penglai-0\.5\.3\.0/);
+  assert.match(welcomeSource, /欢迎使用蓬莱 0\.5\.3/);
+  assert.match(welcomeSource, /Welcome to Penglai 0\.5\.3/);
+  assert.doesNotMatch(
+    welcomeSource,
+    /欢迎使用蓬莱 0\.5\.[12]|Welcome to Penglai 0\.5\.[12]/,
+  );
   const hero = readFileSync(join(dir, heroRel), "utf8");
   assert.match(hero, /conversation\.hero\.brand\.mark/);
   assert.doesNotMatch(hero, /data-penglai-hero-wordmark/);
@@ -131,7 +134,7 @@ test("R2I-BRAND-010/011 overlay applies only on exact upstream hash", async () =
   const welcome = readFileSync(join(dir, welcomeRel), "utf8");
   assert.match(welcome, /欢迎使用蓬莱/);
   assert.match(welcome, /Welcome to Penglai/);
-  assert.match(welcome, /penglai-0\.5\.2\.0/);
+  assert.match(welcome, /penglai-0\.5\.3\.0/);
   assert.match(welcome, /YAML/);
   assert.doesNotMatch(welcome, /内测声明/);
   assert.doesNotMatch(welcome, /official DSH Web/);

--- a/packages/runtime/src/plugin-catalog.ts
+++ b/packages/runtime/src/plugin-catalog.ts
@@ -70,7 +70,7 @@ export interface EmbeddedPluginManifest {
 
 const TARGETS = [...PRODUCT_PLUGIN_TARGETS];
 const common = {
-  version: "0.5.2",
+  version: "0.5.3",
   dsh: { exact: PINNED_PLUGIN_DSH },
   platforms: TARGETS,
   source: "bundled-first-party" as const,
@@ -84,7 +84,7 @@ export const FIRST_PARTY_PLUGIN_METADATA: readonly PluginCatalogMetadata[] =
     {
       ...common,
       id: "@penglai/plugin-center",
-      packageFile: "penglai-plugin-center-0.5.2.tgz",
+      packageFile: "penglai-plugin-center-0.5.3.tgz",
       capabilities: ["settings-ui", "catalog", "profile-transaction"],
       permissions: ["profile-write"],
       defaultEnabled: true,
@@ -94,7 +94,7 @@ export const FIRST_PARTY_PLUGIN_METADATA: readonly PluginCatalogMetadata[] =
     {
       ...common,
       id: "@penglai/im",
-      packageFile: "penglai-im-0.5.2.tgz",
+      packageFile: "penglai-im-0.5.3.tgz",
       capabilities: ["settings-ui", "im-weixin", "im-feishu", "private-voice"],
       permissions: ["credentials-service", "local-database", "outbound-network"],
       defaultEnabled: false,
@@ -104,7 +104,7 @@ export const FIRST_PARTY_PLUGIN_METADATA: readonly PluginCatalogMetadata[] =
     {
       ...common,
       id: "@penglai/plugin-reference",
-      packageFile: "penglai-plugin-reference-0.5.2.tgz",
+      packageFile: "penglai-plugin-reference-0.5.3.tgz",
       capabilities: ["platform-proof"],
       permissions: [],
       defaultEnabled: false,
@@ -114,7 +114,7 @@ export const FIRST_PARTY_PLUGIN_METADATA: readonly PluginCatalogMetadata[] =
     {
       ...common,
       id: "@penglai/asr",
-      packageFile: "penglai-asr-0.5.2.tgz",
+      packageFile: "penglai-asr-0.5.3.tgz",
       capabilities: ["settings-ui", "local-asr", "model-manager"],
       permissions: ["microphone", "local-model"],
       defaultEnabled: false,
@@ -124,7 +124,7 @@ export const FIRST_PARTY_PLUGIN_METADATA: readonly PluginCatalogMetadata[] =
     {
       ...common,
       id: "@penglai/moss-tts",
-      packageFile: "penglai-moss-tts-0.5.2.tgz",
+      packageFile: "penglai-moss-tts-0.5.3.tgz",
       capabilities: ["settings-ui", "local-tts", "model-manager"],
       permissions: ["local-model", "audio-output"],
       defaultEnabled: false,
@@ -134,7 +134,7 @@ export const FIRST_PARTY_PLUGIN_METADATA: readonly PluginCatalogMetadata[] =
     {
       ...common,
       id: "@penglai/context",
-      packageFile: "penglai-context-0.5.2.tgz",
+      packageFile: "penglai-context-0.5.3.tgz",
       capabilities: ["authorized-context", "source-cards"],
       permissions: ["local-index", "authorized-files-read"],
       defaultEnabled: false,
@@ -144,7 +144,7 @@ export const FIRST_PARTY_PLUGIN_METADATA: readonly PluginCatalogMetadata[] =
     {
       ...common,
       id: "@penglai/memory",
-      packageFile: "penglai-memory-0.5.2.tgz",
+      packageFile: "penglai-memory-0.5.3.tgz",
       capabilities: ["layered-memory", "official-skill-promotion"],
       permissions: ["local-memory", "official-skill-write"],
       defaultEnabled: false,
@@ -154,7 +154,7 @@ export const FIRST_PARTY_PLUGIN_METADATA: readonly PluginCatalogMetadata[] =
     {
       ...common,
       id: "@penglai/budget",
-      packageFile: "penglai-budget-0.5.2.tgz",
+      packageFile: "penglai-budget-0.5.3.tgz",
       capabilities: ["token-budget", "pre-invocation-gate"],
       permissions: ["token-meter", "model-invocation-gate"],
       defaultEnabled: false,
@@ -164,7 +164,7 @@ export const FIRST_PARTY_PLUGIN_METADATA: readonly PluginCatalogMetadata[] =
     {
       ...common,
       id: "@penglai/companion",
-      packageFile: "penglai-companion-0.5.2.tgz",
+      packageFile: "penglai-companion-0.5.3.tgz",
       capabilities: ["proactive-companion", "schedule-composition"],
       permissions: ["schedule", "dedicated-agent", "im-send"],
       defaultEnabled: false,

--- a/packages/runtime/src/update-coordinator.test.ts
+++ b/packages/runtime/src/update-coordinator.test.ts
@@ -14,6 +14,7 @@ import { crashSafeUpdate, downloadVerifiedPayload } from "./update-flow.js";
 import {
   UPDATE_STATES,
   verifyManifestBytes,
+  writeUpdateJournal,
   writeUpdateLedger,
   type UpdateManifest,
   type UpdateState,
@@ -139,7 +140,7 @@ function coordinatorConfig(
   };
 }
 
-test("R50-UPD-001..009 signed assisted update commits only after explicit verified handoff", async () => {
+test("R50-UPD-001..009 signed assisted update commits with optional IM disabled after explicit verified handoff", async () => {
   const root = mkdtempSync(join(tmpdir(), "penglai-update-coordinator-"));
   const fixture = signedFixture();
   const opened: Array<{ path: string; kind: "dmg" | "setup" }> = [];
@@ -193,7 +194,6 @@ test("R50-UPD-001..009 signed assisted update commits only after explicit verifi
     profileReady: true,
     pluginsReady: true,
     dshHealthy: true,
-    imHealthy: true,
   });
   assert.equal(committed.state, "COMMITTED");
   const ledger = JSON.parse(readFileSync(join(root, "state", "update-ledger.json"), "utf8")) as {
@@ -479,4 +479,22 @@ test("R50-UPD-004/009/010 ledger and every crash state fail closed", async () =>
   for (const state of UPDATE_STATES) {
     assert.equal(crashSafeUpdate({ operationId: "crash-state", state, drained: false }), expected.get(state));
   }
+
+  const supersededRoot = mkdtempSync(join(tmpdir(), "penglai-update-superseded-"));
+  writeUpdateJournal(join(supersededRoot, "journal"), {
+    operationId: "failed-0.5.2",
+    state: "RECOVERY_REQUIRED",
+    previousVersion: "0.5.1",
+    version: "0.5.2",
+    target: TARGET,
+    drained: true,
+    errorClass: "POST_VERIFY_FAILED",
+  });
+  const superseded = new AssistedUpdateCoordinator(coordinatorConfig(supersededRoot, fixture, {
+    currentVersion: "0.5.3",
+  }));
+  const reconciled = superseded.recoverOnLaunch();
+  assert.equal(reconciled.state, "CURRENT");
+  assert.equal(reconciled.version, "0.5.3");
+  assert.equal(reconciled.errorClass, undefined);
 });

--- a/packages/runtime/src/update-coordinator.ts
+++ b/packages/runtime/src/update-coordinator.ts
@@ -49,7 +49,6 @@ export interface PostUpdateFacts {
   profileReady: boolean;
   pluginsReady: boolean;
   dshHealthy: boolean;
-  imHealthy: boolean;
   installerCancelled?: boolean;
 }
 
@@ -194,6 +193,22 @@ export class AssistedUpdateCoordinator {
   }
 
   recoverOnLaunch(): UpdateCoordinatorStatus {
+    if (
+      this.#journal.state === "RECOVERY_REQUIRED" &&
+      this.#journal.version &&
+      compareSemver(this.#config.currentVersion, this.#journal.version) > 0
+    ) {
+      this.#journal = {
+        operationId: this.#journal.operationId,
+        state: "CURRENT",
+        previousVersion: this.#journal.version,
+        version: this.#config.currentVersion,
+        target: this.#config.target,
+        drained: false,
+      };
+      this.#persist();
+      return this.status();
+    }
     const recovered = crashSafeUpdate(this.#journal);
     if (recovered !== this.#journal.state) {
       this.#journal = {
@@ -503,8 +518,7 @@ export class AssistedUpdateCoordinator {
       facts.runtimeIntegrity &&
       facts.profileReady &&
       facts.pluginsReady &&
-      facts.dshHealthy &&
-      facts.imHealthy;
+      facts.dshHealthy;
     if (!healthy || !this.#journal.manifestSha256) {
       this.#journal = { ...this.#journal, state: "RECOVERY_REQUIRED", errorClass: "POST_VERIFY_FAILED" };
       this.#persist();

--- a/packages/runtime/src/windows-host.test.ts
+++ b/packages/runtime/src/windows-host.test.ts
@@ -198,6 +198,7 @@ test("NSIS script default-preserves user data and only deletes via capability ha
   assert.match(payload, /public-export\.json/);
   assert.match(payload, /release-info\.json/);
   assert.match(payload, /stamp-windows-exe\.mjs/);
+  assert.match(payload, /writeRequiredFuses\(penglaiExe\)/);
   assert.match(payload, /Penglai\.ico/);
   assert.match(payload, /stagingForTarget\(ROOT, "win32-x86_64"\)/);
   assert.match(packager, /stagingForTarget\(ROOT, "win32-x86_64"\)/);

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penglai/testkit",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "type": "module",
   "exports": {

--- a/packaging/electron-fuses.json
+++ b/packaging/electron-fuses.json
@@ -1,5 +1,5 @@
 {
-  "policy": "0.5.2-unpacked-app",
+  "policy": "0.5.3-unpacked-app",
   "runAsNode": false,
   "enableNodeOptionsEnvironmentVariable": false,
   "enableNodeCliInspectArguments": false,

--- a/profile-seed/web/package.json
+++ b/profile-seed/web/package.json
@@ -2,15 +2,15 @@
   "name": "dsh-profile-web",
   "private": true,
   "dependencies": {
-    "@penglai/plugin-center": "0.5.2",
-    "@penglai/im": "0.5.2",
-    "@penglai/asr": "0.5.2",
-    "@penglai/moss-tts": "0.5.2",
-    "@penglai/context": "0.5.2",
-    "@penglai/memory": "0.5.2",
-    "@penglai/budget": "0.5.2",
-    "@penglai/companion": "0.5.2",
-    "@penglai/plugin-reference": "0.5.2"
+    "@penglai/plugin-center": "0.5.3",
+    "@penglai/im": "0.5.3",
+    "@penglai/asr": "0.5.3",
+    "@penglai/moss-tts": "0.5.3",
+    "@penglai/context": "0.5.3",
+    "@penglai/memory": "0.5.3",
+    "@penglai/budget": "0.5.3",
+    "@penglai/companion": "0.5.3",
+    "@penglai/plugin-reference": "0.5.3"
   },
   "dsh": {
     "profile": {

--- a/release-contract.json
+++ b/release-contract.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "product": "Penglai",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "candidateKind": "public-community-release",
   "trustTier": "community-verified",
   "generationId": "penglai-dsh-v0.5",
@@ -12,34 +12,34 @@
   "updaterChannel": "desktop-v0.5",
   "updaterPublicKeyId": "penglai-updater-d706d4f5cf1da7a57b74c068",
   "updaterPublicKeyHex": "d706d4f5cf1da7a57b74c068dd9eb4b7d7f655609c8ef097fd86fb22376bf9ee",
-  "updaterManifestUrl": "https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.2/update-manifest-v1.json",
-  "updaterManifestSignatureUrl": "https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.2/update-manifest-v1.json.sig",
+  "updaterManifestUrl": "https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.3/update-manifest-v1.json",
+  "updaterManifestSignatureUrl": "https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.3/update-manifest-v1.json.sig",
   "updaterAllowedAssetHosts": ["github.com"],
   "canonicalMaker": "penglai-controlled-pipeline",
   "publication": {
     "repo": "kevinchennewbee/PenglaiAgent",
-    "tag": "v0.5.2",
-    "release": "v0.5.2",
-    "channel": "stable-v0.5.2"
+    "tag": "v0.5.3",
+    "release": "v0.5.3",
+    "channel": "stable-v0.5.3"
   },
   "targets": [
     {
       "key": "darwin-aarch64",
       "platform": "darwin",
       "arch": "arm64",
-      "installer": "Penglai_0.5.2_macos_aarch64.dmg"
+      "installer": "Penglai_0.5.3_macos_aarch64.dmg"
     },
     {
       "key": "darwin-x86_64",
       "platform": "darwin",
       "arch": "x64",
-      "installer": "Penglai_0.5.2_macos_x64.dmg"
+      "installer": "Penglai_0.5.3_macos_x64.dmg"
     },
     {
       "key": "win32-x86_64",
       "platform": "win32",
       "arch": "x64",
-      "installer": "Penglai_0.5.2_windows_x64_setup.exe"
+      "installer": "Penglai_0.5.3_windows_x64_setup.exe"
     }
   ],
   "runtimeInputs": [
@@ -93,9 +93,9 @@
     }
   ],
   "exactAssets": [
-    "Penglai_0.5.2_macos_aarch64.dmg",
-    "Penglai_0.5.2_macos_x64.dmg",
-    "Penglai_0.5.2_windows_x64_setup.exe",
+    "Penglai_0.5.3_macos_aarch64.dmg",
+    "Penglai_0.5.3_macos_x64.dmg",
+    "Penglai_0.5.3_windows_x64_setup.exe",
     "update-manifest-v1.json",
     "update-manifest-v1.json.sig",
     "release-manifest.json",

--- a/release-info.json
+++ b/release-info.json
@@ -1,6 +1,6 @@
 {
   "productName": "Penglai",
-  "productVersion": "0.5.2",
+  "productVersion": "0.5.3",
   "buildNumber": 0,
   "candidateOrdinal": 0,
   "candidateKind": "public-community-release",
@@ -16,19 +16,19 @@
       "key": "darwin-aarch64",
       "platform": "darwin",
       "arch": "arm64",
-      "installer": "Penglai_0.5.2_macos_aarch64.dmg"
+      "installer": "Penglai_0.5.3_macos_aarch64.dmg"
     },
     {
       "key": "darwin-x86_64",
       "platform": "darwin",
       "arch": "x64",
-      "installer": "Penglai_0.5.2_macos_x64.dmg"
+      "installer": "Penglai_0.5.3_macos_x64.dmg"
     },
     {
       "key": "win32-x86_64",
       "platform": "win32",
       "arch": "x64",
-      "installer": "Penglai_0.5.2_windows_x64_setup.exe"
+      "installer": "Penglai_0.5.3_windows_x64_setup.exe"
     }
   ],
   "electron": "43.4.0",
@@ -43,9 +43,9 @@
   "authenticode": false,
   "publication": {
     "repo": "kevinchennewbee/PenglaiAgent",
-    "tag": "v0.5.2",
-    "release": "v0.5.2",
-    "channel": "stable-v0.5.2"
+    "tag": "v0.5.3",
+    "release": "v0.5.3",
+    "channel": "stable-v0.5.3"
   },
   "pnpm": "10.14.0"
 }

--- a/scripts/build-local-dmg.mjs
+++ b/scripts/build-local-dmg.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Community-verified macOS DMG for Penglai 0.5.2.
+ * Community-verified macOS DMG for Penglai 0.5.3.
  * Follows PenglaiAgent v0.4.1: complete ad-hoc app seal, codesign strict
  * verification, ordinary UDZO DMG, hdiutil verify. Not Developer ID, not notarized.
  */
@@ -74,14 +74,14 @@ const targetArg = process.argv.includes("--target")
   : process.env.PENGLAI_PACK_TARGET;
 const TARGETS = {
   "darwin-arm64": {
-    out: "dist/Penglai-v0.5.2-arm64",
-    dmg: "dist/Penglai_0.5.2_macos_aarch64.dmg",
-    from: "dist/Penglai-v0.5.2-arm64-from-dmg",
+    out: "dist/Penglai-v0.5.3-arm64",
+    dmg: "dist/Penglai_0.5.3_macos_aarch64.dmg",
+    from: "dist/Penglai-v0.5.3-arm64-from-dmg",
   },
   "darwin-x64": {
-    out: "dist/Penglai-v0.5.2-x64",
-    dmg: "dist/Penglai_0.5.2_macos_x64.dmg",
-    from: "dist/Penglai-v0.5.2-x64-from-dmg",
+    out: "dist/Penglai-v0.5.3-x64",
+    dmg: "dist/Penglai_0.5.3_macos_x64.dmg",
+    from: "dist/Penglai-v0.5.3-x64-from-dmg",
   },
 };
 if (!targetArg || !TARGETS[targetArg]) {
@@ -207,7 +207,7 @@ const dirty =
 const hash = sha256(dmgPath);
 const info = {
   productName: "Penglai",
-  productVersion: "0.5.2",
+  productVersion: "0.5.3",
   name: targetSpec.dmg
     .split("/")
     .pop()

--- a/scripts/bundle-desktop.mjs
+++ b/scripts/bundle-desktop.mjs
@@ -39,6 +39,6 @@ const staticSrc = join(ROOT, "apps/desktop/static");
 if (existsSync(staticSrc)) cpSync(staticSrc, join(outDir, "static"), { recursive: true });
 writeFileSync(
   join(outDir, "package.json"),
-  JSON.stringify({ name: "penglai", version: "0.5.2", type: "module", main: "electron-main.js" }, null, 2),
+  JSON.stringify({ name: "penglai", version: "0.5.3", type: "module", main: "electron-main.js" }, null, 2),
 );
 console.log("bundle-desktop", outDir);

--- a/scripts/e2e-installed.mjs
+++ b/scripts/e2e-installed.mjs
@@ -146,7 +146,7 @@ if (!harnessApp) {
     reason: "exact DMG refused debug flags; UI walk requires a separate harness build",
     refuseCode,
     installer: expectedInstaller,
-    productVersion: "0.5.2",
+    productVersion: "0.5.3",
   });
 }
 const debugPort = await freePort();
@@ -228,7 +228,7 @@ const official = walk?.official ?? {};
 const http = official.http ?? { status: 0, ok: false, official: false };
 if (http.status === 401) http.officialProxy = true;
 const first = {
-  productVersion: "0.5.2",
+  productVersion: "0.5.3",
   pid: launched.child.pid,
   recovery: Boolean(walk?.last?.recovery),
   sourceRead: false,
@@ -289,7 +289,7 @@ const fail = (reason, extra = {}) => {
   const rec = {
     command: "test:e2e:installed",
     verdict: "FAIL",
-    productVersion: "0.5.2",
+    productVersion: "0.5.3",
     fromExactDmg: true,
     installer: expectedInstaller,
     installerSha256: installed.installerSha256,
@@ -342,7 +342,7 @@ const canPass =
 const rec = {
   command: "test:e2e:installed",
   verdict: canPass ? "PASS" : "INCOMPLETE",
-  productVersion: "0.5.2",
+  productVersion: "0.5.3",
   fromExactDmg: true,
   installer: expectedInstaller,
   installerSha256: installed.installerSha256,

--- a/scripts/failure-baseline.mjs
+++ b/scripts/failure-baseline.mjs
@@ -146,14 +146,14 @@ async function probeStaleAlpha() {
 function probeVersions() {
   const root = readJson("package.json");
   const info = readJson("release-info.json");
-  const ok = root.version === "0.5.2" && info.productVersion === "0.5.2";
+  const ok = root.version === "0.5.3" && info.productVersion === "0.5.3";
   if (!ok) {
-    return result("FB-VERSIONS", "REPRODUCED", "workspace/release-info not 0.5.2", {
+    return result("FB-VERSIONS", "REPRODUCED", "workspace/release-info not 0.5.3", {
       packageVersion: root.version,
       productVersion: info.productVersion,
     });
   }
-  return result("FB-VERSIONS", "CLOSED", "root and release-info are 0.5.2", { version: root.version });
+  return result("FB-VERSIONS", "CLOSED", "root and release-info are 0.5.3", { version: root.version });
 }
 
 async function probeAggregator() {
@@ -185,9 +185,9 @@ function probePublication() {
   const pub = info.publication ?? {};
   const ok =
     pub.repo === "kevinchennewbee/PenglaiAgent" &&
-    pub.tag === "v0.5.2" &&
-    pub.release === "v0.5.2" &&
-    pub.channel === "stable-v0.5.2";
+    pub.tag === "v0.5.3" &&
+    pub.release === "v0.5.3" &&
+    pub.channel === "stable-v0.5.3";
   if (!ok) {
     return result("FB-PUBLICATION", "REPRODUCED", "publication fields do not match the owner-authorized destination", { pub });
   }
@@ -340,7 +340,7 @@ const dir = join(ROOT, "evidence", "generated");
 mkdirSync(dir, { recursive: true });
 writeFileSync(
   join(dir, "failure-baseline.json"),
-  JSON.stringify({ schema: 3, version: "0.5.2", probes: out, mustClose: MUST_CLOSE }, null, 2),
+  JSON.stringify({ schema: 3, version: "0.5.3", probes: out, mustClose: MUST_CLOSE }, null, 2),
 );
 console.log(
   "failure-baseline",

--- a/scripts/lib/closure-credential.mjs
+++ b/scripts/lib/closure-credential.mjs
@@ -61,7 +61,7 @@ export function inspectClosureCredential({ staging, candidateSha, expectedTarget
   } catch {
     return { verdict: "FAIL", reason: "runtime manifest is malformed" };
   }
-  if (manifest.target !== expectedTarget || manifest.release !== "0.5.2" || manifest.dsh !== "0.1.1-rc.1") {
+  if (manifest.target !== expectedTarget || manifest.release !== "0.5.3" || manifest.dsh !== "0.1.1-rc.1") {
     return { verdict: "FAIL", reason: "runtime manifest identity mismatch" };
   }
   if (!Array.isArray(manifest.files) || manifest.files.length === 0) {

--- a/scripts/lib/electron-fuses.mjs
+++ b/scripts/lib/electron-fuses.mjs
@@ -49,7 +49,7 @@ export function writeRequiredFuses(path) {
   });
   if (Buffer.compare(before, after) !== 0) writeFileSync(path, after);
   const info = inspectFuseWire(readFileSync(path));
-  if (info.values.runAsNode !== false || info.values.enableNodeCliInspectArguments !== false) {
+  if (info.values.runAsNode !== false || info.values.enableNodeOptionsEnvironmentVariable !== false || info.values.enableNodeCliInspectArguments !== false) {
     throw new Error("failed to write required fuses");
   }
   return info;

--- a/scripts/lib/installed-app.mjs
+++ b/scripts/lib/installed-app.mjs
@@ -6,8 +6,8 @@ import { tmpdir } from "node:os";
 import { ROOT } from "./repo.mjs";
 import { installerForTarget } from "./release-targets.mjs";
 
-export const ARM64_DMG = join(ROOT, "dist/Penglai_0.5.2_macos_aarch64.dmg");
-export const ARM64_INSTALLER = "Penglai_0.5.2_macos_aarch64.dmg";
+export const ARM64_DMG = join(ROOT, "dist/Penglai_0.5.3_macos_aarch64.dmg");
+export const ARM64_INSTALLER = "Penglai_0.5.3_macos_aarch64.dmg";
 
 export function leftoversByCommand(needle) {
   if (process.platform === "win32") {
@@ -129,7 +129,7 @@ export function readInstalledAppIdentity(app, target) {
 export function assertInstalledPenglaiIdentity(app, target) {
   const facts = readInstalledAppIdentity(app, target);
   if (facts.executable !== "Penglai") return { ok: false, reason: `executable ${facts.executable || "<empty>"}` };
-  if (facts.shortVersion !== "0.5.2" || facts.version !== "0.5.2") {
+  if (facts.shortVersion !== "0.5.3" || facts.version !== "0.5.3") {
     return { ok: false, reason: `version ${facts.shortVersion}/${facts.version}` };
   }
   if (facts.bundleId !== "com.penglai.dsh") return { ok: false, reason: `bundle ${facts.bundleId || "<empty>"}` };

--- a/scripts/lib/packaged-candidate.mjs
+++ b/scripts/lib/packaged-candidate.mjs
@@ -7,18 +7,18 @@ import { CLOSURE_CREDENTIAL_SCHEMA } from "./closure-credential.mjs";
 export const PACKAGED_TARGETS = Object.freeze({
   "darwin-aarch64": Object.freeze({
     buildTarget: "darwin-arm64",
-    appRelative: "dist/Penglai-v0.5.2-arm64-from-dmg/Penglai.app",
-    dmgRelative: "dist/Penglai_0.5.2_macos_aarch64.dmg",
+    appRelative: "dist/Penglai-v0.5.3-arm64-from-dmg/Penglai.app",
+    dmgRelative: "dist/Penglai_0.5.3_macos_aarch64.dmg",
   }),
   "darwin-x86_64": Object.freeze({
     buildTarget: "darwin-x64",
-    appRelative: "dist/Penglai-v0.5.2-x64-from-dmg/Penglai.app",
-    dmgRelative: "dist/Penglai_0.5.2_macos_x64.dmg",
+    appRelative: "dist/Penglai-v0.5.3-x64-from-dmg/Penglai.app",
+    dmgRelative: "dist/Penglai_0.5.3_macos_x64.dmg",
   }),
   "win32-x86_64": Object.freeze({
     buildTarget: "win32-x64",
-    appRelative: "dist/Penglai-v0.5.2-win32-x64/Penglai",
-    dmgRelative: "dist/Penglai_0.5.2_windows_x64_setup.exe",
+    appRelative: "dist/Penglai-v0.5.3-win32-x64/Penglai",
+    dmgRelative: "dist/Penglai_0.5.3_windows_x64_setup.exe",
   }),
 });
 
@@ -107,7 +107,7 @@ export function inspectPackagedCandidate({
   }
   if (
     release.productName !== "Penglai" ||
-    release.productVersion !== "0.5.2" ||
+    release.productVersion !== "0.5.3" ||
     release.generationId !== "penglai-dsh-v0.5" ||
     release.trustTier !== "community-verified" ||
     release.targetPlatform !== spec.buildTarget
@@ -137,7 +137,7 @@ export function inspectPackagedCandidate({
     };
   }
   if (
-    manifest.release !== "0.5.2" ||
+    manifest.release !== "0.5.3" ||
     manifest.target !== expectedTarget ||
     manifest.dsh !== release.dsh ||
     !Array.isArray(manifest.files) ||

--- a/scripts/lib/release-targets.mjs
+++ b/scripts/lib/release-targets.mjs
@@ -1,9 +1,9 @@
 export const RELEASE_TARGETS = Object.freeze(["darwin-aarch64", "darwin-x86_64", "win32-x86_64"]);
 
 export const TARGET_INSTALLERS = Object.freeze({
-  "darwin-aarch64": "Penglai_0.5.2_macos_aarch64.dmg",
-  "darwin-x86_64": "Penglai_0.5.2_macos_x64.dmg",
-  "win32-x86_64": "Penglai_0.5.2_windows_x64_setup.exe",
+  "darwin-aarch64": "Penglai_0.5.3_macos_aarch64.dmg",
+  "darwin-x86_64": "Penglai_0.5.3_macos_x64.dmg",
+  "win32-x86_64": "Penglai_0.5.3_windows_x64_setup.exe",
 });
 
 export function assertReleaseTarget(target) {

--- a/scripts/nsis/Penglai.nsi
+++ b/scripts/nsis/Penglai.nsi
@@ -1,13 +1,13 @@
-; Penglai 0.5.2 current-user NSIS Setup.
+; Penglai 0.5.3 current-user NSIS Setup.
 ; Cross-compiled / compiled only on Windows x64. This source is the contract
 ; for install identity, bilingual UI, default-preserve userData, and
 ; capability-bound complete delete. Native PASS is reserved for win-x64.
 
 !ifndef PENGLAI_VERSION
-  !define PENGLAI_VERSION "0.5.2"
+  !define PENGLAI_VERSION "0.5.3"
 !endif
 !ifndef PENGLAI_OUTFILE
-  !define PENGLAI_OUTFILE "Penglai_0.5.2_windows_x64_setup.exe"
+  !define PENGLAI_OUTFILE "Penglai_0.5.3_windows_x64_setup.exe"
 !endif
 
 Unicode true
@@ -62,7 +62,7 @@ LangString DESC_Desktop ${LANG_ENGLISH} "Desktop shortcut"
 
 Function .onInit
   ${IfNot} ${RunningX64}
-    MessageBox MB_ICONSTOP "Penglai 0.5.2 requires 64-bit Windows."
+    MessageBox MB_ICONSTOP "Penglai 0.5.3 requires 64-bit Windows."
     Abort
   ${EndIf}
   ReadRegStr $0 HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_ID}" "DisplayVersion"

--- a/scripts/nsis/license.rtf
+++ b/scripts/nsis/license.rtf
@@ -1,7 +1,7 @@
 {\rtf1\ansi\ansicpg1252\deff0
 {\fonttbl{\f0 Times New Roman;}}
 \fs24
-Penglai 0.5.2 is community-verified, ad-hoc sealed, and not Authenticode signed.
+Penglai 0.5.3 is community-verified, ad-hoc sealed, and not Authenticode signed.
 Install for the current user only. User data stays under %LOCALAPPDATA%\\Penglai\\0.5
 unless you later confirm a complete-delete capability.
 \par

--- a/scripts/package-mac.mjs
+++ b/scripts/package-mac.mjs
@@ -20,14 +20,14 @@ const targetArg = process.argv.includes("--target")
   : process.env.PENGLAI_PACK_TARGET;
 const TARGETS = {
   "darwin-arm64": {
-    out: "dist/Penglai-v0.5.2-arm64",
-    zip: "dist/Penglai-v0.5.2-arm64.zip",
+    out: "dist/Penglai-v0.5.3-arm64",
+    zip: "dist/Penglai-v0.5.3-arm64.zip",
     triple: "darwin-arm64",
     runtimeTarget: "darwin-aarch64",
   },
   "darwin-x64": {
-    out: "dist/Penglai-v0.5.2-x64",
-    zip: "dist/Penglai-v0.5.2-x64.zip",
+    out: "dist/Penglai-v0.5.3-x64",
+    zip: "dist/Penglai-v0.5.3-x64.zip",
     triple: "darwin-x64",
     runtimeTarget: "darwin-x86_64",
   },
@@ -208,12 +208,12 @@ if (existsSync(framework)) {
 }
 writeFileSync(
   join(outRoot, "README-UNSIGNED.txt"),
-  "Penglai 0.5.2 community release. trustTier=community-verified. Ad-hoc signed, not notarized. Gatekeeper may warn; do not disable system security.\n",
+  "Penglai 0.5.3 community release. trustTier=community-verified. Ad-hoc signed, not notarized. Gatekeeper may warn; do not disable system security.\n",
 );
 
 const info = {
   productName: "Penglai",
-  productVersion: "0.5.2",
+  productVersion: "0.5.3",
   name: targetSpec.out.split("/").pop(),
   buildNumber: 0,
   candidateOrdinal: 0,

--- a/scripts/package-windows-nsis.mjs
+++ b/scripts/package-windows-nsis.mjs
@@ -8,7 +8,7 @@ import { ROOT } from "./lib/repo.mjs";
 import { stagingForTarget } from "./lib/closure-credential.mjs";
 
 const contract = {
-  installer: "Penglai_0.5.2_windows_x64_setup.exe",
+  installer: "Penglai_0.5.3_windows_x64_setup.exe",
   currentUser: true,
   languages: ["zh", "en"],
   refuseDowngrade: true,
@@ -74,7 +74,7 @@ if (!existsSync(out)) {
   console.error("package-windows-nsis FAIL: setup missing after makensis");
   process.exit(1);
 }
-const installedRoot = resolve(ROOT, "dist", "Penglai-v0.5.2-win32-x64");
+const installedRoot = resolve(ROOT, "dist", "Penglai-v0.5.3-win32-x64");
 const installedApp = join(installedRoot, "Penglai");
 const installedRelative = relative(resolve(ROOT, "dist"), installedRoot);
 if (!installedRelative || installedRelative === ".." || installedRelative.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`) || isAbsolute(installedRelative)) {

--- a/scripts/package-windows-payload.mjs
+++ b/scripts/package-windows-payload.mjs
@@ -6,6 +6,7 @@ import { spawnSync } from "node:child_process";
 import { ROOT, gitState } from "./lib/repo.mjs";
 import { finish } from "./lib/exit-contract.mjs";
 import { stagingForTarget } from "./lib/closure-credential.mjs";
+import { writeRequiredFuses } from "./lib/electron-fuses.mjs";
 
 const staging = stagingForTarget(ROOT, "win32-x86_64");
 const payload = join(staging, "payload");
@@ -100,6 +101,11 @@ const stamped = run(process.execPath, [
 ]);
 if (stamped !== 0) {
   finish("FAIL", { command: "package:windows-payload", reason: "Penglai.exe resource stamping failed" });
+}
+try {
+  writeRequiredFuses(penglaiExe);
+} catch (error) {
+  finish("FAIL", { command: "package:windows-payload", reason: `Penglai.exe fuse hardening failed: ${String(error)}` });
 }
 
 const resources = join(payload, "resources");

--- a/scripts/package-windows-payload.mjs
+++ b/scripts/package-windows-payload.mjs
@@ -117,7 +117,7 @@ if (native) {
     join(resources, "release-info.json"),
     `${JSON.stringify({
       productName: "Penglai",
-      productVersion: "0.5.2",
+      productVersion: "0.5.3",
       buildNumber: 0,
       candidateOrdinal: 0,
       candidateKind: "public-community-release",

--- a/scripts/sbom.mjs
+++ b/scripts/sbom.mjs
@@ -79,10 +79,10 @@ const sbom = {
   specVersion: "1.5",
   version: 1,
   metadata: {
-    component: { type: "application", name: "Penglai", version: "0.5.2" },
-    tools: [{ name: "penglai-sbom", version: "0.5.2" }],
+    component: { type: "application", name: "Penglai", version: "0.5.3" },
+    tools: [{ name: "penglai-sbom", version: "0.5.3" }],
   },
-  release: "0.5.2",
+  release: "0.5.3",
   lockfileSha256: createHash("sha256").update(lock).digest("hex"),
   componentCount: components.length,
   components,

--- a/scripts/soak-installed.mjs
+++ b/scripts/soak-installed.mjs
@@ -56,7 +56,7 @@ const expectedInstaller = installerForTarget(expectedTarget);
 if (process.env.PENGLAI_SOAK_ALLOW_LONG !== "1") {
   finish("INCOMPLETE", {
     command: "test:soak:installed",
-    productVersion: "0.5.2",
+    productVersion: "0.5.3",
     requestedHours: hoursWanted,
     sourceSha: git.head,
     reason:
@@ -344,7 +344,7 @@ const leftover = leftoversByCommand(installedDsh).filter((line) => line.includes
 const elapsedHours = (Date.now() - started) / 3600_000;
 const rec = {
   command: "test:soak:installed",
-  productVersion: "0.5.2",
+  productVersion: "0.5.3",
   hours: elapsedHours,
   requestedHours: hoursWanted,
   samples,

--- a/scripts/stamp-windows-exe.mjs
+++ b/scripts/stamp-windows-exe.mjs
@@ -67,12 +67,12 @@ for (const version of versions) {
     version.setStringValues(language, {
       CompanyName: "Penglai",
       FileDescription: "Penglai",
-      FileVersion: "0.5.2.0",
+      FileVersion: "0.5.3.0",
       InternalName: "Penglai",
       LegalCopyright: "Penglai contributors",
       OriginalFilename: "Penglai.exe",
       ProductName: "Penglai",
-      ProductVersion: "0.5.2.0",
+      ProductVersion: "0.5.3.0",
     });
   }
   version.outputToResourceEntries(resources.entries);

--- a/scripts/u3-first-party-plugins.mjs
+++ b/scripts/u3-first-party-plugins.mjs
@@ -250,7 +250,7 @@ const commonOk = phases.every(
 const activeOk = activePhases.every(
   (phase) =>
     phase.rows.every((row) => row.present && row.enabled && row.phase === "active") &&
-    phase.packages.every((pkg) => pkg.present && pkg.version === "0.5.2"),
+    phase.packages.every((pkg) => pkg.present && pkg.version === "0.5.3"),
 );
 const disabledOk = disabledPhases.every((phase) =>
   phase.rows.every((row) => row.present && !row.enabled && row.phase === null),

--- a/scripts/verify-asr-real.ts
+++ b/scripts/verify-asr-real.ts
@@ -32,7 +32,7 @@ async function fetchFixture(): Promise<Buffer> {
   for (let hop = 0; hop <= 5; hop += 1) {
     const response = await fetch(url, {
       redirect: "manual",
-      headers: { "User-Agent": "Penglai/0.5.2 ASR real verifier" },
+      headers: { "User-Agent": "Penglai/0.5.3 ASR real verifier" },
       signal: AbortSignal.timeout(60_000),
     });
     if ([301, 302, 303, 307, 308].includes(response.status)) {

--- a/scripts/verify-contracts.mjs
+++ b/scripts/verify-contracts.mjs
@@ -117,9 +117,9 @@ if (notes051.includes("0.1.0-rc.8")) {
   console.error("RELEASE_NOTES_0.5.1 still pins rc.8");
   process.exit(1);
 }
-const notes052 = readFileSync(join(ROOT, "docs/RELEASE_NOTES_0.5.2.md"), "utf8");
+const notes052 = readFileSync(join(ROOT, "docs/RELEASE_NOTES_0.5.3.md"), "utf8");
 if (!notes052.includes("0.5.1 users") || !notes052.includes("Penglai → Update")) {
-  console.error("RELEASE_NOTES_0.5.2 does not describe the signed 0.5.1 assisted update");
+  console.error("RELEASE_NOTES_0.5.3 does not describe the signed 0.5.1 assisted update");
   process.exit(1);
 }
 const findings = readFileSync(join(ROOT, "docs/0.5.1/FINDINGS.md"), "utf8");
@@ -132,4 +132,4 @@ if (!ensure.includes("--target") || ensure.includes("this script has no --arch")
   console.error("ensure-electron is still host-only");
   process.exit(1);
 }
-console.log("verify:contracts ok", PINNED_DSH, "lark 1.73.0", "audio codecs 3.7.1/0.2.0", "release-contract 0.5.2");
+console.log("verify:contracts ok", PINNED_DSH, "lark 1.73.0", "audio codecs 3.7.1/0.2.0", "release-contract 0.5.3");

--- a/scripts/verify-fuses.mjs
+++ b/scripts/verify-fuses.mjs
@@ -22,10 +22,10 @@ if (!existsSync(policyPath)) {
   });
 }
 const raw = JSON.parse(readFileSync(policyPath, "utf8"));
-if (raw.runAsNode !== false || raw.enableNodeCliInspectArguments !== false) {
+if (raw.runAsNode !== false || raw.enableNodeOptionsEnvironmentVariable !== false || raw.enableNodeCliInspectArguments !== false) {
   finish("FAIL", {
     command: "verify:fuses",
-    reason: "fuse policy must disable RunAsNode and CLI inspect",
+    reason: "fuse policy must disable RunAsNode, NODE_OPTIONS, and CLI inspect",
   });
 }
 
@@ -53,7 +53,8 @@ if (packaged.verdict !== "PASS") {
     expectedTarget,
   });
 }
-const binary = join(app, "Contents/Frameworks/Electron Framework.framework/Electron Framework");
+const windows = expectedTarget === "win32-x86_64";
+const binary = windows ? join(app, "Penglai.exe") : join(app, "Contents/Frameworks/Electron Framework.framework/Electron Framework");
 if (!existsSync(binary)) {
   finish("INCOMPLETE", {
     command: "verify:fuses",
@@ -68,10 +69,10 @@ try {
 } catch (err) {
   finish("FAIL", { command: "verify:fuses", reason: String(err), binary });
 }
-if (info.values.runAsNode !== false || info.values.enableNodeCliInspectArguments !== false) {
+if (info.values.runAsNode !== false || info.values.enableNodeOptionsEnvironmentVariable !== false || info.values.enableNodeCliInspectArguments !== false) {
   finish("FAIL", {
     command: "verify:fuses",
-    reason: "packaged binary fuses do not match required disabled RunAsNode/inspect",
+    reason: "packaged binary fuses do not match required disabled RunAsNode/NODE_OPTIONS/inspect",
     values: info.values,
     binary,
   });
@@ -87,10 +88,10 @@ identity.recordAssertion({
   runnerNative: process.platform === "darwin" && ((expectedTarget === "darwin-aarch64" && process.arch === "arm64") || (expectedTarget === "darwin-x86_64" && process.arch === "x64")),
   exitCode: 0,
   details: {
-    safe: "packaged Electron Framework bytes have RunAsNode and CLI inspect disabled",
+    safe: "packaged Electron binary bytes have RunAsNode, NODE_OPTIONS, and CLI inspect disabled",
   },
 });
-identity.recordAssertion({
+if (!windows) identity.recordAssertion({
   acceptanceId: "R50-MAC-005",
   runnerId: "security",
   testId: "verify-fuses-binary",
@@ -101,7 +102,7 @@ identity.recordAssertion({
   runnerNative: process.platform === "darwin" && ((expectedTarget === "darwin-aarch64" && process.arch === "arm64") || (expectedTarget === "darwin-x86_64" && process.arch === "x64")),
   exitCode: 0,
   details: {
-    safe: "arm64 packaged binary fuse wire inspected; onlyLoadAppFromAsar remains false for unpacked app",
+    safe: "packaged macOS binary fuse wire inspected; onlyLoadAppFromAsar remains false for unpacked app",
   },
 });
 finish("PASS", {

--- a/scripts/verify-installed.mjs
+++ b/scripts/verify-installed.mjs
@@ -59,14 +59,14 @@ const path = existsSync(join(evidenceDir, evidenceName("installed-e2e", target))
     ? join(evidenceDir, "installed-e2e.json")
     : join(evidenceDir, evidenceName("installed-e2e", target));
 if (!existsSync(path)) {
-  finish("INCOMPLETE", { command: "verify:installed", reason: `no 0.5.2 installed evidence for ${target}`, target });
+  finish("INCOMPLETE", { command: "verify:installed", reason: `no 0.5.3 installed evidence for ${target}`, target });
 }
 const rec = JSON.parse(readFileSync(path, "utf8"));
 const blob = JSON.stringify(rec);
 if (/0\.2\.0-alpha|usable-fixture|sourceRead":true|Penglai-v0\.2\.0/.test(blob)) {
   finish("STALE", { command: "verify:installed", reason: "installed evidence is stale alpha or test-endpoint based" });
 }
-if (rec.productVersion !== "0.5.2" || rec.verdict !== "PASS") {
+if (rec.productVersion !== "0.5.3" || rec.verdict !== "PASS") {
   finish("INCOMPLETE", { command: "verify:installed", reason: "0.5 installed suite not PASS", target });
 }
 const expectedInstaller = installerForTarget(target);

--- a/scripts/verify-live-plugin-catalog.mjs
+++ b/scripts/verify-live-plugin-catalog.mjs
@@ -34,7 +34,7 @@ const shared = {
   cacheRoot: join(root, "cas"),
   trustPath: join(root, "trust-state.json"),
   lastGoodPath: join(root, "last-good-catalog.json"),
-  penglaiVersion: "0.5.2",
+  penglaiVersion: "0.5.3",
   dshExact: "0.1.1-rc.1",
   target: "darwin-aarch64",
   fetchImpl: authenticatedGithubApiFetch,

--- a/scripts/verify-live-plugin-catalog.mjs
+++ b/scripts/verify-live-plugin-catalog.mjs
@@ -16,7 +16,8 @@ import {
   pluginPermissionDigest,
 } from "../packages/runtime/src/index.ts";
 
-const expectedTag = process.argv[2] || "plugin-catalog-v1.000001";
+const expectedTag = process.argv[2] || "plugin-catalog-v1.000002";
+const expectedPlugin = process.argv[3] || "@penglai/office-reader";
 const root = mkdtempSync(join(tmpdir(), "penglai-live-plugin-catalog-"));
 const githubToken = process.env.GITHUB_TOKEN?.trim();
 const authenticatedGithubApiFetch = async (input, init = {}) => {
@@ -44,15 +45,20 @@ let record;
 try {
   const online = new PluginDistributionClient(shared);
   const snapshot = await online.refresh();
-  const entry = snapshot.catalog.entries.find((row) => row.id === "@penglai/plugin-pilot");
-  if (!entry) throw new Error("signed catalog is missing @penglai/plugin-pilot");
-  const pkg = await online.downloadPackage("@penglai/plugin-pilot");
+  const entry = snapshot.catalog.entries.find((row) => row.id === expectedPlugin);
+  if (!entry) throw new Error(`signed catalog is missing ${expectedPlugin}`);
+  if (!snapshot.catalog.entries.some((row) => row.id === "@penglai/plugin-pilot")) {
+    throw new Error("signed catalog dropped @penglai/plugin-pilot");
+  }
+  const pkg = await online.downloadPackage(expectedPlugin);
   const userDataRoot = join(root, "user-data");
   const profileDir = join(userDataRoot, "dsh-home", "profiles", "web");
   const txDir = join(userDataRoot, "profiles", "center-tx");
-  const pluginsDir = join(userDataRoot, "plugins", "packages");
+  const bundledPluginsDir = join(root, "bundled-plugins");
+  const registryPackagesDir = join(userDataRoot, "plugins", "packages");
   mkdirSync(profileDir, { recursive: true, mode: 0o700 });
-  mkdirSync(pluginsDir, { recursive: true, mode: 0o700 });
+  mkdirSync(bundledPluginsDir, { recursive: true, mode: 0o700 });
+  mkdirSync(registryPackagesDir, { recursive: true, mode: 0o700 });
   writeFileSync(join(profileDir, "cordis.patch.yml"), "# live signed catalog install\n", { mode: 0o600 });
 
   const desired = {};
@@ -63,7 +69,7 @@ try {
       installed
         ? [
             {
-              entryId: "penglai-plugin-pilot",
+              entryId: expectedPlugin.replace(/^@/, "").replaceAll("/", "-"),
               moduleName: entry.id,
               disabled: !enabled,
               enabled,
@@ -104,8 +110,8 @@ try {
     }),
     profileDir,
     txDir,
-    pluginsDir,
-    registryPackagesDir: pluginsDir,
+    pluginsDir: bundledPluginsDir,
+    registryPackagesDir,
     userDataRoot,
     target: "darwin-aarch64",
   });
@@ -126,8 +132,7 @@ try {
   const installedManifestPath = join(
     profileDir,
     "node_modules",
-    "@penglai",
-    "plugin-pilot",
+    ...entry.id.split("/"),
     "package.json",
   );
   const installedManifest = JSON.parse(readFileSync(installedManifestPath, "utf8"));
@@ -144,6 +149,8 @@ try {
       desired[entry.id] === false &&
       inventory.list()[0]?.enabled === false &&
       journal.phase === "committed" &&
+      existsSync(join(registryPackagesDir, `${entry.id.replace("@", "").replaceAll("/", "-")}-${entry.version}.tgz`)) &&
+      !existsSync(join(bundledPluginsDir, `${entry.id.replace("@", "").replaceAll("/", "-")}-${entry.version}.tgz`)) &&
       !existsSync(join(txDir, "active.lock")) &&
       !existsSync(join(userDataRoot, "plugins", "owner-capability.json")),
   );
@@ -157,7 +164,7 @@ try {
   const ok = Boolean(
     snapshot.source === "github-immutable" &&
       snapshot.tag === expectedTag &&
-      snapshot.sequence >= 1 &&
+      snapshot.sequence === 2 &&
       snapshot.signatureOk &&
       entry?.defaultEnabled === false &&
       entry.nativeCode === false &&

--- a/scripts/verify-live-plugin-catalog.mjs
+++ b/scripts/verify-live-plugin-catalog.mjs
@@ -105,12 +105,9 @@ try {
     profileDir,
     txDir,
     pluginsDir,
+    registryPackagesDir: pluginsDir,
     userDataRoot,
     target: "darwin-aarch64",
-    async stagePackage(downloaded) {
-      const name = `${downloaded.id.replace("@", "").replaceAll("/", "-")}-${downloaded.version}.tgz`;
-      writeFileSync(join(pluginsDir, name), readFileSync(downloaded.path), { mode: 0o600 });
-    },
   });
   const grant = issuePluginOwnerGrant({
     userDataRoot,

--- a/scripts/verify-live.mjs
+++ b/scripts/verify-live.mjs
@@ -8,7 +8,7 @@ if (!existsSync(path)) {
   finish("INCOMPLETE", { command: "verify:live", reason: "no 0.5 live evidence" });
 }
 const rec = JSON.parse(readFileSync(path, "utf8"));
-if (rec.productVersion !== "0.5.2") {
-  finish("STALE", { command: "verify:live", reason: "live evidence is not 0.5.2" });
+if (rec.productVersion !== "0.5.3") {
+  finish("STALE", { command: "verify:live", reason: "live evidence is not 0.5.3" });
 }
 finish("INCOMPLETE", { command: "verify:live", reason: "final live is reserved for RC15" });

--- a/scripts/verify-release-keys.mjs
+++ b/scripts/verify-release-keys.mjs
@@ -40,7 +40,7 @@ const pluginMatch =
 if (!updaterMatch || !pluginMatch) {
   finish("FAIL", {
     command: "verify:release-keys",
-    reason: "on-disk public keys do not match embedded 0.5.2 trust roots",
+    reason: "on-disk public keys do not match embedded 0.5.3 trust roots",
     updaterMatch,
     pluginMatch,
   });

--- a/scripts/verify-signing.mjs
+++ b/scripts/verify-signing.mjs
@@ -57,7 +57,7 @@ if (!adhoc) {
   process.exit(1);
 }
 
-const summary = ["Penglai 0.5.2 community-verified ad-hoc contract", `app=${app}`, `sourceSha=${packaged.release.sourceSha}`, `target=${expectedTarget}`, "codesign --verify --deep --strict --verbose=2: PASS", "signatureKind=adhoc", "developerIdSigned=false", "notarized=false", "authenticode=false", display.text.trim()].join("\n");
+const summary = ["Penglai 0.5.3 community-verified ad-hoc contract", `app=${app}`, `sourceSha=${packaged.release.sourceSha}`, `target=${expectedTarget}`, "codesign --verify --deep --strict --verbose=2: PASS", "signatureKind=adhoc", "developerIdSigned=false", "notarized=false", "authenticode=false", display.text.trim()].join("\n");
 mkdirSync(join(ROOT, "dist"), { recursive: true });
 writeFileSync(join(ROOT, "dist/codesign-verification.txt"), `${summary}\n`);
 finish("PASS", {

--- a/scripts/verify-soak.mjs
+++ b/scripts/verify-soak.mjs
@@ -15,7 +15,7 @@ const rec = JSON.parse(readFileSync(path, "utf8"));
 if (/0\.2\.0-alpha|ba5ba3dd|c19e393e/.test(JSON.stringify(rec))) {
   finish("STALE", { command: "verify:soak", reason: "soak evidence bound to stale alpha source/artifact" });
 }
-if (rec.productVersion !== "0.5.2" || rec.hours < 2) {
+if (rec.productVersion !== "0.5.3" || rec.hours < 2) {
   finish("INCOMPLETE", { command: "verify:soak", reason: "exact 0.5 two-hour soak not present" });
 }
 const current = existsSync(dmgPath) ? JSON.parse(readFileSync(dmgPath, "utf8")) : null;

--- a/scripts/verify-versions.mjs
+++ b/scripts/verify-versions.mjs
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { ROOT } from "./lib/repo.mjs";
 import { finish } from "./lib/exit-contract.mjs";
 
-const EXPECT = "0.5.2";
+const EXPECT = "0.5.3";
 const pkgs = [join(ROOT, "package.json"), join(ROOT, "apps/desktop/package.json")];
 for (const name of readdirSync(join(ROOT, "packages"))) {
   pkgs.push(join(ROOT, "packages", name, "package.json"));


### PR DESCRIPTION
## What changed

- make optional Penglai IM stay optional during post-update verification
- reconcile a superseded 0.5.2 recovery journal only after a genuinely newer app is installed, without fabricating a signed update ledger
- bump the full three-target release identity to 0.5.3
- add regression tests, release correction, and 0.5.3 publication/runbook contracts
- preserve 0.5.2 history and document its immutable post-verify defect

## Local verification

- format: PASS
- typecheck: PASS
- unit: 424/424 PASS
- contract: 62/62 PASS
- integration: 21/21 PASS
- desktop E2E: 68/68 PASS
- security: 15/15 PASS
- versions/identity/contracts/dependencies/secrets/release-key fingerprints: PASS

Public export evidence intentionally remains stale until the merged clean main SHA is frozen and regenerated. No private key or provider credential is included.