### PR TITLE
fix: keep 0.5.3 public downloads off GitHub API

### DIFF
--- a/packages/plugin-registry/src/download.ts
+++ b/packages/plugin-registry/src/download.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { PenglaiError } from "@penglai/contracts";
-import { ALLOWED_ASSET_HOSTS, GITHUB_API_ORIGIN, GITHUB_OWNER, PLUGIN_REGISTRY_REPO } from "./catalog-schema.js";
+import { ALLOWED_ASSET_HOSTS, GITHUB_API_ORIGIN } from "./catalog-schema.js";
 
 export interface DownloadRequest {
   url: string;
@@ -64,27 +64,12 @@ export function assertSafeDownloadUrl(raw: string, previous?: URL): URL {
   return parsed;
 }
 
-function inferOwnerRepo(url: string): string | undefined {
-  const parsed = new URL(url);
-  const github = /^\/([^/]+)\/([^/]+)\/releases\//.exec(parsed.pathname);
-  if (parsed.hostname === "github.com" && github) return `${github[1]}/${github[2]}`;
-  const api = /^\/repos\/([^/]+)\/([^/]+)\//.exec(parsed.pathname);
-  if (parsed.hostname === "api.github.com" && api) return `${api[1]}/${api[2]}`;
-  return undefined;
-}
-
-function githubAssetApiUrl(assetId: number, ownerRepo?: string): string {
-  const repo = ownerRepo ?? `${GITHUB_OWNER}/${PLUGIN_REGISTRY_REPO}`;
-  return `${GITHUB_API_ORIGIN}/repos/${repo}/releases/assets/${assetId}`;
-}
-
 export async function downloadVerifiedBytes(input: DownloadRequest): Promise<Buffer> {
-  let url = input.url;
-  const ownerRepo = input.ownerRepo ?? inferOwnerRepo(input.url);
-  if (input.assetId && input.assetId > 0 && new URL(input.url).hostname === "github.com") {
-    url = githubAssetApiUrl(input.assetId, ownerRepo);
-  }
-  const parsed = assertSafeDownloadUrl(url);
+  // Keep the signed, tagged browser_download_url as the transport URL. The
+  // asset id remains part of the signed catalog/update identity, but routing a
+  // public download through the REST asset endpoint consumes GitHub's tiny
+  // anonymous API quota and can make an otherwise public package return 403.
+  const parsed = assertSafeDownloadUrl(input.url);
   if (input.size <= 0 || input.size > input.maxBytes) throw new PenglaiError("SECURITY_POLICY", "download size bound");
   const fetchImpl = input.fetchImpl ?? fetch;
   const timeout = AbortSignal.timeout(30_000);

--- a/packages/plugin-registry/src/registry.test.ts
+++ b/packages/plugin-registry/src/registry.test.ts
@@ -383,7 +383,11 @@ test("PPDP/1 host refresh uses embedded keys and last-good offline", async () =>
   const dir = mkdtempSync(join(tmpdir(), "penglai-ppdp-"));
   const fetchImpl = (async (input) => {
     const url = String(input);
-    if (url.includes("/releases") && !url.includes("/assets/")) {
+    if (
+      url.startsWith("https://api.github.com/") &&
+      url.includes("/releases") &&
+      !url.includes("/assets/")
+    ) {
       return new Response(
         JSON.stringify([
           {

--- a/packages/plugin-registry/src/registry.test.ts
+++ b/packages/plugin-registry/src/registry.test.ts
@@ -456,11 +456,15 @@ test("GitHub 302 to official asset host is followed and hashed", async () => {
     url: "https://github.com/kevinchennewbee/PenglaiPluginRegistry/releases/download/plugin-pilot-v1.0.0/penglai-plugin-pilot-1.0.0-any.tgz",
     sha256: sha,
     size: body.length,
+    assetId: 123,
+    ownerRepo: "kevinchennewbee/PenglaiPluginRegistry",
     maxBytes: 1024,
     fetchImpl,
   });
   assert.equal(got.equals(body), true);
   assert.equal(hops.length, 2);
+  assert.equal(hops[0]?.startsWith("https://github.com/kevinchennewbee/PenglaiPluginRegistry/releases/download/"), true);
+  assert.equal(hops.some((url) => url.includes("api.github.com/repos/")), false);
 });
 
 test("GitHub 302 to a non-GitHub host is refused", async () => {


### PR DESCRIPTION
## Why
The installed 0.5.3 candidate refreshed signed catalog 000002 but Office Reader install failed with `download refused: 403` after the shared anonymous GitHub REST quota was exhausted.

## Fix
Keep the signed immutable `browser_download_url` as the byte transport. `assetId`, exact tag URL, size, SHA-256, and Ed25519 signatures remain bound and verified; only the unnecessary REST asset hop is removed.

## Evidence
- typecheck PASS
- direct transport regression PASS with assetId present
- anonymous live catalog 000002 refresh/download/verify/install-disabled/offline-last-good PASS