### PR TITLE
test: walk collapsed DSH settings on Windows

### DIFF
--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -6,6 +6,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { runInNewContext } from "node:vm";
 import {
   REQUIRED_FRESH_SETTINGS_WALK,
   REQUIRED_FULL_SETTINGS_WALK,
@@ -102,9 +103,34 @@ test("installed e2e drives packaged BrowserWindow via CDP and has no in-app prob
   assert.match(walk, /\^Later\$/);
   assert.match(walk, /official-byok-dismiss/);
   assert.match(walk, /clickButtonText\(\["\^蓬莱\$", "\^Penglai\$"\]\)/);
+  assert.match(walk, /button\[aria-haspopup=\\?"dialog\\?"\]\[aria-expanded\]/);
+  assert.match(walk, /semanticFallback/);
   assert.match(e2e, /assertInstalledPenglaiIdentity/);
   assert.match(e2e, /launchPackaged\(exe, resources, refuseUser/);
   assert.match(e2e, /launchInstalledHarness\(harnessApp, resources, userData/);
+});
+
+test("collapsed official DSH settings trigger opens through its dialog semantics", async () => {
+  const { settingsTriggerClickScript } = await import("../../../scripts/lib/browser-window-walk.mjs");
+  let clicked = false;
+  const button = {
+    disabled: false,
+    textContent: "",
+    getAttribute(name: string) {
+      if (name === "aria-haspopup") return "dialog";
+      if (name === "aria-expanded") return "false";
+      return null;
+    },
+    click() { clicked = true; },
+  };
+  const document = {
+    querySelectorAll: () => [button],
+    querySelector: (selector: string) => selector === 'button[aria-haspopup="dialog"][aria-expanded]' ? button : null,
+  };
+  const result = runInNewContext(settingsTriggerClickScript(), { document });
+  assert.equal(result.ok, true);
+  assert.equal(result.semanticFallback, true);
+  assert.equal(clicked, true);
 });
 
 test("live installed evidence captures public screenshots only after model selection and completed onboarding", () => {

--- a/scripts/lib/browser-window-walk.mjs
+++ b/scripts/lib/browser-window-walk.mjs
@@ -144,6 +144,27 @@ function clickButtonText(patterns) {
   })()`;
 }
 
+export function settingsTriggerClickScript() {
+  return `(() => {
+    const normalized = (value) => String(value || "").replace(/\\s+/g, " ").trim();
+    const buttons = Array.from(document.querySelectorAll("button, [role=button]"));
+    const byText = buttons.find((node) =>
+      [node.textContent, node.getAttribute("aria-label"), node.getAttribute("title")]
+        .map(normalized)
+        .some((label) => /^(设置|Settings)$/.test(label)),
+    );
+    const button = byText || document.querySelector('button[aria-haspopup="dialog"][aria-expanded]');
+    if (!button) return { ok: false, reason: "missing", semanticFallback: false };
+    if (button.disabled) return { ok: false, reason: "disabled", semanticFallback: button !== byText };
+    button.click();
+    return {
+      ok: true,
+      semanticFallback: button !== byText,
+      text: normalized(button.textContent) || normalized(button.getAttribute("aria-label")) || normalized(button.getAttribute("title")),
+    };
+  })()`;
+}
+
 function clickPluginAction(pluginId, action) {
   return `(() => {
     const card = Array.from(document.querySelectorAll("[data-penglai-plugin-card]")).find(
@@ -180,7 +201,7 @@ async function installOptionalPlugins(session) {
         45_000,
       );
     }
-    await evaluate(session, clickButtonText(["^设置$", "^Settings$"]));
+    await evaluate(session, settingsTriggerClickScript());
     await delay(300);
     await evaluate(session, clickButtonText(["^蓬莱$", "^Penglai$"]));
     return waitEval(session, SNAPSHOT_JS, (snap) => Boolean(snap?.center), 15_000);
@@ -607,7 +628,10 @@ export async function walkInstalledBrowserWindow(session, opts = {}) {
   ];
   const installResults = [];
   for (const target of settingsTargets) {
-    const click = await evaluate(session, clickButtonText(target.patterns));
+    const click = await evaluate(
+      session,
+      target.id === "ui-settings-open" ? settingsTriggerClickScript() : clickButtonText(target.patterns),
+    );
     await delay(700);
     const after = await waitEval(session, SNAPSHOT_JS, () => true, 1_000);
     if (target.flag && after?.[target.flag] && !settingsWalked.includes(target.id)) settingsWalked.push(target.id);


### PR DESCRIPTION
## Summary

- open the official DSH settings trigger by its dialog semantics when the responsive sidebar hides the visible label
- preserve the text-label path for expanded Chinese and English layouts
- add an executable regression for the narrow Windows icon-only state

## Evidence

- `pnpm test:unit` (556/556)
- `pnpm exec tsx --test apps/desktop/src/installed-walk.test.ts` (17/17)
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm audit:secrets`

This keeps every installed Office/Memory/optional-plugin settings requirement intact; it only fixes the native UI walker so the Windows collapsed layout is tested through the real official DSH button.