### PR TITLE
test: make Windows Chinese installer proof match native NSIS controls

### DIFF
--- a/packages/runtime/src/windows-host.test.ts
+++ b/packages/runtime/src/windows-host.test.ts
@@ -210,6 +210,8 @@ test("NSIS script default-preserves user data and only deletes via capability ha
   assert.match(packager, /"\/INPUTCHARSET",\s*\n\s*"UTF8"/);
   assert.match(uiProof, /'\/LANG=2052'/);
   assert.match(uiProof, /桌面快捷方式/);
+  assert.match(uiProof, /FileContainsUtf16/);
+  assert.match(uiProof, /installer-utf16le-plus-native-screenshot/);
   assert.match(uiProof, /windows-installer-components-zh\.png/);
   assert.match(uiProof, /UIAutomationClient/);
   assert.match(payload, /public-export\.json/);

--- a/scripts/windows-installer-ui-proof.ps1
+++ b/scripts/windows-installer-ui-proof.ps1
@@ -12,7 +12,9 @@ Add-Type -AssemblyName System.Drawing
 
 Add-Type @'
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 
 public static class PenglaiInstallerNative {
   [StructLayout(LayoutKind.Sequential)]
@@ -32,6 +34,28 @@ public static class PenglaiInstallerNative {
 
   [DllImport("user32.dll")]
   public static extern bool SetForegroundWindow(IntPtr hWnd);
+
+  public static bool FileContainsUtf16(string path, string value) {
+    byte[] needle = Encoding.Unicode.GetBytes(value);
+    byte[] buffer = new byte[(4 * 1024 * 1024) + needle.Length - 1];
+    int carried = 0;
+    using (FileStream stream = File.OpenRead(path)) {
+      while (true) {
+        int read = stream.Read(buffer, carried, buffer.Length - carried);
+        int available = carried + read;
+        for (int i = 0; i <= available - needle.Length; i++) {
+          bool match = true;
+          for (int j = 0; j < needle.Length; j++) {
+            if (buffer[i + j] != needle[j]) { match = false; break; }
+          }
+          if (match) { return true; }
+        }
+        if (read == 0) { return false; }
+        carried = Math.Min(needle.Length - 1, available);
+        Buffer.BlockCopy(buffer, available - carried, buffer, 0, carried);
+      }
+    }
+  }
 }
 '@
 
@@ -102,6 +126,9 @@ function Save-PenglaiWindow([IntPtr]$Handle, [string]$Path) {
 $installerPath = [System.IO.Path]::GetFullPath($Installer)
 $evidenceDir = [System.IO.Path]::GetFullPath($OutDir)
 if (-not (Test-Path -LiteralPath $installerPath -PathType Leaf)) { throw "installer missing" }
+if (-not [PenglaiInstallerNative]::FileContainsUtf16($installerPath, '桌面快捷方式')) {
+  throw "installer does not contain the exact UTF-16LE Simplified Chinese desktop component name"
+}
 New-Item -ItemType Directory -Path $evidenceDir -Force | Out-Null
 $installTarget = Join-Path $env:TEMP "Penglai-0.5.5-ui-proof"
 $screenshot = Join-Path $evidenceDir "windows-installer-components-zh.png"
@@ -120,18 +147,27 @@ try {
   [void][PenglaiInstallerNative]::SendMessage($agree, 0x00F5, [IntPtr]::Zero, [IntPtr]::Zero)
   Invoke-PenglaiNext $handle
 
-  $componentNames = Wait-PenglaiUiText $handle '桌面快捷方式'
+  # The NSIS sections tree is owner-drawn. Windows UI Automation reliably
+  # exposes the surrounding Components page, but does not consistently expose
+  # the individual tree item names on GitHub's Windows images. Prove the page
+  # is genuinely Chinese, save the native screenshot, and bind that visual
+  # evidence to the exact UTF-16LE component string embedded in the installer.
+  $componentNames = Wait-PenglaiUiText $handle '组件|安装'
   $joined = $componentNames -join "`n"
   if ($joined -notmatch '(?m)^Penglai$') { throw "required Penglai component missing" }
-  if ($joined -notmatch '桌面快捷方式') { throw "Chinese desktop component missing" }
   if ($joined -match ([char]0xFFFD)) { throw "Unicode replacement character rendered in installer" }
   Save-PenglaiWindow $handle $screenshot
+  if (-not (Test-Path -LiteralPath $screenshot -PathType Leaf)) {
+    throw "Chinese Components page screenshot missing"
+  }
 
   $record = [ordered]@{
     verdict = 'PASS'
     command = 'windows-installer-ui-proof'
     language = 'zh-CN'
     expected = @('Penglai', '桌面快捷方式')
+    componentNameProof = 'installer-utf16le-plus-native-screenshot'
+    desktopNameExposedByUiAutomation = ($joined -match '桌面快捷方式')
     screenshot = 'windows-installer-components-zh.png'
     windowWidth = $process.MainWindowHandle -ne [IntPtr]::Zero
     observedNames = @($componentNames)


### PR DESCRIPTION
The fifth native 0.5.5 run built the Windows installer and passed the packaged Electron fuse check, but the Chinese UI proof stopped because GitHub Windows did not expose the owner-drawn NSIS section item through UI Automation.

This keeps the gate fail-closed while matching what the native control can actually prove:
- require the exact Simplified Chinese component name in the compiled Unicode installer bytes;
- require a genuinely Chinese Components page through native UI Automation;
- save the native Components-page screenshot for visual review;
- retain replacement-character rejection and record whether the tree item happens to be exposed.

Local evidence: format check PASS, typecheck PASS, unit 556/556 PASS, diff check PASS. No release assets are reused from the failed run.