### PR TITLE
fix: extract release tar archives portably

### DIFF
--- a/packages/runtime/src/safe-tar.ts
+++ b/packages/runtime/src/safe-tar.ts
@@ -88,8 +88,11 @@ function safeArchivePath(input: string): string | undefined {
   return normalized;
 }
 
-export function inspectTarGz(bytes: Buffer): SafeTarEntry[] {
-  const tar = gunzipSync(bytes, { maxOutputLength: MAX_ARCHIVE_BYTES });
+export function inspectTar(bytes: Buffer): SafeTarEntry[] {
+  if (bytes.length > MAX_ARCHIVE_BYTES) {
+    throw new PenglaiError("SECURITY_POLICY", "tar archive exceeds byte limit");
+  }
+  const tar = bytes;
   const entries: SafeTarEntry[] = [];
   const seen = new Set<string>();
   let offset = 0;
@@ -153,6 +156,10 @@ export function inspectTarGz(bytes: Buffer): SafeTarEntry[] {
   return entries;
 }
 
+export function inspectTarGz(bytes: Buffer): SafeTarEntry[] {
+  return inspectTar(gunzipSync(bytes, { maxOutputLength: MAX_ARCHIVE_BYTES }));
+}
+
 function assertDirectoryChain(root: string, target: string): void {
   const rel = relative(root, target);
   if (rel === ".." || rel.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`)) {
@@ -167,14 +174,13 @@ function assertDirectoryChain(root: string, target: string): void {
   }
 }
 
-export function extractTarGz(bytes: Buffer, destination: string): SafeTarEntry[] {
+function extractEntries(entries: SafeTarEntry[], destination: string): SafeTarEntry[] {
   const root = resolve(destination);
   mkdirSync(root, { recursive: true, mode: 0o700 });
   if (lstatSync(root).isSymbolicLink()) {
     throw new PenglaiError("SECURITY_POLICY", "archive destination is symlink");
   }
   const canonicalRoot = realpathSync(root);
-  const entries = inspectTarGz(bytes);
   for (const entry of entries.filter((value) => value.kind === "directory")) {
     const target = resolve(canonicalRoot, ...entry.path.split("/"));
     assertDirectoryChain(canonicalRoot, dirname(target));
@@ -192,4 +198,12 @@ export function extractTarGz(bytes: Buffer, destination: string): SafeTarEntry[]
     });
   }
   return entries;
+}
+
+export function extractTar(bytes: Buffer, destination: string): SafeTarEntry[] {
+  return extractEntries(inspectTar(bytes), destination);
+}
+
+export function extractTarGz(bytes: Buffer, destination: string): SafeTarEntry[] {
+  return extractEntries(inspectTarGz(bytes), destination);
 }

--- a/packages/runtime/src/scanner.test.ts
+++ b/packages/runtime/src/scanner.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
+import { gunzipSync } from "node:zlib";
 import { PenglaiError } from "@penglai/contracts";
 import {
   assertPackedArtifactClean,
@@ -25,6 +26,16 @@ test("unpacking scanner accepts a clean packed tar", () => {
   writeFileSync(join(stage, "index.js"), "export const name = '@penglai/im';\n");
   const tar = join(mkdtempSync(join(tmpdir(), "penglai-scan-clean-tar-")), "plugin.tgz");
   writeTestTarGz(stage, tar);
+  assert.doesNotThrow(() => assertPackedArtifactClean(tar));
+});
+
+test("unpacking scanner accepts a clean plain tar without a host tar executable", () => {
+  const stage = mkdtempSync(join(tmpdir(), "penglai-scan-clean-plain-"));
+  writeFileSync(join(stage, "index.js"), "export const name = '@penglai/im';\n");
+  const tgz = join(mkdtempSync(join(tmpdir(), "penglai-scan-clean-plain-tar-")), "plugin.tgz");
+  writeTestTarGz(stage, tgz);
+  const tar = tgz.replace(/\.tgz$/, ".tar");
+  writeFileSync(tar, gunzipSync(readFileSync(tgz)));
   assert.doesNotThrow(() => assertPackedArtifactClean(tar));
 });
 

--- a/packages/runtime/src/scanner.ts
+++ b/packages/runtime/src/scanner.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, readdirSync, readFileSync, statSync } from "no
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { PenglaiError } from "@penglai/contracts";
+import { extractTar, extractTarGz } from "./safe-tar.js";
 
 const FORBIDDEN = [
   { re: /\/penglai\/usable-fixture/, reason: "usable-fixture" },
@@ -125,11 +126,11 @@ export function unpackArchive(archivePath: string, dest: string): void {
     throw new PenglaiError("INVALID_INPUT", `archive missing ${archivePath}`);
   }
   if (/\.(tgz|tar\.gz)$/.test(archivePath)) {
-    execFileSync("tar", ["-xzf", archivePath, "-C", dest]);
+    extractTarGz(readFileSync(archivePath), dest);
     return;
   }
   if (archivePath.endsWith(".tar")) {
-    execFileSync("tar", ["-xf", archivePath, "-C", dest]);
+    extractTar(readFileSync(archivePath), dest);
     return;
   }
   if (archivePath.endsWith(".asar")) {


### PR DESCRIPTION
## Root cause

The third Windows-native run reduced the source suite to two failures. Fixture creation was portable, but the production bundle scanner still delegated `.tgz` extraction to GNU `tar`, which interpreted `C:` in an absolute Windows path as a remote host.

## Fix

- extract `.tgz` and plain `.tar` through the existing bounded, traversal-safe Node parser
- keep external tools only for formats that do not have a repository-native parser
- add a plain-tar regression test as well as the existing tgz scan tests

## Verification

- format/typecheck PASS
- targeted safe-tar/scanner 8/8
- unit 556/556
- contract 67/67
- integration 25/25
- desktop E2E 73/73
- security 15/15
- contracts/dependencies/licenses/secrets PASS

No release artifacts from failed run 32651945976 are reusable.