### PR TITLE
docs: publish Penglai 0.5.5 evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center"><strong>DeepSeek Harness, ready to live on a personal computer.</strong></p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/0.5.5-release%20candidate-d97706?style=flat-square" alt="Penglai 0.5.5 release candidate">
+  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.5"><img src="https://img.shields.io/badge/release-0.5.5-0f766e?style=flat-square" alt="Penglai 0.5.5"></a>
   <a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://img.shields.io/badge/DSH-0.1.1--rc.2-7c3aed?style=flat-square" alt="DeepSeek Harness 0.1.1-rc.2"></a>
   <img src="https://img.shields.io/badge/targets-Apple%20Silicon%20%7C%20Intel%20Mac%20%7C%20Windows%20x64-0f766e?style=flat-square" alt="Apple Silicon, Intel Mac, and Windows x64">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-16a34a?style=flat-square" alt="MIT License"></a>
@@ -19,23 +19,24 @@
   <a href="#english">English</a> ·
   <a href="#中文">中文</a> ·
   <a href="https://penglai.pages.dev">Website</a> ·
-  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.3">Current download</a> ·
+  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.5">Current download</a> ·
   <a href="docs/RELEASE_NOTES_0.5.5.md">0.5.5 notes</a> ·
   <a href="AGENTS.md">For AI contributors</a> ·
   <a href="SECURITY.md">Security</a>
 </p>
 
-> Penglai 0.5.5 is still going through native release verification. There is no
-> `v0.5.5` tag or GitHub Release yet, so 0.5.3 remains the public download.
-> Apple Silicon installed-product tests are green. Intel Mac and Windows x64
-> must still pass on matching GitHub runners. macOS builds are ad-hoc signed and
-> not notarized; Windows builds do not have Authenticode.
+> Penglai 0.5.5 is available for Apple Silicon, Intel Mac, and Windows x64.
+> All three installers came from one merged source commit and passed native
+> installed-product tests. The ten-asset Release is immutable and its public
+> bytes, hashes, updater signatures, and source identity were downloaded and
+> verified again after publication. macOS remains ad-hoc signed and not
+> notarized; Windows does not have Authenticode.
 
 <p align="center">
   <img src=".github/assets/0.5.5/plugin-center.png" width="49%" alt="Penglai 0.5.5 Plugin Center in the installed DSH settings">
   <img src=".github/assets/0.5.5/memory.png" width="49%" alt="Penglai Memory in the installed DSH settings">
 </p>
-<p align="center"><sub>Real screenshots from the installed Apple Silicon 0.5.5 candidate, not design mockups.</sub></p>
+<p align="center"><sub>Real screenshots from the installed 0.5.5 application, not design mockups.</sub></p>
 
 <a id="english"></a>
 
@@ -178,14 +179,19 @@ go Back, retry a failed credential, resume after restart, and reject the app's
 own data or installation directory as a Workspace. Finishing the wizard means a
 real model reply was received, not merely that a health endpoint answered.
 
