### PR TITLE
fix: close Windows-native 0.5.5 regressions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,9 @@ packages/moss-tts/third_party/*.txt text eol=lf
 packages/moss-tts/third_party/*.md text eol=lf
 packages/moss-tts/src/third_party/moss_tts/LICENSE text eol=lf
 packages/moss-tts/src/third_party/moss_tts/runtime.mjs text eol=lf
+
+# Overlay hashes are release inputs. Keep source text byte-identical on
+# Windows instead of letting core.autocrlf invalidate the pinned manifest.
+overlays/dsh-0.1.1-rc.2/**/*.js text eol=lf
+overlays/dsh-0.1.1-rc.2/**/*.html text eol=lf
+overlays/dsh-0.1.1-rc.2/**/*.json text eol=lf

--- a/packages/memory/src/engine/service.test.ts
+++ b/packages/memory/src/engine/service.test.ts
@@ -28,7 +28,7 @@ test("mnemon service remembers, isolates workspaces, and forgets", async () => {
   await memory.forget(personal.id);
   const after = await memory.search("测试用户");
   assert.equal(after.some((row) => row.id === personal.id), false);
-  assert.match(personalDataDir(dir), /memory\/mnemon\/personal/);
+  assert.equal(personalDataDir(dir), join(dir, "memory", "mnemon", "personal"));
   assert.notEqual(workspaceDataDir(dir, "ws-a"), workspaceDataDir(dir, "ws-b"));
   const graph = await memory.graph("ws-a");
   assert.equal(Array.isArray(graph.nodes), true);

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -107,6 +107,7 @@ async function waitForOfficialSkill(
 export function createDurableMemoryService(opts: {
   userData: string;
   skills: NonNullable<CordisContextLike["skills"]>;
+  onClose?: () => void;
 }) {
   const engine = new MnemonMemoryService(opts.userData, {
     ...(process.env.PENGLAI_MNEMON_BINARY ? { binaryPath: process.env.PENGLAI_MNEMON_BINARY } : {}),
@@ -188,7 +189,11 @@ export function createDurableMemoryService(opts: {
     close() {
       if (closed) return;
       closed = true;
-      engine.close();
+      try {
+        engine.close();
+      } finally {
+        opts.onClose?.();
+      }
     },
     resourceSnapshot() {
       return {
@@ -213,7 +218,11 @@ export function apply(ctx: CordisContextLike) {
   const sources = applyEmbeddedMemorySources(ctx);
   let service: ReturnType<typeof createDurableMemoryService> | undefined;
   try {
-    service = createDurableMemoryService({ userData, skills: ctx.skills });
+    service = createDurableMemoryService({
+      userData,
+      skills: ctx.skills,
+      onClose: () => sources.close(),
+    });
     const activeService = service;
     registerMemoryTools(ctx, activeService.engine);
     ctx.provide("penglaiMemory", activeService);
@@ -223,8 +232,8 @@ export function apply(ctx: CordisContextLike) {
     }
     ctx.effect?.(() => () => activeService.close?.());
   } catch (error) {
-    service?.close();
-    sources.close();
+    if (service) service.close();
+    else sources.close();
     throw error;
   }
   return service;

--- a/packages/office/src/transaction.ts
+++ b/packages/office/src/transaction.ts
@@ -7,13 +7,12 @@ import {
   lstatSync,
   mkdirSync,
   openSync,
-  readFileSync,
   renameSync,
   writeFileSync,
 } from "node:fs";
 import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { randomBytes } from "node:crypto";
-import { PenglaiError } from "@penglai/contracts";
+import { PenglaiError, readExactRegularFile } from "@penglai/contracts";
 import { digestBytes } from "./jobs.js";
 
 /**
@@ -80,24 +79,12 @@ function fsyncPath(path: string): void {
 }
 
 function readExistingRegularFile(path: string): Buffer | undefined {
-  let fd: number;
   try {
-    fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    return readExactRegularFile(path);
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
     if (code === "ENOENT") return undefined;
-    if (code === "ELOOP") {
-      throw new PenglaiError("SECURITY_POLICY", "office refuses a pre-existing symlink destination");
-    }
     throw error;
-  }
-  try {
-    if (!fstatSync(fd).isFile()) {
-      throw new PenglaiError("SECURITY_POLICY", "office destination must be a regular file");
-    }
-    return readFileSync(fd);
-  } finally {
-    closeSync(fd);
   }
 }
 

--- a/packages/plugin-center/src/center.test.ts
+++ b/packages/plugin-center/src/center.test.ts
@@ -23,6 +23,7 @@ import {
 } from "./index.js";
 import { contribute } from "./client.js";
 import { type PluginCatalogEntry } from "@penglai/runtime";
+import { writeTestTarGz } from "../../../scripts/lib/test-tar-fixture.mjs";
 
 const TEST_CATALOG: PluginCatalogEntry[] = R2_CATALOG.map((entry) => ({
   ...entry,
@@ -527,7 +528,6 @@ test("R50-UPD-006/R50-UN-001 settings client registers update and uninstall cate
 });
 
 test("R50-CENTER-004/007 first enable installs verified package and rejects a bad update", async () => {
-  const { execFileSync } = await import("node:child_process");
   const { createHash } = await import("node:crypto");
   const { runProfileTransaction } = await import("./profile-tx.js");
   const root = mkdtempSync(join(tmpdir(), "penglai-center-tx-"));
@@ -573,7 +573,7 @@ test("R50-CENTER-004/007 first enable installs verified package and rejects a ba
     }),
   );
   const tgz = join(plugins, metadata.packageFile);
-  execFileSync("tar", ["-czf", tgz, "-C", pkgDir, "."]);
+  writeTestTarGz(pkgDir, tgz);
   const sha = createHash("sha256").update(readFileSync(tgz)).digest("hex");
   const entry: PluginCatalogEntry = {
     ...metadata,

--- a/packages/runtime/src/foundation.test.ts
+++ b/packages/runtime/src/foundation.test.ts
@@ -32,7 +32,7 @@ test("R50-DIST-006 generation layout isolates 0.5 and lists legacy", () => {
   assert.ok(mac.legacyCandidates.some((p) => p.includes("penglai-v0.2.0-alpha.3") || p.includes(".dsh")));
   const win = resolveGenerationLayout({ platform: "win32", home: "C:\\Users\\测 试", localAppData: "C:\\Users\\测 试\\AppData\\Local" });
   assert.match(win.userData.replace(/\\/g, "/"), /Penglai\/0\.5$/);
-  assert.equal(joinUserData("/tmp/Penglai"), "/tmp/Penglai/0.5");
+  assert.equal(joinUserData(join(tmpdir(), "Penglai")), join(tmpdir(), "Penglai", "0.5"));
 });
 
 test("R50-DIST-007 arch guard rejects mixed Electron/Node", () => {

--- a/packages/runtime/src/lifecycle.test.ts
+++ b/packages/runtime/src/lifecycle.test.ts
@@ -265,7 +265,7 @@ test("managed layout keeps settings DSH credentials memory and cache as disjoint
   const preview = previewDeletionPlan(plan, root, [], [], { ...POSIX_INSPECTION, dataLayout });
   assert.equal(preview.targets.length, plan.paths.length);
   assert.equal(preview.targets.every((target) => target.category.length > 0), true);
-  const inventory = inspectStorageInventory(dataLayout, [], []);
+  const inventory = inspectStorageInventory(dataLayout, [], [], { ...POSIX_INSPECTION, dataLayout });
   assert.equal(inventory.categories.length, 13);
   assert.equal(inventory.categories.every((category) => category.deletable), true);
 

--- a/packages/runtime/src/runtime.test.ts
+++ b/packages/runtime/src/runtime.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { createHash } from "node:crypto";
-import { execFileSync } from "node:child_process";
 import {
   chmodSync,
   existsSync,
@@ -38,6 +37,7 @@ import {
   runtimePluginTarget,
   windowsOwnedProcessEnvironment,
 } from "./index.js";
+import { writeTestTarGz } from "../../../scripts/lib/test-tar-fixture.mjs";
 
 test("embedded DSH Web never opens the operating-system browser", () => {
   assert.deepEqual(dshWebArgs(3080), [
@@ -124,7 +124,7 @@ function writeTrustedPluginSet(
       }),
     );
     const archive = join(pluginsDir, metadata.packageFile);
-    execFileSync("tar", ["-czf", archive, "-C", stage, "."]);
+    writeTestTarGz(stage, archive);
     return {
       ...metadata,
       sha256: createHash("sha256").update(readFileSync(archive)).digest("hex"),
@@ -299,7 +299,7 @@ test("R2I-DIST-007 refuses to install historical keychain tarball into profile",
   writeFileSync(join(dir, "package.json"), "{\"name\":\"@penglai/credentials-keychain\",\"main\":\"dist/index.js\"}\n");
   writeFileSync(join(dir, "dist", "index.js"), "export const name = 'kc';\n");
   mkdirSync(join(app, "plugins"), { recursive: true });
-  execFileSync("tar", ["-czf", join(app, "plugins", "penglai-credentials-keychain-0.2.0.tgz"), "-C", dir, "."]);
+  writeTestTarGz(dir, join(app, "plugins", "penglai-credentials-keychain-0.2.0.tgz"));
   writeTrustedPluginSet(app);
   mkdirSync(user.profileWeb, { recursive: true });
   mkdirSync(user.transactions, { recursive: true });

--- a/packages/runtime/src/scanner.test.ts
+++ b/packages/runtime/src/scanner.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { execFileSync } from "node:child_process";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
@@ -10,13 +9,14 @@ import {
   assertProductionBundleClean,
   scanBundleBytes,
 } from "./scanner.js";
+import { writeTestTarGz } from "../../../scripts/lib/test-tar-fixture.mjs";
 
 test("unpacking scanner fails when a packed tar contains loopback/probe/shortcut/alpha fixture", () => {
   const stage = mkdtempSync(join(tmpdir(), "penglai-scan-dirty-"));
   writeFileSync(join(stage, "index.js"), "export const provider = 'penglai-loopback';\nexport function proveCausalRoute() {}\n");
   writeFileSync(join(stage, "probe.js"), "process.env.PENGLAI_INSTALLED_PROBE\n");
   const tar = join(mkdtempSync(join(tmpdir(), "penglai-scan-tar-")), "plugin.tgz");
-  execFileSync("tar", ["-czf", tar, "-C", stage, "."]);
+  writeTestTarGz(stage, tar);
   assert.throws(() => assertPackedArtifactClean(tar), /penglai-loopback|installed-probe|proveCausalRoute/);
 });
 
@@ -24,7 +24,7 @@ test("unpacking scanner accepts a clean packed tar", () => {
   const stage = mkdtempSync(join(tmpdir(), "penglai-scan-clean-"));
   writeFileSync(join(stage, "index.js"), "export const name = '@penglai/im';\n");
   const tar = join(mkdtempSync(join(tmpdir(), "penglai-scan-clean-tar-")), "plugin.tgz");
-  execFileSync("tar", ["-czf", tar, "-C", stage, "."]);
+  writeTestTarGz(stage, tar);
   assert.doesNotThrow(() => assertPackedArtifactClean(tar));
 });
 

--- a/scripts/lib/test-tar-fixture.mjs
+++ b/scripts/lib/test-tar-fixture.mjs
@@ -1,0 +1,58 @@
+import { lstatSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { relative, resolve, sep } from "node:path";
+import { gzipSync } from "node:zlib";
+
+function putOctal(header, offset, length, value) {
+  header.write(`${value.toString(8).padStart(length - 1, "0")}\0`, offset, length, "ascii");
+}
+
+function tarEntry(path, data, mode) {
+  const pathBytes = Buffer.byteLength(path, "utf8");
+  if (pathBytes === 0 || pathBytes > 100) {
+    throw new Error(`test tar path must fit the ustar name field: ${path}`);
+  }
+  const header = Buffer.alloc(512);
+  header.write(path, 0, 100, "utf8");
+  putOctal(header, 100, 8, mode & 0o777);
+  putOctal(header, 108, 8, 0);
+  putOctal(header, 116, 8, 0);
+  putOctal(header, 124, 12, data.length);
+  putOctal(header, 136, 12, 0);
+  header.fill(0x20, 148, 156);
+  header.write("0", 156, 1, "ascii");
+  header.write("ustar\0", 257, 6, "ascii");
+  header.write("00", 263, 2, "ascii");
+  const sum = header.reduce((total, byte) => total + byte, 0);
+  header.write(`${sum.toString(8).padStart(6, "0")}\0 `, 148, 8, "ascii");
+  const padding = Buffer.alloc((512 - (data.length % 512)) % 512);
+  return Buffer.concat([header, data, padding]);
+}
+
+function regularFiles(root) {
+  const files = [];
+  const visit = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const absolute = resolve(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(absolute);
+        continue;
+      }
+      const stat = lstatSync(absolute);
+      if (!stat.isFile()) {
+        throw new Error(`test tar fixtures only admit regular files: ${absolute}`);
+      }
+      const archivePath = relative(root, absolute).split(sep).join("/");
+      files.push({ absolute, archivePath, mode: stat.mode });
+    }
+  };
+  visit(root);
+  return files.sort((a, b) => a.archivePath.localeCompare(b.archivePath));
+}
+
+export function writeTestTarGz(sourceRoot, destination) {
+  const root = resolve(sourceRoot);
+  const entries = regularFiles(root).map(({ absolute, archivePath, mode }) =>
+    tarEntry(archivePath, readFileSync(absolute), mode),
+  );
+  writeFileSync(destination, gzipSync(Buffer.concat([...entries, Buffer.alloc(1024)])));
+}


### PR DESCRIPTION
## What changed

- close the embedded Memory Sources database with the main Penglai Memory lifecycle
- reuse the descriptor-bound exact-file reader for Office destination backups on Windows
- replace host `tar` test fixtures with a deterministic pure-Node ustar writer
- make path and deletion-inventory tests platform-semantic
- pin rc.2 overlay text to LF so Windows checkout preserves release hashes

## Local verification

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:unit` (555/555)
- `pnpm test:contract` (67/67)
- `pnpm test:integration` (25/25)
- `pnpm test:e2e` (73/73)
- `pnpm test:security` (15/15)
- versions / identity / contracts / dependencies / licenses / secrets gates PASS

This PR does not publish, tag, or reuse artifacts from the failed native run.