### PR TITLE
fix: scan packed plugins from compiled runtime

### DIFF
--- a/scripts/pack-plugins.mjs
+++ b/scripts/pack-plugins.mjs
@@ -1210,9 +1210,12 @@ for (const p of packs) {
   });
 }
 
-const { assertPackedArtifactClean } = await import(
-  pathToFileURL(join(ROOT, "packages/runtime/src/scanner.ts")).href
-);
+const scannerModule = join(ROOT, "packages/runtime/dist/scanner.js");
+if (!existsSync(scannerModule)) {
+  console.error("compiled runtime scanner missing; run pnpm build before pack:plugins");
+  process.exit(1);
+}
+const { assertPackedArtifactClean } = await import(pathToFileURL(scannerModule).href);
 for (const entry of entries) {
   assertPackedArtifactClean(join(dest, entry.packageFile));
 }


### PR DESCRIPTION
The native jobs correctly reached packaging after the Windows source suite passed. Packaging then imported `scanner.ts` directly; its new local `.js` dependency is valid after TypeScript compilation but cannot be resolved by Node source stripping.

This makes the packer consume the already-built runtime scanner and fail clearly if `pnpm build` was skipped. It does not change scanner policy.

Verified locally: format, typecheck, build, deterministic nine-plugin pack and production scan, and secret audit all PASS. Failed run 32652399380 remains invalid.