-The 0.5.5 Release will contain exactly three native installers built from one
-merged source SHA:
+The immutable 0.5.5 Release contains exactly three native installers built from
+source commit [`2136ff69`](https://github.com/kevinchennewbee/PenglaiAgent/commit/2136ff691afa8bdbefa3079236426a72a3851237):
 
-| Platform | Planned asset | Current candidate evidence |
+| Platform | Release asset | Native installed evidence |
 | --- | --- | --- |
-| Apple Silicon, macOS 13+ | `Penglai_0.5.5_macos_aarch64.dmg` | Installed U3 PASS locally |
-| Intel Mac | `Penglai_0.5.5_macos_x64.dmg` | Awaiting matching native runner |
-| Windows x64 | `Penglai_0.5.5_windows_x64_setup.exe` | Awaiting matching native runner |
+| Apple Silicon, macOS 13+ | [`Penglai_0.5.5_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.5/Penglai_0.5.5_macos_aarch64.dmg) | U3 PASS on native runner |
+| Intel Mac | [`Penglai_0.5.5_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.5/Penglai_0.5.5_macos_x64.dmg) | U3 PASS on native runner |
+| Windows x64 | [`Penglai_0.5.5_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.5/Penglai_0.5.5_windows_x64_setup.exe) | U3 PASS plus native Simplified Chinese installer screenshot |
+
+The matching [native workflow](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/32656584336)
+passed for all three targets. A post-publication read-back downloaded all ten
+Release assets and rechecked the exact set, byte sizes, SHA-256 values, source
+tag, public-export tree, update manifest, and detached Ed25519 signatures.
 
 Penglai 0.5.1, 0.5.2, and 0.5.3 can check the signed 0.5 line from **Settings →
 Penglai → Updates**, or use a same-platform manual overlay. There is no silent
@@ -395,13 +401,19 @@ SenseVoice 和 MOSS-TTS 默认关闭，是因为模型文件较大。语音识�
 真实 DSH Turn。它支持返回、密钥失败后重试、重启后续接，也会拒绝把应用数据目录
 或安装目录选作 Workspace。只有模型真的回复了，才算完成，不会拿健康接口冒充。
 
-0.5.5 最终 Release 必须由同一个合并后的源码 SHA，在对应原生机器上生成三个包：
+不可变的 0.5.5 Release 已由同一个合并后的源码提交
+[`2136ff69`](https://github.com/kevinchennewbee/PenglaiAgent/commit/2136ff691afa8bdbefa3079236426a72a3851237)
+在对应原生 runner 上生成三个包：
 
-| 平台 | 计划中的文件 | 当前候选证据 |
+| 平台 | 正式文件 | 原生安装证据 |
 | --- | --- | --- |
-| Apple Silicon，macOS 13+ | `Penglai_0.5.5_macos_aarch64.dmg` | 本机安装 U3 PASS |
-| Intel Mac | `Penglai_0.5.5_macos_x64.dmg` | 等待匹配的原生 runner |
-| Windows x64 | `Penglai_0.5.5_windows_x64_setup.exe` | 等待匹配的原生 runner |
+| Apple Silicon，macOS 13+ | [`Penglai_0.5.5_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.5/Penglai_0.5.5_macos_aarch64.dmg) | 原生 runner U3 PASS |
+| Intel Mac | [`Penglai_0.5.5_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.5/Penglai_0.5.5_macos_x64.dmg) | 原生 runner U3 PASS |
+| Windows x64 | [`Penglai_0.5.5_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.5/Penglai_0.5.5_windows_x64_setup.exe) | U3 PASS，并有原生简体中文安装器截图 |
+
+对应的[三端原生工作流](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/32656584336)
+全部通过。发布后又从公网下载十个 Release 资产，重新核对了精确文件集、大小、SHA-256、
+源码 tag、公开源码树、升级 manifest 和 Ed25519 分离签名。
 
 0.5.1、0.5.2、0.5.3 可以从 **设置 → 蓬莱 → 更新** 检查 0.5 系列签名版本，
 也可以用同平台安装包手动覆盖。它不会静默升级。0.5.0 没有生产升级信任链，只能

--- a/docs/PUBLICATION_0.5.5.md
+++ b/docs/PUBLICATION_0.5.5.md
@@ -7,3 +7,11 @@
 - `Penglai_0.5.5_windows_x64_setup.exe`
 
 The source branch must enter `main` through review and required checks. Build all three installers from the same merged source SHA on matching native runners, collect those exact bytes without rebuilding, generate and sign the remaining seven metadata assets, publish an immutable bilingual `v0.5.5` Release, then perform remote byte-for-byte readback. A failed required gate stops publication.
+
+This contract was fulfilled on 2026-08-24. Source commit
+`2136ff691afa8bdbefa3079236426a72a3851237` passed the three-target native run
+[`32656584336`](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/32656584336).
+The bilingual [`v0.5.5`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.5)
+Release is immutable, contains the exact ten assets required by the release
+identity contract, and passed public byte-for-byte readback including update and
+installer signature verification.

--- a/docs/PUBLICATION_MANIFEST_0.5.5.md
+++ b/docs/PUBLICATION_MANIFEST_0.5.5.md
@@ -1,23 +1,35 @@
 # PUBLICATION_MANIFEST 0.5.5
 
-Status: `UNFROZEN`
+Status: `IMMUTABLE`
 
 | Field | Value |
 | --- | --- |
 | productVersion | `0.5.5` |
 | DSH | `0.1.1-rc.2` |
 | trustTier | `community-verified` |
-| source SHA | `NONE` |
+| source SHA | `2136ff691afa8bdbefa3079236426a72a3851237` |
+| public export tree | `a55c3d7a3010b4734c58ae8f59690685bea8369f462a2f62d434a7cca24d2d16` (638 files) |
 | repository | `kevinchennewbee/PenglaiAgent` |
-| tag / Release | `v0.5.5` (not created) |
+| tag / Release | [`v0.5.5`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.5), Release `375290439`, immutable |
+| native run | [`32656584336`](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/32656584336), all three targets PASS |
 | publication channel | `stable-v0.5.5` |
 
-| Target | Exact installer |
-| --- | --- |
-| Apple Silicon | `Penglai_0.5.5_macos_aarch64.dmg` |
-| Intel Mac | `Penglai_0.5.5_macos_x64.dmg` |
-| Windows x64 | `Penglai_0.5.5_windows_x64_setup.exe` |
+| Target | Exact installer | Bytes | SHA-256 |
+| --- | --- | ---: | --- |
+| Apple Silicon | `Penglai_0.5.5_macos_aarch64.dmg` | 461033213 | `51a145ec4f6b74a7fca1eba851bd58496517c340233816c0c02171c3745ad136` |
+| Intel Mac | `Penglai_0.5.5_macos_x64.dmg` | 390157471 | `7d5245543c6ee12b90fdcdaa8aae81a3d9fc92f9b4b376732dac9244a74552dd` |
+| Windows x64 | `Penglai_0.5.5_windows_x64_setup.exe` | 355983707 | `2539bb423d7a4f53f012a08f7938644cf26e8717f777f0ef9a5893b120a44e03` |
 
-The intended Release set is those three installers plus `update-manifest-v1.json`, `update-manifest-v1.json.sig`, `release-manifest.json`, `SBOM.cdx.json`, `THIRD_PARTY_NOTICES.txt`, `SHA256SUMS`, and `public-export-manifest.json`.
+The exact Release set is those three installers plus `update-manifest-v1.json`, `update-manifest-v1.json.sig`, `release-manifest.json`, `SBOM.cdx.json`, `THIRD_PARTY_NOTICES.txt`, `SHA256SUMS`, and `public-export-manifest.json`.
 
-Owner authorized this manifest to progress from `UNFROZEN` to a merged source SHA and immutable Release only after the required local and GitHub gates pass. Until then, `NONE` and `UNFROZEN` remain honest placeholders and must not be replaced with predicted values.
+The three matching native jobs passed clean export, exact installer identity,
+Electron fuse checks, installed welcome/process smoke, and installed first-party
+plugin compatibility. The Windows job additionally passed its native
+Simplified Chinese NSIS screenshot gate. Update manifest sequence `4` binds the
+three GitHub asset IDs, sizes, hashes, detached installer signatures, source
+identity, public-export tree, and release-manifest digest.
+
+After publication, `readback:release v0.5.5` downloaded all ten public assets
+and returned `PASS` for the immutable flag, exact asset set, tag-to-source
+identity, SHA256SUMS, update-manifest signature, and all three installer
+signatures. No value in this manifest is a predicted candidate value.

--- a/docs/RELEASE_NOTES_0.5.5.md
+++ b/docs/RELEASE_NOTES_0.5.5.md
@@ -1,17 +1,18 @@
 # Penglai 0.5.5 release notes
 
-Status: release candidate. This document does not claim that `v0.5.5` has been
-published. Source SHA, native run, installer hashes, and public read-back will be
-frozen only after the remaining release gates pass.
+Status: released. The immutable bilingual [`v0.5.5`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.5)
+Release was published from source commit `2136ff691afa8bdbefa3079236426a72a3851237`.
+All three native targets passed and the ten public assets were downloaded and
+verified again after publication.
 
 Trust tier: `community-verified`. This is not silent auto-update.
 
 ## English
 
 Penglai 0.5.5 moves from official DeepSeek Harness `0.1.1-rc.1` to
-`0.1.1-rc.2`. DSH remains the only agent core. The release is planned for Apple
-Silicon (`darwin-aarch64`), Intel Mac (`darwin-x86_64`), and Windows x64
-(`win32-x86_64`) from one merged source commit.
+`0.1.1-rc.2`. DSH remains the only agent core. Apple Silicon
+(`darwin-aarch64`), Intel Mac (`darwin-x86_64`), and Windows x64
+(`win32-x86_64`) were built from one merged source commit.
 
 ### The short version
 
@@ -105,33 +106,34 @@ reference fixture and budget card are not presented as ordinary products.
 
 ### Catalog transition
 
-The planned signed `plugin-catalog-v1.000006` contains no replacement download.
+The signed [`plugin-catalog-v1.000006`](https://github.com/kevinchennewbee/PenglaiPluginRegistry/releases/tag/plugin-catalog-v1.000006) contains no replacement download.
 It revokes the old `@penglai/office-reader` exact artifact because full Penglai
 Office now ships in the desktop application. Catalog 000006 must not be
-published until the immutable 0.5.5 desktop Release exists. The historical
+published only after the immutable 0.5.5 desktop Release existed. The historical
 catalog Releases remain immutable.
 
 ### Verification and known limits
 
-The Apple Silicon candidate has been built from a clean public export, installed
-from its exact DMG, mounted against official DSH rc.2, and exercised through the
-required Office/Memory default plus optional plugin enable/restart/disable
-phases. Memory engine readiness, authorised-source UI, all optional settings
-surfaces, official HTTP/WebSocket, source identity, and zero leftover owned
-processes are part of that gate.
+The matching [native workflow](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/32656584336)
+passed on Apple Silicon, Intel Mac, and Windows x64. Every target used the same
+638-file clean public-export tree and passed exact installer identity, packaged
+Electron fuses, installed welcome/process smoke, Office and Memory defaults,
+and optional plugin enable/restart/disable/restart. The Windows runner also
+captured the real Simplified Chinese NSIS component page.
 
-Before publication, the matching Intel Mac and Windows x64 native jobs, final
-source gates, merge identity, metadata/signature generation, and immutable
-GitHub byte read-back must still pass. Real Weixin/Feishu accounts remain a
-separate external-credential limit. macOS is ad-hoc signed and not notarized;
-Windows has no Authenticode. Penglai signatures protect updater and plugin
-bytes, not operating-system publisher identity.
+The immutable Release contains exactly ten assets. Public read-back verified
+the tag-to-source binding, byte sizes, SHA-256 values, public-export tree,
+sequence-4 update manifest, manifest signature, and all three installer
+signatures. Real Weixin/Feishu accounts remain a separate external-credential
+limit. macOS is ad-hoc signed and not notarized; Windows has no Authenticode.
+Penglai signatures protect updater and plugin bytes, not operating-system
+publisher identity.
 
 ## 中文
 
 蓬莱 0.5.5 把唯一核心从官方 DeepSeek Harness `0.1.1-rc.1` 更新到
-`0.1.1-rc.2`。最终计划由同一个合并后的源码提交，在 Apple Silicon、Intel Mac 和
-Windows x64 三个原生环境分别构建。
+`0.1.1-rc.2`。Apple Silicon、Intel Mac 和 Windows x64 三个原生安装包已由同一个
+合并后的源码提交分别构建。
 
 ### 一句话版本
 
@@ -207,17 +209,20 @@ ASR、MOSS-TTS、记忆、办公、隐藏高级预算控制和主动陪伴。用
 
 ### 插件目录过渡
 
-计划中的签名 `plugin-catalog-v1.000006` 不提供替代下载。它按精确身份撤销旧
+已发布的签名 [`plugin-catalog-v1.000006`](https://github.com/kevinchennewbee/PenglaiPluginRegistry/releases/tag/plugin-catalog-v1.000006)
+不提供替代下载。它按精确身份撤销旧
 `@penglai/office-reader`，因为完整蓬莱办公已经随客户端提供。目录 000006 必须等
-不可变 0.5.5 桌面 Release 真实存在后才能发布；旧目录 Release 保持不可变。
+不可变 0.5.5 桌面 Release 真实存在后才发布；旧目录 Release 保持不可变。
 
 ### 验收与已知限制
 
-Apple Silicon 候选已经从 clean public export 构建，并从精确 DMG 安装。测试覆盖
-official DSH rc.2、办公与记忆默认启用、可选插件启用/重启/停用、记忆引擎 ready、
-授权资料 UI、全部可选设置页、official HTTP/WebSocket、源码身份和进程零残留。
+对应的[三端原生工作流](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/32656584336)
+已在 Apple Silicon、Intel Mac 和 Windows x64 全部通过。三个目标使用同一份 638 文件
+clean public-export 树，并通过安装包精确身份、Electron fuse、安装后首次启动与进程、
+办公和记忆默认启用，以及可选插件启用/重启/停用/再次重启。Windows runner 还保存了
+真实简体中文 NSIS 组件页截图。
 
-发布前仍需通过 Intel Mac、Windows x64 匹配原生 runner、最终源码门禁、合并身份、
-元数据与签名生成，以及 GitHub 不可变字节回读。真实微信/飞书账号仍是单独的外部
-凭据边界。macOS 为 ad-hoc 签名且未公证，Windows 没有 Authenticode。蓬莱签名保护
-升级和插件字节，不代表操作系统发布者身份。
+不可变 Release 严格包含十个资产。公网回读重新验证了 tag 到源码、字节大小、SHA-256、
+公开源码树、序号 4 的升级 manifest、manifest 签名和三个安装包签名。真实微信/飞书账号
+仍是单独的外部凭据边界。macOS 为 ad-hoc 签名且未公证，Windows 没有 Authenticode。
+蓬莱签名保护升级和插件字节，不代表操作系统发布者身份。


### PR DESCRIPTION
## Summary

- switch README downloads and status from the 0.5.5 candidate to the immutable release
- record the three native installed PASS results and Windows Chinese-installer evidence
- freeze exact source, public-export tree, installer sizes and hashes
- replace pre-publication wording with the completed public byte-for-byte readback
- link the independently published signed plugin catalog 000006

## Verification

- immutable v0.5.5 Release: exact 10 assets
- public `readback:release v0.5.5`: PASS
- native run 32656584336: Apple Silicon, Intel Mac, Windows x64 all PASS
- plugin catalog 000006 immutable readback and signature: PASS
- `pnpm format:check`
- `pnpm audit:secrets`
- `git diff --check`
