### PR TITLE
fix: restart DSH after verified plugin updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Penglai Center is a real DSH host/client plugin inside the official DSH settings
 
 Penglai includes PPDP/1, the Penglai Plugin Distribution Protocol. The client can discover versioned GitHub Releases from the public [Penglai Plugin Registry](https://github.com/kevinchennewbee/PenglaiPluginRegistry), verify a Penglai Ed25519 signature and each archive hash, install a package in the disabled state, ask for permission confirmation, and roll back a failed activation.
 
-The current signed catalog is the immutable [`plugin-catalog-v1.000002`](https://github.com/kevinchennewbee/PenglaiPluginRegistry/releases/tag/plugin-catalog-v1.000002) Release. It keeps the Pilot and adds `@penglai/office-reader` 0.1.0 for bounded, read-only DOCX/XLSX/PPTX extraction. The production client has refreshed it from GitHub, verified both signatures, staged the archive under app-private data, installed it disabled, and recovered the signed last-good catalog offline. Future reviewed DSH plugins can be published in a new catalog sequence without rebuilding the Penglai desktop application.
+The current signed catalog is the immutable [`plugin-catalog-v1.000004`](https://github.com/kevinchennewbee/PenglaiPluginRegistry/releases/tag/plugin-catalog-v1.000004) Release. It keeps the Pilot and carries `@penglai/office-reader` 0.1.2 for bounded, read-only DOCX/XLSX/PPTX extraction under the exact DSH 0.1.1-rc.1 tool contracts. The production client has refreshed it from GitHub, verified both signatures, staged the archive under app-private data, installed it disabled, and recovered the signed last-good catalog offline. Future reviewed DSH plugins can be published in a new catalog sequence without rebuilding the Penglai desktop application.
 
 Penglai Center does not accept arbitrary npm packages, Git repositories, or download URLs. A DSH plugin runs with the local DSH process permissions. Catalog permission fields explain what was reviewed and what the user is confirming; they are not an operating-system sandbox.
 
@@ -251,7 +251,7 @@ Penglai Center 是 official DSH settings 里的真实 host/client 插件。insta
 
 蓬莱包含 PPDP/1，也就是蓬莱插件发行协议。客户端从公开的 [Penglai Plugin Registry](https://github.com/kevinchennewbee/PenglaiPluginRegistry) 查找按版本发布的 GitHub Release，验证蓬莱 Ed25519 签名和每个 tar 包的 SHA。插件先以 disabled 状态安装，用户确认权限后再启用；启用失败会回滚。
 
-当前签名 catalog 是不可变的 [`plugin-catalog-v1.000002`](https://github.com/kevinchennewbee/PenglaiPluginRegistry/releases/tag/plugin-catalog-v1.000002) Release。它保留试航插件，并新增 `@penglai/office-reader` 0.1.0，用于有界、只读地提取 DOCX、XLSX、PPTX。生产客户端已经真实完成 GitHub 刷新、两层验签、用户私有目录 staging、默认关闭安装，以及断网后的 signed last-good 恢复。以后加入经过审核的 DSH 插件，只需要发布新的 catalog sequence，不需要为了改列表重做桌面客户端。
+当前签名 catalog 是不可变的 [`plugin-catalog-v1.000004`](https://github.com/kevinchennewbee/PenglaiPluginRegistry/releases/tag/plugin-catalog-v1.000004) Release。它保留试航插件，并提供 `@penglai/office-reader` 0.1.2，在 DSH 0.1.1-rc.1 的精确工具 contract 下有界、只读地提取 DOCX、XLSX、PPTX。生产客户端已经真实完成 GitHub 刷新、两层验签、用户私有目录 staging、默认关闭安装，以及断网后的 signed last-good 恢复。以后加入经过审核的 DSH 插件，只需要发布新的 catalog sequence，不需要为了改列表重做桌面客户端。
 
 插件中心不接受任意 npm、Git 仓库或下载 URL。DSH 插件与本机 DSH 进程共享权限。catalog 里的 permission 用来说明审核内容和用户正在确认什么，不是操作系统沙箱。
 

--- a/apps/desktop/src/desktop.test.ts
+++ b/apps/desktop/src/desktop.test.ts
@@ -12,6 +12,7 @@ test("community release notice keeps platform trust limits without candidate wor
 
 test("IPC allowlist rejects unknown", () => {
   assert.equal(assertIpcName("getHealth"), true);
+  assert.equal(assertIpcName("restartPluginRuntime"), true);
   assert.equal(assertIpcName("eval"), false);
 });
 

--- a/apps/desktop/src/electron-main.ts
+++ b/apps/desktop/src/electron-main.ts
@@ -50,6 +50,12 @@ import {
 import { productionDebuggerForbidden } from "./production-flags.js";
 import { onboardingLedgerComplete, sanitizeStartupReason, wizardUrlForOrigin } from "./wizard-gate.js";
 import { createContextGrantReceipt } from "./context-grant.js";
+import {
+  issuePluginRuntimeRestart,
+  verifyPluginRuntimeRestart,
+  type PendingPluginRuntimeRestart,
+  type PluginUpdateJournalEvidence,
+} from "./plugin-runtime-restart.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 
@@ -292,6 +298,7 @@ async function main(): Promise<void> {
     authorizer: DeletionAuthorizer;
     preview: DeletionPreview;
   } | undefined;
+  let pendingPluginRuntimeRestart: PendingPluginRuntimeRestart | undefined;
 
   const workspaceProtectionPath = join(user.root, "plugins", "workspace-protection.json");
 
@@ -749,7 +756,44 @@ async function main(): Promise<void> {
               nativeCode: described.nativeCode,
             }),
           });
+          if (ownerAction === "plugin-update") {
+            pendingPluginRuntimeRestart = issuePluginRuntimeRestart({
+              id: described.id,
+              version: described.version,
+              sha256: described.sha256,
+            });
+          }
           return { capabilityId: grant.capabilityId };
+        }
+        if (name === "restartPluginRuntime") {
+          if (args.length !== 1) throw new PenglaiError("INVALID_INPUT", "one plugin restart payload is required");
+          const rec = args[0] as { id?: unknown };
+          if (!rec || typeof rec.id !== "string" || !rec.id) {
+            throw new PenglaiError("INVALID_INPUT", "plugin id required");
+          }
+          const journalPath = join(user.root, "profiles", "center-tx", "journal.json");
+          if (!existsSync(journalPath)) {
+            throw new PenglaiError("SECURITY_POLICY", "plugin update journal is missing");
+          }
+          const evidence = JSON.parse(readFileSync(journalPath, "utf8")) as PluginUpdateJournalEvidence;
+          const authorized = verifyPluginRuntimeRestart({
+            pending: pendingPluginRuntimeRestart,
+            requestedId: rec.id,
+            journal: evidence,
+          });
+          pendingPluginRuntimeRestart = undefined;
+          const timer = setTimeout(() => {
+            void exclusive(async () => {
+              await stopOwnedServices();
+              await restartOwnedServices();
+            }).catch((error) => failProbe(error instanceof Error ? error.message : String(error)));
+          }, 100);
+          timer.unref?.();
+          return {
+            scheduled: true,
+            id: authorized.id,
+            version: authorized.version,
+          };
         }
         if (name === "wizardPickFolder") {
           requireNoArguments(args);

--- a/apps/desktop/src/plugin-runtime-restart.test.ts
+++ b/apps/desktop/src/plugin-runtime-restart.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  issuePluginRuntimeRestart,
+  verifyPluginRuntimeRestart,
+} from "./plugin-runtime-restart.js";
+
+const sha256 = "a".repeat(64);
+
+test("plugin runtime restart requires the exact committed update journal", () => {
+  const pending = issuePluginRuntimeRestart({
+    id: "@penglai/office-reader",
+    version: "0.1.2",
+    sha256,
+    nowMs: 1_000,
+  });
+  assert.deepEqual(
+    verifyPluginRuntimeRestart({
+      pending,
+      requestedId: "@penglai/office-reader",
+      journal: {
+        phase: "committed",
+        action: "update",
+        id: "@penglai/office-reader",
+        version: "0.1.2",
+        packageSha256: sha256,
+      },
+      nowMs: 1_001,
+    }),
+    pending,
+  );
+});
+
+test("plugin runtime restart fails closed for stale or mismatched evidence", () => {
+  const pending = issuePluginRuntimeRestart({
+    id: "@penglai/office-reader",
+    version: "0.1.2",
+    sha256,
+    nowMs: 1_000,
+    ttlMs: 100,
+  });
+  const journal = {
+    phase: "committed",
+    action: "update",
+    id: "@penglai/office-reader",
+    version: "0.1.2",
+    packageSha256: sha256,
+  };
+  assert.throws(
+    () => verifyPluginRuntimeRestart({ pending, requestedId: pending.id, journal, nowMs: 1_101 }),
+    /expired/,
+  );
+  assert.throws(
+    () => verifyPluginRuntimeRestart({
+      pending,
+      requestedId: pending.id,
+      journal: { ...journal, phase: "rolled_back" },
+      nowMs: 1_050,
+    }),
+    /mismatch/,
+  );
+});

--- a/apps/desktop/src/plugin-runtime-restart.ts
+++ b/apps/desktop/src/plugin-runtime-restart.ts
@@ -1,0 +1,62 @@
+import { PenglaiError } from "@penglai/contracts";
+
+export interface PendingPluginRuntimeRestart {
+  id: string;
+  version: string;
+  sha256: string;
+  expiresAt: number;
+}
+
+export interface PluginUpdateJournalEvidence {
+  phase?: unknown;
+  id?: unknown;
+  action?: unknown;
+  version?: unknown;
+  packageSha256?: unknown;
+}
+
+export function issuePluginRuntimeRestart(input: {
+  id: string;
+  version: string;
+  sha256: string;
+  nowMs?: number;
+  ttlMs?: number;
+}): PendingPluginRuntimeRestart {
+  if (!input.id || !input.version || !/^[0-9a-f]{64}$/.test(input.sha256)) {
+    throw new PenglaiError("SECURITY_POLICY", "plugin runtime restart identity is incomplete");
+  }
+  const now = input.nowMs ?? Date.now();
+  const ttl = input.ttlMs ?? 2 * 60_000;
+  if (!Number.isSafeInteger(ttl) || ttl <= 0 || ttl > 5 * 60_000) {
+    throw new PenglaiError("SECURITY_POLICY", "plugin runtime restart ttl is invalid");
+  }
+  return {
+    id: input.id,
+    version: input.version,
+    sha256: input.sha256,
+    expiresAt: now + ttl,
+  };
+}
+
+export function verifyPluginRuntimeRestart(input: {
+  pending: PendingPluginRuntimeRestart | undefined;
+  requestedId: string;
+  journal: PluginUpdateJournalEvidence;
+  nowMs?: number;
+}): PendingPluginRuntimeRestart {
+  const pending = input.pending;
+  if (!pending || (input.nowMs ?? Date.now()) > pending.expiresAt) {
+    throw new PenglaiError("SECURITY_POLICY", "plugin runtime restart authorization expired");
+  }
+  if (
+    input.requestedId !== pending.id ||
+    input.journal.phase !== "committed" ||
+    input.journal.action !== "update" ||
+    input.journal.id !== pending.id ||
+    input.journal.version !== pending.version ||
+    input.journal.packageSha256 !== pending.sha256
+  ) {
+    throw new PenglaiError("SECURITY_POLICY", "plugin runtime restart evidence mismatch");
+  }
+  return pending;
+}

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -18,6 +18,7 @@ export const PRELOAD_API = [
   "wizardPickFolder",
   "pickContextFolder",
   "confirmPluginAction",
+  "restartPluginRuntime",
 ] as const;
 
 export type PreloadApiName = (typeof PRELOAD_API)[number];

--- a/docs/PLUGIN_CENTER.md
+++ b/docs/PLUGIN_CENTER.md
@@ -34,7 +34,7 @@ Plugin Center 是 official DSH Web 的 host/client plugin，UI 注册在 `settin
 
 0.5.1 起，Center 只从公开仓库 `kevinchennewbee/PenglaiPluginRegistry` 的不可变 GitHub Release 发现远程插件。目录 JSON 与每个 tar 包分别使用内置 Ed25519 信任根验签；sequence 只能前进，断网时只读已验签的 last-good。远程包默认关闭，用户确认权限后才安装；包先写入用户私有的 `Penglai/0.5/plugins/packages`，不得修改应用内置插件目录。
 
-当前不可变目录是 `plugin-catalog-v1.000002`。其中 `@penglai/office-reader` 0.1.0 只读提取 DOCX/XLSX/PPTX，声明 `workspace.read`，无网络、原生代码、安装脚本或宏执行。它不是完整 Office 编辑套件，公式只报告不计算，布局、图表和图片不冒充已还原。以后发布兼容的新目录 sequence 不需要重做 Penglai 客户端。
+当前不可变目录是 `plugin-catalog-v1.000004`。其中 `@penglai/office-reader` 0.1.2 只读提取 DOCX/XLSX/PPTX，声明 `workspace.read`，无网络、原生代码、安装脚本或宏执行，并使用 DSH 0.1.1-rc.1 要求的结构化输入与输出 contract。它不是完整 Office 编辑套件，公式只报告不计算，布局、图表和图片不冒充已还原。以后发布兼容的新目录 sequence 不需要重做 Penglai 客户端；插件包更新成功后，0.5.3 会在已授权且事务身份完全匹配时重启内置 DSH，以免 Node 模块缓存继续运行旧代码。
 
 安装包离线携带这些 tarball 是为了让普通用户无需联网取代码即可选择扩展，不代表它们已安装。完成 BYOK 后 official DSH 必须独立可用；fresh profile 只安装 Center，其他扩展在用户点击“安装并启用”后才校验、写入、加载。任一可选插件 absent/disabled/unconfigured 都不得阻断 DSH core、已安装 IM 的 text 链或无关插件。
 

--- a/docs/RELEASE_NOTES_0.5.3.md
+++ b/docs/RELEASE_NOTES_0.5.3.md
@@ -13,7 +13,7 @@ Penglai 0.5.3 is an update-closeout hotfix. It keeps official DeepSeek Harness `
 
 ## Office Reader plugin
 
-The immutable signed catalog [`plugin-catalog-v1.000002`](https://github.com/kevinchennewbee/PenglaiPluginRegistry/releases/tag/plugin-catalog-v1.000002) adds `@penglai/office-reader` 0.1.0. It is a deliberately read-only first release: bounded text and cell extraction for DOCX, XLSX, and PPTX through the official DSH filesystem, with no network, native code, install scripts, or macro execution. It remains disabled until the owner confirms `workspace.read` in Plugin Center. Publishing later compatible catalog sequences does not require another desktop release.
+The immutable signed catalog [`plugin-catalog-v1.000004`](https://github.com/kevinchennewbee/PenglaiPluginRegistry/releases/tag/plugin-catalog-v1.000004) carries `@penglai/office-reader` 0.1.2. It is a deliberately read-only first release: bounded text and cell extraction for DOCX, XLSX, and PPTX through the official DSH filesystem, with no network, native code, install scripts, or macro execution. Version 0.1.2 uses the exact structured input/output contracts required by DSH 0.1.1-rc.1. It remains disabled until the owner confirms `workspace.read` in Plugin Center. Publishing later compatible catalog sequences does not require another desktop release.
 
 ## 0.5.2 correction
 
@@ -32,4 +32,4 @@ All paths preserve the `Penglai/0.5` data generation and external Workspaces. Th
 
 This remains a `community-verified` release. macOS packages are ad-hoc signed and not notarized; Windows is not Authenticode signed. Gatekeeper or SmartScreen may warn. Do not disable system security.
 
-The Plugin Center remains independent of desktop releases: another compatible, Penglai-signed catalog generation or DSH plugin archive can be published through the public [Penglai Plugin Registry](https://github.com/kevinchennewbee/PenglaiPluginRegistry) without rebuilding the client. Catalog 2 has passed production-path GitHub refresh, catalog and package signature verification, app-private staging, disabled-by-default installation, and offline last-good recovery.
+The Plugin Center remains independent of desktop releases: another compatible, Penglai-signed catalog generation or DSH plugin archive can be published through the public [Penglai Plugin Registry](https://github.com/kevinchennewbee/PenglaiPluginRegistry) without rebuilding the client. Catalog 4 has passed production-path GitHub refresh, catalog and package signature verification, app-private staging, disabled-by-default installation, and offline last-good recovery. When an updated plugin package requires a fresh module instance, 0.5.3 permits an automatic embedded-DSH restart only after native owner approval and an exact committed update journal match.

--- a/packages/plugin-center/src/center.test.ts
+++ b/packages/plugin-center/src/center.test.ts
@@ -105,6 +105,8 @@ test("R50-E2E-003 Center client marks loading and ready with data-penglai-center
   assert.match(client, /window\.location\.reload\(\)/);
   assert.match(client, /unwrapRemote\(await centerRemote\.enable/);
   assert.match(client, /centerRemote\.refreshRegistry/);
+  assert.match(client, /restartRequired === true/);
+  assert.match(client, /api\.restartPluginRuntime\(\{ id \}\)/);
   const block = client.match(/const FIRST_PARTY_CARDS = \[([\s\S]*?)\];/);
   assert.ok(block);
   const cardIds = [...block[1].matchAll(/id: "(@penglai\/[^"]+)"/g)].map(

--- a/packages/plugin-center/src/dsh-client.js
+++ b/packages/plugin-center/src/dsh-client.js
@@ -1026,8 +1026,18 @@ window.__ModuleLoader__.load({
             }
             if (action === "enable")
               return unwrapRemote(await centerRemote.enable({ id, capabilityId: cap.capabilityId }));
-            if (action === "update")
-              return unwrapRemote(await centerRemote.update({ id, capabilityId: cap.capabilityId }));
+            if (action === "update") {
+              const result = unwrapRemote(
+                await centerRemote.update({ id, capabilityId: cap.capabilityId }),
+              );
+              if (result?.restartRequired === true) {
+                if (typeof api.restartPluginRuntime !== "function") {
+                  throw new Error("native plugin runtime restart is required");
+                }
+                await api.restartPluginRuntime({ id });
+              }
+              return result;
+            }
             return unwrapRemote(
               await centerRemote.installDisabled({ id, capabilityId: cap.capabilityId }),
             );

--- a/scripts/verify-live-plugin-catalog.mjs
+++ b/scripts/verify-live-plugin-catalog.mjs
@@ -16,8 +16,11 @@ import {
   pluginPermissionDigest,
 } from "../packages/runtime/src/index.ts";
 
-const expectedTag = process.argv[2] || "plugin-catalog-v1.000002";
+const expectedTag = process.argv[2] || "plugin-catalog-v1.000004";
 const expectedPlugin = process.argv[3] || "@penglai/office-reader";
+const expectedSequenceMatch = /^plugin-catalog-v1\.(\d{6})$/.exec(expectedTag);
+if (!expectedSequenceMatch) throw new Error("expected catalog tag is invalid");
+const expectedSequence = Number(expectedSequenceMatch[1]);
 const root = mkdtempSync(join(tmpdir(), "penglai-live-plugin-catalog-"));
 const githubToken = process.env.GITHUB_TOKEN?.trim();
 const authenticatedGithubApiFetch = async (input, init = {}) => {
@@ -164,7 +167,7 @@ try {
   const ok = Boolean(
     snapshot.source === "github-immutable" &&
       snapshot.tag === expectedTag &&
-      snapshot.sequence === 2 &&
+      snapshot.sequence === expectedSequence &&
       snapshot.signatureOk &&
       entry?.defaultEnabled === false &&
       entry.nativeCode === false &&


### PR DESCRIPTION
## Summary
- restart the embedded DSH runtime after a committed plugin package update so Node does not retain the previous module bytes
- bind that restart to a recent native owner approval and the exact committed plugin id, version, and SHA-256 journal evidence
- advance live catalog verification and public documentation to immutable catalog 4 / Office Reader 0.1.2

## Verification
- targeted desktop, restart authorization, and Plugin Center tests: 36/36 PASS
- full local format/type/unit/contract/integration/e2e/security/version/dependency/license/secret gates passed before this isolated commit
- live immutable catalog 4 signature, package hash, disabled install, and offline last-good verification PASS

## Release boundary
This PR does not publish v0.5.3. Existing draft artifacts target the prior SHA and must be replaced after merge and fresh three-platform native packaging.
