### PR TITLE
fix: close Windows native release gaps

### DIFF
--- a/.github/workflows/native-release-candidate.yml
+++ b/.github/workflows/native-release-candidate.yml
@@ -143,6 +143,7 @@ jobs:
       - name: Build source from the clean checkout
         run: pnpm build
       - name: Source and onboarding regression gates
+        shell: bash
         run: |
           pnpm test:unit
           pnpm test:contract

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -4,6 +4,7 @@ import {
   constants,
   existsSync,
   fstatSync,
+  lstatSync,
   mkdirSync,
   openSync,
   readdirSync,
@@ -445,9 +446,24 @@ export function readExactRegularFile(path: string, maxBytes = Number.POSITIVE_IN
   let fd: number | undefined;
   try {
     const noFollow = process.platform === "win32" ? 0 : constants.O_NOFOLLOW;
-    fd = openSync(path, constants.O_RDONLY | noFollow);
+    try {
+      fd = openSync(path, constants.O_RDONLY | noFollow);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ELOOP") {
+        throw new PenglaiError("SECURITY_POLICY", "file is a symlink source");
+      }
+      throw error;
+    }
     const before = fstatSync(fd);
     if (!before.isFile()) throw new PenglaiError("STORE_CORRUPT", "file is not a regular file");
+    const source = lstatSync(path);
+    if (source.isSymbolicLink()) {
+      throw new PenglaiError("SECURITY_POLICY", "file is a symlink source");
+    }
+    if (!source.isFile()) throw new PenglaiError("STORE_CORRUPT", "file is not a regular file");
+    if (source.dev !== before.dev || source.ino !== before.ino || source.size !== before.size) {
+      throw new PenglaiError("STORE_CORRUPT", "file path identity changed after open");
+    }
     if (!Number.isSafeInteger(maxBytes) && maxBytes !== Number.POSITIVE_INFINITY) {
       throw new PenglaiError("INVALID_INPUT", "file byte limit invalid");
     }

--- a/packages/contracts/src/media-admit.test.ts
+++ b/packages/contracts/src/media-admit.test.ts
@@ -61,7 +61,10 @@ test("exact regular-file reader bounds bytes and rejects symlinks", () => {
   if (process.platform !== "win32") {
     const link = join(dir, "entry-link.json");
     symlinkSync(file, link);
-    assert.throws(() => readExactRegularFile(link, 7), /ELOOP|regular file|STORE_CORRUPT/i);
+    assert.throws(
+      () => readExactRegularFile(link, 7),
+      /ELOOP|regular file|symlink source|STORE_CORRUPT|SECURITY_POLICY/i,
+    );
   }
 });
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,13 +1,9 @@
 import { createHash, randomUUID } from "node:crypto";
 import {
-  closeSync,
-  constants,
   chmodSync,
   existsSync,
-  fstatSync,
   lstatSync,
   mkdirSync,
-  openSync,
   readFileSync,
   readlinkSync,
   renameSync,
@@ -64,24 +60,13 @@ export const NODE_TARBALL_SHA256 = "db4b275b83736df67533529a18cc55de2549a8329ace
 function readRegularFileNoFollow(path: string): Buffer | undefined;
 function readRegularFileNoFollow(path: string, encoding: "utf8"): string | undefined;
 function readRegularFileNoFollow(path: string, encoding?: "utf8"): Buffer | string | undefined {
-  let fd: number;
   try {
-    fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const bytes = readExactRegularFile(path);
+    return encoding === "utf8" ? bytes.toString("utf8") : bytes;
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
     if (code === "ENOENT") return undefined;
-    if (code === "ELOOP") {
-      throw new PenglaiError("SECURITY_POLICY", `runtime refuses a symlink source: ${path}`);
-    }
     throw error;
-  }
-  try {
-    if (!fstatSync(fd).isFile()) {
-      throw new PenglaiError("SECURITY_POLICY", `runtime source is not a regular file: ${path}`);
-    }
-    return encoding === "utf8" ? readFileSync(fd, "utf8") : readFileSync(fd);
-  } finally {
-    closeSync(fd);
   }
 }
 

--- a/packages/runtime/src/overlay.test.ts
+++ b/packages/runtime/src/overlay.test.ts
@@ -7,7 +7,6 @@ import {
   writeFileSync,
   readFileSync,
   cpSync,
-  readdirSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -51,16 +50,10 @@ test("R2I-BRAND-010/011 overlay applies only on exact upstream hash", async () =
     ),
     join(dir, heroRel),
   );
-  const settingsPackage = readdirSync(join(root, "node_modules/.pnpm")).find((name) =>
-    name.startsWith("@deepseek-ai+dsh-client-ui-settings-general@0.1.1-rc.2"),
-  );
-  assert.ok(settingsPackage);
   cpSync(
     join(
       root,
-      "node_modules/.pnpm",
-      settingsPackage,
-      "node_modules/@deepseek-ai/dsh-client-ui-settings-general/lib/client.js",
+      "overlays/dsh-0.1.1-rc.2/upstream/dsh-client-ui-settings-general.client.js",
     ),
     join(dir, settingsRel),
   );

--- a/packages/runtime/src/windows-host.test.ts
+++ b/packages/runtime/src/windows-host.test.ts
@@ -204,6 +204,8 @@ test("NSIS script default-preserves user data and only deletes via capability ha
   assert.equal(contract.posixModeImpersonation, false);
   const payload = readFileSync(new URL("../../../scripts/package-windows-payload.mjs", import.meta.url), "utf8");
   const packager = readFileSync(new URL("../../../scripts/package-windows-nsis.mjs", import.meta.url), "utf8");
+  const workflow = readFileSync(new URL("../../../.github/workflows/native-release-candidate.yml", import.meta.url), "utf8");
+  const windowsWorkflow = workflow.slice(workflow.indexOf("\n  windows:"));
   const uiProof = readFileSync(new URL("../../../scripts/windows-installer-ui-proof.ps1", import.meta.url), "utf8");
   assert.match(packager, /"\/INPUTCHARSET",\s*\n\s*"UTF8"/);
   assert.match(uiProof, /'\/LANG=2052'/);
@@ -214,6 +216,9 @@ test("NSIS script default-preserves user data and only deletes via capability ha
   assert.match(payload, /release-info\.json/);
   assert.match(payload, /stamp-windows-exe\.mjs/);
   assert.match(payload, /writeRequiredFuses\(penglaiExe\)/);
+  assert.match(payload, /cpSync\(join\(staging, "mnemon"\), join\(resources, "mnemon"\)/);
+  assert.match(payload, /payload is missing the pinned Mnemon binary or license/);
+  assert.match(windowsWorkflow, /- name: Source and onboarding regression gates\s+shell: bash\s+run: \|/);
   assert.match(payload, /Penglai\.ico/);
   assert.match(payload, /stagingForTarget\(ROOT, "win32-x86_64"\)/);
   assert.match(packager, /stagingForTarget\(ROOT, "win32-x86_64"\)/);

--- a/scripts/package-windows-payload.mjs
+++ b/scripts/package-windows-payload.mjs
@@ -116,6 +116,9 @@ cpSync(join(ROOT, "dist", "desktop-bundle"), join(resources, "app"), { recursive
 cpSync(join(staging, "runtime"), join(resources, "runtime"), { recursive: true });
 cpSync(join(staging, "profile-seed"), join(resources, "profile-seed"), { recursive: true });
 cpSync(join(staging, "plugins"), join(resources, "plugins"), { recursive: true });
+if (existsSync(join(staging, "mnemon"))) {
+  cpSync(join(staging, "mnemon"), join(resources, "mnemon"), { recursive: true });
+}
 for (const name of ["runtime-manifest.json", "release-contract.json", ".closure-complete"]) {
   const src = join(staging, name);
   if (existsSync(src)) cpSync(src, join(resources, name === ".closure-complete" ? "closure-credential.json" : name));
@@ -154,6 +157,9 @@ if (native) {
 }
 if (native && !existsSync(join(resources, "runtime", "helpers", "penglai-windows-host.exe"))) {
   finish("FAIL", { command: "package:windows-payload", reason: "payload is missing the compiled Windows helper" });
+}
+if (native && (!existsSync(join(resources, "mnemon", "mnemon.exe")) || !existsSync(join(resources, "mnemon", "LICENSE")))) {
+  finish("FAIL", { command: "package:windows-payload", reason: "payload is missing the pinned Mnemon binary or license" });
 }
 
 const arch = spawnSync(process.execPath, ["scripts/verify-native-arch.mjs", payload, "win32-x86_64"], {


### PR DESCRIPTION
## What failed on the native runner

- The Windows payload omitted the pinned Mnemon binary and Apache-2.0 license even though both were declared in the runtime manifest. The final fuse/closure verifier correctly rejected the package.
- The Windows PowerShell regression step did not stop after a failing external command, so two Windows-specific unit failures were visible in logs but later commands still ran.
- The overlay fixture depended on pnpm virtual-store directory naming, which differs on the Windows host.
- Exact regular-file reads did not perform a pre-open `lstat` on Windows, so the legacy Context-to-Memory migration symlink test did not fail closed.

## Fix

- Copy and require exact Mnemon bytes in the Windows payload.
- Run the Windows source/onboarding regression block under fail-fast Bash.
- Use the repository-pinned DSH upstream overlay fixture rather than pnpm store internals.
- Reject symlink sources before opening and bind the opened descriptor to the pre-open file identity.

## Local evidence

- format check, typecheck, build: PASS
- targeted regression: 40/40 PASS
- full unit, contract, integration, desktop E2E, security: PASS
- DSH/release contracts, dependencies, licenses, secrets: PASS

The failed run and all artifacts from its old source SHA remain ineligible for release. A new three-target native run is required after merge.