### PR TITLE
fix: complete remote plugin lifecycle transaction

### DIFF
--- a/packages/plugin-center/src/center.test.ts
+++ b/packages/plugin-center/src/center.test.ts
@@ -15,6 +15,7 @@ import vm from "node:vm";
 import {
   PluginCenterHost,
   R2_CATALOG,
+  createPluginLifecycle,
   validateCatalog,
   verifyPackage,
   workspaceProtectionSnapshot,
@@ -170,6 +171,62 @@ test("production Center has Typert remote and no ad-hoc HTTP", async () => {
   assert.equal(client.includes('fetch("/penglai/center"'), false);
   assert.match(remotes, /TypertRemoteService/);
   assert.match(remotes, /penglaiCenter/);
+});
+
+test("Center lifecycle creates a newly installed plugin by loader entry id and removes it on rollback", async () => {
+  const rows: Array<Record<string, unknown>> = [];
+  const calls: string[] = [];
+  const loader = {
+    resolve(id: string) {
+      calls.push(`resolve:${id}`);
+      return {
+        async update(options: { disabled?: boolean }) {
+          calls.push(`update:${id}:${String(options.disabled)}`);
+        },
+      };
+    },
+    async create(options: { id: string; name: string; disabled?: boolean }) {
+      calls.push(
+        `create:${options.id}:${options.name}:${String(options.disabled)}`,
+      );
+      rows.push({
+        entryId: options.id,
+        moduleName: options.name,
+        fiberPhase: options.disabled ? "disabled" : "active",
+      });
+      return options.id;
+    },
+    async remove(id: string) {
+      calls.push(`remove:${id}`);
+      const index = rows.findIndex((row) => row.entryId === id);
+      if (index >= 0) rows.splice(index, 1);
+    },
+    async await() {
+      calls.push("await");
+    },
+  };
+  const lifecycle = createPluginLifecycle(loader, { list: () => rows });
+  await lifecycle.apply({
+    id: "@penglai/office-reader",
+    enabled: false,
+    forceReload: false,
+    present: true,
+  });
+  assert.deepEqual(calls, [
+    "create:penglai-office-reader:@penglai/office-reader:true",
+    "await",
+  ]);
+  assert.equal(rows.length, 1);
+
+  calls.length = 0;
+  await lifecycle.apply({
+    id: "@penglai/office-reader",
+    enabled: false,
+    forceReload: false,
+    present: false,
+  });
+  assert.deepEqual(calls, ["remove:penglai-office-reader", "await"]);
+  assert.equal(rows.length, 0);
 });
 
 test("Penglai settings mounts strict generated-client descriptors before using remotes", async () => {

--- a/packages/plugin-center/src/index.ts
+++ b/packages/plugin-center/src/index.ts
@@ -296,7 +296,11 @@ export class PluginCenterHost {
       const isLoaded = rowLoaded(hit);
       const wanted = Boolean(desired[id]);
       const installed = this.installedVersion(id);
-      const version = e?.version ?? (installed !== "not-installed" && installed !== "invalid" ? installed : "remote");
+      const version =
+        e?.version ??
+        (installed !== "not-installed" && installed !== "invalid"
+          ? installed
+          : "remote");
       let health: PluginHealthResult = { healthy: false };
       if (isLoaded) {
         try {
@@ -313,8 +317,7 @@ export class PluginCenterHost {
         desired: wanted ? version : "disabled",
         installed,
         loaded: isLoaded,
-        healthy:
-          wanted && isLoaded && installed === version && health.healthy,
+        healthy: wanted && isLoaded && installed === version && health.healthy,
         actual: isLoaded ? "active" : wanted ? "failed" : "disabled",
         ...(health.error ? { error: health.error } : {}),
         ...(health.configuration === undefined
@@ -479,17 +482,65 @@ function resourceProbeFrom(
   };
 }
 
-export function apply(ctx: {
-  loader: {
-    resolve(id: string): {
-      update(
-        options: { disabled?: boolean },
-        create?: boolean,
-        force?: boolean,
-      ): Promise<void>;
-    };
-    await(): Promise<void>;
+interface CenterLoader {
+  resolve(id: string): {
+    update(
+      options: { disabled?: boolean },
+      create?: boolean,
+      force?: boolean,
+    ): Promise<void>;
   };
+  create(options: {
+    id: string;
+    name: string;
+    disabled?: boolean;
+  }): Promise<string>;
+  remove(id: string): Promise<void>;
+  await(): Promise<void>;
+}
+
+export function createPluginLifecycle(
+  loader: CenterLoader,
+  inventory: { list(): unknown },
+) {
+  return {
+    async apply(input: {
+      id: string;
+      enabled: boolean;
+      forceReload: boolean;
+      present: boolean;
+    }) {
+      const row = normalizeInventory(inventory.list()).find((entry) =>
+        rowMatches(entry, input.id),
+      );
+      if (!input.present) {
+        if (row?.entryId) {
+          await loader.remove(row.entryId);
+          await loader.await();
+        }
+        return;
+      }
+      if (!row?.entryId) {
+        await loader.create({
+          id: input.id.replace(/^@/, "").replaceAll("/", "-"),
+          name: input.id,
+          disabled: !input.enabled,
+        });
+        await loader.await();
+        return;
+      }
+      const entry = loader.resolve(row.entryId);
+      if (input.forceReload && input.enabled) {
+        await entry.update({ disabled: true }, false, true);
+      }
+      await entry.update({ disabled: !input.enabled }, false, true);
+      await loader.await();
+    },
+  };
+}
+
+export function apply(ctx: {
+  loader: CenterLoader;
   pluginInventory: { list(): unknown };
   llm?: OfficialLlm;
   get?: (name: string) => unknown;
@@ -616,24 +667,7 @@ export function apply(ctx: {
     inventory,
     catalog: catalog.entries,
     registry,
-    lifecycle: {
-      async apply(input) {
-        const row = normalizeInventory(inventory.list()).find((entry) =>
-          rowMatches(entry, input.id),
-        );
-        if (!row?.entryId) {
-          await ctx.loader.resolve(input.id).update({ disabled: !input.enabled }, true, true);
-          await ctx.loader.await();
-          return;
-        }
-        const entry = ctx.loader.resolve(row.entryId);
-        if (input.forceReload && input.enabled) {
-          await entry.update({ disabled: true }, false, true);
-        }
-        await entry.update({ disabled: !input.enabled }, false, true);
-        await ctx.loader.await();
-      },
-    },
+    lifecycle: createPluginLifecycle(ctx.loader, inventory),
     resourceProbe: (id) =>
       resourceProbeFrom(
         ctx as typeof ctx & Record<string, unknown>,

--- a/packages/plugin-center/src/profile-tx.ts
+++ b/packages/plugin-center/src/profile-tx.ts
@@ -19,7 +19,11 @@ import {
   sha256File,
   type PluginCatalogEntry,
 } from "@penglai/runtime";
-import { assertManifestMatchesCatalog, inspectPluginEntries, type ArchiveFile } from "@penglai/plugin-registry";
+import {
+  assertManifestMatchesCatalog,
+  inspectPluginEntries,
+  type ArchiveFile,
+} from "@penglai/plugin-registry";
 
 export interface ProfileTxResult {
   phase: "committed" | "rolled_back";
@@ -48,6 +52,7 @@ interface TransactionJournal {
   id: string;
   action: ProfileTxResult["action"];
   previousEnabled: boolean;
+  previousPresent: boolean;
   version?: string;
   packageSha256?: string;
   errorClass?: string;
@@ -70,13 +75,25 @@ function assertTransactionPaths(opts: {
     resolve(opts.profileDir) === resolve(opts.userDataRoot) ||
     resolve(opts.txDir) === resolve(opts.userDataRoot)
   ) {
-    throw new PenglaiError("SECURITY_POLICY", "Center transaction path escaped userData");
+    throw new PenglaiError(
+      "SECURITY_POLICY",
+      "Center transaction path escaped userData",
+    );
   }
-  if (existsSync(opts.profileDir) && lstatSync(opts.profileDir).isSymbolicLink()) {
-    throw new PenglaiError("SECURITY_POLICY", "Center profile must not be a symlink");
+  if (
+    existsSync(opts.profileDir) &&
+    lstatSync(opts.profileDir).isSymbolicLink()
+  ) {
+    throw new PenglaiError(
+      "SECURITY_POLICY",
+      "Center profile must not be a symlink",
+    );
   }
   if (existsSync(opts.txDir) && lstatSync(opts.txDir).isSymbolicLink()) {
-    throw new PenglaiError("SECURITY_POLICY", "Center transaction dir must not be a symlink");
+    throw new PenglaiError(
+      "SECURITY_POLICY",
+      "Center transaction dir must not be a symlink",
+    );
   }
 }
 
@@ -150,13 +167,19 @@ export function setPatchDisabled(
   return endsWithNl && !joined.endsWith("\n") ? `${joined}\n` : joined;
 }
 
-export function upsertPatchDisabled(patchText: string, pluginId: string, disabled: boolean): string {
+export function upsertPatchDisabled(
+  patchText: string,
+  pluginId: string,
+  disabled: boolean,
+): string {
   try {
     return setPatchDisabled(patchText, pluginId, disabled);
   } catch {
     const short = pluginId.replace(/^@/, "").replaceAll("/", "-");
     const row = `    - id: ${short}\n      name: "${pluginId}"\n      disabled: ${disabled ? "true" : "false"}\n`;
-    return patchText.endsWith("\n") ? `${patchText}${row}` : `${patchText}\n${row}`;
+    return patchText.endsWith("\n")
+      ? `${patchText}${row}`
+      : `${patchText}\n${row}`;
   }
 }
 
@@ -195,7 +218,10 @@ async function verifyExtractedPackage(
   const root = extractedRoot(directory);
   if (entry.source === "penglai-plugin-registry") {
     if (!archiveFiles) {
-      throw new PenglaiError("SECURITY_POLICY", "signed archive inspection evidence missing");
+      throw new PenglaiError(
+        "SECURITY_POLICY",
+        "signed archive inspection evidence missing",
+      );
     }
     const inspected = inspectPluginEntries(archiveFiles);
     assertManifestMatchesCatalog({
@@ -208,31 +234,53 @@ async function verifyExtractedPackage(
       ...(entry.entry ? { catalogEntry: entry.entry } : {}),
       ...(entry.clientEntry ? { catalogClientEntry: entry.clientEntry } : {}),
       ...(entry.nativeCode === false ? { catalogNativeCode: false } : {}),
-      ...(entry.networkOrigins ? { catalogNetworkOrigins: entry.networkOrigins } : {}),
+      ...(entry.networkOrigins
+        ? { catalogNetworkOrigins: entry.networkOrigins }
+        : {}),
       ...(entry.dataPaths ? { catalogDataPaths: entry.dataPaths } : {}),
     });
     const host = join(root, inspected.manifest.entry);
     if (!existsSync(host)) {
-      throw new PenglaiError("STORE_CORRUPT", `${entry.id} host bundle missing`);
+      throw new PenglaiError(
+        "STORE_CORRUPT",
+        `${entry.id} host bundle missing`,
+      );
     }
-    if (inspected.manifest.clientEntry && !existsSync(join(root, inspected.manifest.clientEntry))) {
-      throw new PenglaiError("STORE_CORRUPT", `${entry.id} client bundle missing`);
+    if (
+      inspected.manifest.clientEntry &&
+      !existsSync(join(root, inspected.manifest.clientEntry))
+    ) {
+      throw new PenglaiError(
+        "STORE_CORRUPT",
+        `${entry.id} client bundle missing`,
+      );
     }
   } else {
-    const manifest = JSON.parse(readFileSync(join(root, "package.json"), "utf8")) as unknown;
+    const manifest = JSON.parse(
+      readFileSync(join(root, "package.json"), "utf8"),
+    ) as unknown;
     assertPluginPackageManifest(manifest, entry);
     const host = join(root, "dist", "index.js");
     if (!existsSync(host)) {
-      throw new PenglaiError("STORE_CORRUPT", `${entry.id} host bundle missing`);
+      throw new PenglaiError(
+        "STORE_CORRUPT",
+        `${entry.id} host bundle missing`,
+      );
     }
     if (entry.hasClient && !existsSync(join(root, "dist", "client.js"))) {
-      throw new PenglaiError("STORE_CORRUPT", `${entry.id} client bundle missing`);
+      throw new PenglaiError(
+        "STORE_CORRUPT",
+        `${entry.id} client bundle missing`,
+      );
     }
   }
   const host = join(root, entry.entry ?? "dist/index.js");
   const source = readFileSync(host, "utf8");
   if (/from\s+["'][^"']*\/src\/|\.tsx?["']/.test(source)) {
-    throw new PenglaiError("SECURITY_POLICY", `${entry.id} source dependency in package`);
+    throw new PenglaiError(
+      "SECURITY_POLICY",
+      `${entry.id} source dependency in package`,
+    );
   }
   if (importModule) {
     const loaded = (await import(
@@ -244,7 +292,10 @@ async function verifyExtractedPackage(
       typeof plugin.apply !== "function" &&
       typeof loaded.default !== "function"
     ) {
-      throw new PenglaiError("STORE_CORRUPT", `${entry.id} plugin apply export missing`);
+      throw new PenglaiError(
+        "STORE_CORRUPT",
+        `${entry.id} plugin apply export missing`,
+      );
     }
   }
   return root;
@@ -285,14 +336,17 @@ export async function runProfileTransaction(opts: {
   entry: PluginCatalogEntry;
   action: "enable" | "disable" | "update" | "install";
   previousEnabled: boolean;
+  previousPresent?: boolean;
   applyLive: (input: {
     id: string;
     enabled: boolean;
     forceReload: boolean;
+    present: boolean;
   }) => Promise<void>;
   verifyActual: (input: {
     id: string;
     enabled: boolean;
+    present: boolean;
   }) => Promise<void>;
   readResources?: () => ResourceCounts;
   commitDesired: (enabled: boolean) => void;
@@ -300,7 +354,10 @@ export async function runProfileTransaction(opts: {
 }): Promise<ProfileTxResult> {
   assertTransactionPaths(opts);
   if (!isAbsolute(opts.pluginsDir)) {
-    throw new PenglaiError("SECURITY_POLICY", "trusted plugin directory must be absolute");
+    throw new PenglaiError(
+      "SECURITY_POLICY",
+      "trusted plugin directory must be absolute",
+    );
   }
   mkdirSync(opts.txDir, { recursive: true, mode: 0o700 });
   const operationId = randomUUID();
@@ -316,6 +373,7 @@ export async function runProfileTransaction(opts: {
       : opts.action === "enable"
         ? true
         : opts.previousEnabled;
+  const previousPresent = opts.previousPresent ?? true;
   const journal: TransactionJournal = {
     schema: 2,
     operationId,
@@ -323,8 +381,11 @@ export async function runProfileTransaction(opts: {
     id: opts.entry.id,
     action: opts.action,
     previousEnabled: opts.previousEnabled,
+    previousPresent,
     version: opts.entry.version,
-    ...(opts.action === "update" || opts.action === "enable" || opts.action === "install"
+    ...(opts.action === "update" ||
+    opts.action === "enable" ||
+    opts.action === "install"
       ? { packageSha256: opts.entry.sha256 }
       : {}),
   };
@@ -355,19 +416,33 @@ export async function runProfileTransaction(opts: {
     ) {
       const packageFile = join(opts.pluginsDir, opts.entry.packageFile);
       if (!isUnder(opts.pluginsDir, packageFile)) {
-        throw new PenglaiError("SECURITY_POLICY", "plugin package escaped catalog root");
+        throw new PenglaiError(
+          "SECURITY_POLICY",
+          "plugin package escaped catalog root",
+        );
       }
       assertPackageIntegrity(packageFile, opts.entry.sha256);
       mkdirSync(packageStage, { recursive: true, mode: 0o700 });
-      const archiveFiles = extractTarGz(readFileSync(packageFile), packageStage);
-      const packageRoot = await verifyExtractedPackage(packageStage, opts.entry, false, archiveFiles);
+      const archiveFiles = extractTarGz(
+        readFileSync(packageFile),
+        packageStage,
+      );
+      const packageRoot = await verifyExtractedPackage(
+        packageStage,
+        opts.entry,
+        false,
+        archiveFiles,
+      );
       rmSync(scoped, { recursive: true, force: true });
       copyDir(packageRoot, scoped);
       await verifyExtractedPackage(scoped, opts.entry, true, archiveFiles);
     } else if (opts.action === "enable") {
       const packageFile = join(opts.pluginsDir, opts.entry.packageFile);
       if (!isUnder(opts.pluginsDir, packageFile)) {
-        throw new PenglaiError("SECURITY_POLICY", "plugin package escaped catalog root");
+        throw new PenglaiError(
+          "SECURITY_POLICY",
+          "plugin package escaped catalog root",
+        );
       }
       assertPackageIntegrity(packageFile, opts.entry.sha256);
       const archiveFiles = inspectTarGz(readFileSync(packageFile));
@@ -388,13 +463,21 @@ export async function runProfileTransaction(opts: {
       id: opts.entry.id,
       enabled: desiredEnabled,
       forceReload: opts.action === "update",
+      present: true,
     });
     journal.phase = "verifying";
     atomicJournal(journalPath, journal);
-    await opts.verifyActual({ id: opts.entry.id, enabled: desiredEnabled });
+    await opts.verifyActual({
+      id: opts.entry.id,
+      enabled: desiredEnabled,
+      present: true,
+    });
     if (!desiredEnabled) {
       if (!opts.readResources) {
-        throw new PenglaiError("DSH_UNAVAILABLE", `${opts.entry.id} resource probe missing`);
+        throw new PenglaiError(
+          "DSH_UNAVAILABLE",
+          `${opts.entry.id} resource probe missing`,
+        );
       }
       assertResourceZero(opts.readResources());
     }
@@ -422,8 +505,13 @@ export async function runProfileTransaction(opts: {
         id: opts.entry.id,
         enabled: opts.previousEnabled,
         forceReload: opts.action === "update",
+        present: previousPresent,
       });
-      await opts.verifyActual({ id: opts.entry.id, enabled: opts.previousEnabled });
+      await opts.verifyActual({
+        id: opts.entry.id,
+        enabled: opts.previousEnabled,
+        present: previousPresent,
+      });
       opts.rollbackDesired(opts.previousEnabled);
     } catch (rollbackError) {
       throw new AggregateError(
@@ -469,7 +557,10 @@ export function recoverInterruptedTransaction(opts: {
   if (["staging", "activating", "verifying"].includes(String(raw.phase))) {
     const id = opts.id ?? raw.id;
     if (!id || typeof raw.previousEnabled !== "boolean") {
-      throw new PenglaiError("STORE_CORRUPT", "Center recovery journal incomplete");
+      throw new PenglaiError(
+        "STORE_CORRUPT",
+        "Center recovery journal incomplete",
+      );
     }
     const out = rollbackLastGood({ ...opts, id });
     rmSync(lockPath, { force: true });
@@ -508,7 +599,10 @@ export function rollbackLastGood(opts: {
   }
   const journalPath = join(opts.txDir, "journal.json");
   if (existsSync(journalPath)) {
-    const raw = JSON.parse(readFileSync(journalPath, "utf8")) as Record<string, unknown>;
+    const raw = JSON.parse(readFileSync(journalPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
     atomicJournal(journalPath, { ...raw, phase: "rolled_back" });
   }
   return { phase: "rolled_back", id: opts.id, action: "rollback" };

--- a/packages/plugin-center/src/remotes.ts
+++ b/packages/plugin-center/src/remotes.ts
@@ -57,6 +57,7 @@ export interface PluginLifecycle {
     id: string;
     enabled: boolean;
     forceReload: boolean;
+    present: boolean;
   }): Promise<void>;
 }
 
@@ -140,6 +141,7 @@ async function waitForInventory(
   inventory: { list(): unknown },
   id: string,
   enabled: boolean,
+  present = true,
   timeoutMs = 8_000,
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
@@ -149,16 +151,19 @@ async function waitForInventory(
       rowMatches(candidate, id),
     );
     observed = row ? String(row.fiberPhase ?? "disabled") : "missing";
-    if (rowLoaded(row) === enabled) return;
+    if (!present ? !row : Boolean(row) && rowLoaded(row) === enabled) return;
     await new Promise<void>((resolveWait) => setTimeout(resolveWait, 50));
   }
   throw new PenglaiError(
     "DSH_UNAVAILABLE",
-    `${id} loader postcondition expected enabled=${String(enabled)} observed=${observed}`,
+    `${id} loader postcondition expected present=${String(present)} enabled=${String(enabled)} observed=${observed}`,
   );
 }
 
-function previousEnabledFromJournal(txDir: string, id: string): boolean {
+function previousStateFromJournal(
+  txDir: string,
+  id: string,
+): { enabled: boolean; present: boolean } {
   const file = join(txDir, "journal.json");
   if (!existsSync(file)) {
     throw new PenglaiError("STORE_CORRUPT", "Center rollback journal missing");
@@ -166,11 +171,15 @@ function previousEnabledFromJournal(txDir: string, id: string): boolean {
   const raw = JSON.parse(readFileSync(file, "utf8")) as {
     id?: unknown;
     previousEnabled?: unknown;
+    previousPresent?: unknown;
   };
   if (raw.id !== id || typeof raw.previousEnabled !== "boolean") {
     throw new PenglaiError("STORE_CORRUPT", "Center rollback journal mismatch");
   }
-  return raw.previousEnabled;
+  return {
+    enabled: raw.previousEnabled,
+    present: raw.previousPresent !== false,
+  };
 }
 
 function isUnder(root: string, candidate: string): boolean {
@@ -347,6 +356,9 @@ export function createCenterRemote(opts: {
       );
     }
     const previousEnabled = Boolean(opts.host.desired()[id]);
+    const previousPresent = normalizeInventory(opts.inventory.list()).some(
+      (row) => rowMatches(row, id),
+    );
     const probe = opts.resourceProbe(id);
     return runProfileTransaction({
       userDataRoot: opts.userDataRoot,
@@ -359,9 +371,15 @@ export function createCenterRemote(opts: {
       entry,
       action,
       previousEnabled,
+      previousPresent,
       applyLive: (input) => opts.lifecycle.apply(input),
       verifyActual: (input) =>
-        waitForInventory(opts.inventory, input.id, input.enabled),
+        waitForInventory(
+          opts.inventory,
+          input.id,
+          input.enabled,
+          input.present,
+        ),
       ...(probe ? { readResources: () => probe.snapshot() } : {}),
       commitDesired: (enabled) => opts.host.setDesired(id, enabled),
       rollbackDesired: (enabled) => opts.host.setDesired(id, enabled),
@@ -526,16 +544,26 @@ export function createCenterRemote(opts: {
     },
     async rollback(id: string) {
       catalogEntry(opts.catalog, id, opts.registry, hostTarget());
-      const enabled = previousEnabledFromJournal(opts.txDir, id);
+      const previous = previousStateFromJournal(opts.txDir, id);
       const out = await rollbackLastGood({
         userDataRoot: opts.userDataRoot,
         profileDir: opts.profileDir,
         txDir: opts.txDir,
         id,
       });
-      await opts.lifecycle.apply({ id, enabled, forceReload: true });
-      await waitForInventory(opts.inventory, id, enabled);
-      opts.host.setDesired(id, enabled);
+      await opts.lifecycle.apply({
+        id,
+        enabled: previous.enabled,
+        forceReload: true,
+        present: previous.present,
+      });
+      await waitForInventory(
+        opts.inventory,
+        id,
+        previous.enabled,
+        previous.present,
+      );
+      opts.host.setDesired(id, previous.enabled);
       return out;
     },
   };


### PR DESCRIPTION
## Outcome

Fixes the real installed 0.5.3 candidate failure when a signed remote plugin is downloaded but cannot be committed into the live DSH loader.

## Root cause

The first installation used the package name @penglai/office-reader as a loader entry id. The official DSH loader resolves the configured entry id penglai-office-reader and cannot resolve a package name that has no inventory row yet. Rollback also did not distinguish an originally absent plugin from an originally disabled one.

## Change

- create absent plugins through the official loader create API with a deterministic entry id
- remove newly-created entries when rollback restores an originally absent plugin
- persist previousPresent in the transaction journal
- verify both presence and enabled state in postconditions
- add a focused create/rollback regression

## Verification

- format PASS
- typecheck PASS
- unit 427/427 PASS
- contract 62/62 PASS
- integration 21/21 PASS
- desktop E2E 69/69 PASS
- security 15/15 PASS
- versions/contracts/dependencies/licenses/secrets PASS

This PR does not publish a release. The installed Office plugin flow will be rerun from the exact merged SHA before v0.5.3 is frozen.