### PR TITLE
fix: bind updater verification to opened installer bytes

### DIFF
--- a/packages/runtime/src/leftover.test.ts
+++ b/packages/runtime/src/leftover.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { createHash, generateKeyPairSync, sign } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { PenglaiError } from "@penglai/contracts";
@@ -96,6 +96,33 @@ test("R50-UPD-008/009/010 verified installer and crash replay", () => {
   assert.equal(applyUpdateOutcome("HANDOFF_TO_INSTALLER", false), "ROLLED_BACK");
   assert.equal(replayUpdateCrash("DOWNLOADING"), "DOWNLOADING");
   assert.equal(replayUpdateCrash("VERIFYING"), "VERIFYING");
+});
+
+test("verified installer handoff refuses a symlink even when target bytes are signed", () => {
+  if (process.platform === "win32") return;
+  const root = mkdtempSync(join(tmpdir(), "penglai-update-handoff-link-"));
+  const outside = join(root, "signed-outside.dmg");
+  const linked = join(root, "Penglai_0.5.3_macos_aarch64.dmg");
+  const payload = Buffer.from("signed-installer");
+  writeFileSync(outside, payload);
+  symlinkSync(outside, linked);
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const publicKeyHex = Buffer.from(
+    publicKey.export({ type: "spki", format: "der" }).subarray(-32),
+  ).toString("hex");
+  const signature = sign(null, payload, privateKey);
+  const sha256 = createHash("sha256").update(payload).digest("hex");
+  const handoff = new VerifiedInstallerHandoff(root, publicKeyHex);
+  assert.throws(
+    () => handoff.register({
+      operationId: "operation-link",
+      path: linked,
+      sha256,
+      size: payload.length,
+      signature,
+    }),
+    /identity mismatch/,
+  );
 });
 
 test("R50-UN-004 default uninstall preserves user data", () => {

--- a/packages/runtime/src/update-flow.ts
+++ b/packages/runtime/src/update-flow.ts
@@ -7,11 +7,11 @@ import {
   mkdirSync,
   openSync,
   closeSync,
+  fstatSync,
   fsyncSync,
   readFileSync,
   renameSync,
   rmSync,
-  statSync,
 } from "node:fs";
 import { dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import { pipeline } from "node:stream/promises";
@@ -20,6 +20,7 @@ import { PenglaiError } from "@penglai/contracts";
 import { assertSafeDownloadUrl } from "@penglai/plugin-registry";
 import {
   nextUpdateState,
+  readBoundUpdatePayload,
   verifyPayload,
   writeUpdateJournal,
   type UpdateJournal,
@@ -62,16 +63,9 @@ export async function downloadVerifiedPayload(opts: {
   const part = join(opts.destDir, `${opts.expectedSha256}${suffix}.part`);
   const finalPath = join(opts.destDir, `${opts.expectedSha256}${suffix}`);
   if (existsSync(finalPath)) {
-    const stat = lstatSync(finalPath);
-    if (
-      stat.isSymbolicLink() ||
-      !stat.isFile() ||
-      stat.size !== opts.expectedSize ||
-      (process.platform !== "win32" && (stat.mode & 0o111) !== 0)
-    ) {
-      throw new PenglaiError("SECURITY_POLICY", "existing update payload identity mismatch");
-    }
-    const bytes = readFileSync(finalPath);
+    const bytes = readBoundUpdatePayload(finalPath, opts.expectedSize, {
+      forbidExecutable: true,
+    });
     verifyPayload(bytes, opts.expectedSha256, opts.signature, opts.publicKeyHex);
     return { path: finalPath, bytes: bytes.length, kind };
   }
@@ -91,7 +85,9 @@ export async function downloadVerifiedPayload(opts: {
     existing = 0;
   }
   if (existing === opts.expectedSize) {
-    const complete = readFileSync(part);
+    const complete = readBoundUpdatePayload(part, opts.expectedSize, {
+      forbidExecutable: true,
+    });
     try {
       verifyPayload(complete, opts.expectedSha256, opts.signature, opts.publicKeyHex);
     } catch (error) {
@@ -100,6 +96,15 @@ export async function downloadVerifiedPayload(opts: {
     }
     renameSync(part, finalPath);
     chmodSync(finalPath, 0o600);
+    try {
+      const committed = readBoundUpdatePayload(finalPath, opts.expectedSize, {
+        forbidExecutable: true,
+      });
+      verifyPayload(committed, opts.expectedSha256, opts.signature, opts.publicKeyHex);
+    } catch (error) {
+      rmSync(finalPath, { force: false, maxRetries: 0 });
+      throw error;
+    }
     return { path: finalPath, bytes: complete.length, kind };
   }
   const fetchImpl = opts.fetchImpl ?? fetch;
@@ -194,14 +199,19 @@ export async function downloadVerifiedPayload(opts: {
   }
   chmodSync(part, 0o600);
   const fileHandle = openSync(part, "r");
+  let buf: Buffer;
   try {
     fsyncSync(fileHandle);
+    const opened = fstatSync(fileHandle);
+    if (!opened.isFile() || opened.size !== opts.expectedSize) {
+      throw new PenglaiError("SECURITY_POLICY", "update size mismatch");
+    }
+    buf = readFileSync(fileHandle);
   } finally {
     closeSync(fileHandle);
   }
-  const bytes = statSync(part).size;
+  const bytes = buf.length;
   if (bytes !== opts.expectedSize) throw new PenglaiError("SECURITY_POLICY", "update size mismatch");
-  const buf = await import("node:fs/promises").then((fs) => fs.readFile(part));
   try {
     verifyPayload(buf, opts.expectedSha256, opts.signature, opts.publicKeyHex);
   } catch (error) {
@@ -210,6 +220,15 @@ export async function downloadVerifiedPayload(opts: {
   }
   renameSync(part, finalPath);
   chmodSync(finalPath, 0o600);
+  try {
+    const committed = readBoundUpdatePayload(finalPath, opts.expectedSize, {
+      forbidExecutable: true,
+    });
+    verifyPayload(committed, opts.expectedSha256, opts.signature, opts.publicKeyHex);
+  } catch (error) {
+    rmSync(finalPath, { force: false, maxRetries: 0 });
+    throw error;
+  }
   if (process.platform !== "win32") {
     const dirHandle = openSync(opts.destDir, "r");
     try {

--- a/packages/runtime/src/update.ts
+++ b/packages/runtime/src/update.ts
@@ -1,6 +1,16 @@
 import { spawn } from "node:child_process";
 import { createHash, createPublicKey, verify } from "node:crypto";
-import { existsSync, lstatSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { PenglaiError } from "@penglai/contracts";
 
@@ -307,6 +317,50 @@ export function verifyPayload(buf: Buffer, sha256: string, signature: Buffer, pu
   verifyDetached(buf, signature, publicKeyHex, "payload");
 }
 
+export function readBoundUpdatePayload(
+  path: string,
+  expectedSize: number,
+  options: { forbidExecutable?: boolean } = {},
+): Buffer {
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, "r");
+    const opened = fstatSync(fd);
+    const named = lstatSync(path);
+    if (
+      !opened.isFile() ||
+      named.isSymbolicLink() ||
+      !named.isFile() ||
+      opened.dev !== named.dev ||
+      opened.ino !== named.ino ||
+      opened.size !== expectedSize ||
+      (options.forbidExecutable === true &&
+        process.platform !== "win32" &&
+        (opened.mode & 0o111) !== 0)
+    ) {
+      throw new PenglaiError("SECURITY_POLICY", "update payload identity mismatch");
+    }
+    const bytes = readFileSync(fd);
+    if (bytes.length !== expectedSize) {
+      throw new PenglaiError("SECURITY_POLICY", "update payload size changed while reading");
+    }
+    return bytes;
+  } catch (error) {
+    if (
+      error &&
+      typeof error === "object" &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      throw new PenglaiError("INVALID_INPUT", "verified installer missing");
+    }
+    if (error instanceof PenglaiError) throw error;
+    throw new PenglaiError("SECURITY_POLICY", "update payload could not be opened safely");
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
 export function verifyManifestBytes(input: {
   bytes: Buffer;
   signature: Buffer;
@@ -539,11 +593,8 @@ export class VerifiedInstallerHandoff {
   }
 
   #verifyFile(path: string, size: number, sha256: string, signature: Buffer): void {
-    if (!existsSync(path)) throw new PenglaiError("INVALID_INPUT", "verified installer missing");
-    const lst = lstatSync(path);
-    if (lst.isSymbolicLink() || !lst.isFile()) throw new PenglaiError("SECURITY_POLICY", "installer must be a regular file");
-    if (statSync(path).size !== size) throw new PenglaiError("SECURITY_POLICY", "installer size changed");
-    verifyPayload(readFileSync(path), sha256, signature, this.#publicKeyHex);
+    const bytes = readBoundUpdatePayload(path, size, { forbidExecutable: true });
+    verifyPayload(bytes, sha256, signature, this.#publicKeyHex);
   }
 }
 


### PR DESCRIPTION
## Summary
- verify cached, resumed, and freshly downloaded installers from the same opened regular-file descriptor used for size and inode/device identity checks
- re-verify the committed final path after the atomic rename and remove it if that final verification fails
- use the same bound read for the one-shot native installer handoff
- reject a signed-byte symlink fixture explicitly

## Why
CodeQL correctly identified check/read file-system race windows in the assisted updater. A local process under the same account must not be able to swap the pathname between metadata checks and signature verification.

## Verification
- format check PASS
- monorepo typecheck PASS
- full unit suite PASS
- contract 62/62 PASS
- integration 21/21 PASS
- desktop E2E 71/71 PASS
- security 15/15 PASS
- versions/contracts/dependencies/licenses/secrets PASS

## Release boundary
This PR publishes nothing. The prior native candidate run was cancelled; all three packages must be rebuilt from the post-merge main SHA.
