### PR TITLE
docs: close Penglai 0.5.6 publication

### DIFF
--- a/.github/workflows/native-release-candidate.yml
+++ b/.github/workflows/native-release-candidate.yml
@@ -26,7 +26,9 @@ jobs:
   plugin-distribution:
     name: Signed Plugin Center distribution
     if: ${{ inputs.mode == 'catalog' }}
-    runs-on: ubuntu-latest
+    # The boot-time revocation path deliberately derives the product plugin
+    # target from the native host. Linux is not a Penglai release target.
+    runs-on: macos-15
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@
   <a href="SECURITY.md">Security</a>
 </p>
 
-> Penglai 0.5.6 targets Apple Silicon, Intel Mac, and Windows x64. This source
-> candidate is not called released until all three native jobs and immutable
-> ten-asset public readback pass. macOS remains ad-hoc signed and not notarized;
-> Windows does not have Authenticode.
+> Penglai 0.5.6 targets Apple Silicon, Intel Mac, and Windows x64. The exact
+> source is `75bbd591c61b757dfe015e54e40ad21ccf9ab94b`; all three rebuilt native jobs
+> and the immutable ten-asset public readback passed.
+> macOS remains ad-hoc signed and not notarized; Windows has no Authenticode.
 
 <p align="center">
   <img src=".github/assets/0.5.5/plugin-center.png" width="49%" alt="Penglai 0.5.5 Plugin Center in the installed DSH settings">
@@ -196,20 +196,20 @@ go Back, retry a failed credential, resume after restart, and reject the app's
 own data or installation directory as a Workspace. Finishing the wizard means a
 real model reply was received, not merely that a health endpoint answered.
 
-The 0.5.6 release contract names exactly three native installers. Exact source,
-workflow, byte-size, and digest values are added here only after the matching
-native run and immutable public readback pass:
+The 0.5.6 release contract contains exactly three native installers from source
+`75bbd591c61b757dfe015e54e40ad21ccf9ab94b`. Rebuilt native run
+[`32795706687`](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/32795706687)
+passed; the immutable public readback also passed:
 
 | Platform | Release asset | Native installed evidence |
 | --- | --- | --- |
-| Apple Silicon, macOS 13+ | `Penglai_0.5.6_macos_aarch64.dmg` | Pending exact native/public evidence |
-| Intel Mac | `Penglai_0.5.6_macos_x64.dmg` | Pending exact native/public evidence |
-| Windows x64 | `Penglai_0.5.6_windows_x64_setup.exe` | Pending exact native/public evidence plus Simplified Chinese installer screenshot |
+| Apple Silicon, macOS 13+ | `Penglai_0.5.6_macos_aarch64.dmg` | 467,566,184 bytes · `2a9097c791a183fb705d24e9f359a5a6dc2b09d98507a8bc785e763a05abffb3` |
+| Intel Mac | `Penglai_0.5.6_macos_x64.dmg` | 396,796,619 bytes · `b37f1eab02244c2c06b0d6dc220f899ed866463143f3315a99f8d408b2bffea3` |
+| Windows x64 | `Penglai_0.5.6_windows_x64_setup.exe` | 355,959,044 bytes · `b56b163b38f63337f760fd0d2fade3fd36f9a2cb72e00a2932154a693c74c989` · Simplified Chinese native UI PASS |
 
-The release closes only after the matching native workflow passes all three
-targets and a post-publication readback downloads all ten Release assets to
-recheck the exact set, byte sizes, SHA-256 values, source tag, public-export
-tree, update manifest, and detached Ed25519 signatures.
+The post-publication readback downloaded all ten Release assets and rechecked
+the exact set, byte sizes, SHA-256 values, source tag, public-export tree,
+update manifest, and detached Ed25519 signatures.
 
 Penglai 0.5.1 through 0.5.5 can check the signed 0.5 line from **Settings →
 Penglai → Updates**, or use a same-platform manual overlay. There is no silent
@@ -437,18 +437,19 @@ SenseVoice 和 MOSS-TTS 默认关闭，是因为模型文件较大。语音识�
 真实 DSH Turn。它支持返回、密钥失败后重试、重启后续接，也会拒绝把应用数据目录
 或安装目录选作 Workspace。只有模型真的回复了，才算完成，不会拿健康接口冒充。
 
-0.5.6 发布契约固定三个原生安装包。只有对应 native workflow 与不可变公网回读通过后，
-这里才会填写精确源码、工作流、字节大小和摘要：
+0.5.6 发布契约固定从源码 `75bbd591c61b757dfe015e54e40ad21ccf9ab94b`
+生成三个原生安装包。原生任务
+[`32795706687`](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/32795706687)
+已经通过；不可变公网回读也已通过：
 
 | 平台 | 正式文件 | 原生安装证据 |
 | --- | --- | --- |
-| Apple Silicon，macOS 13+ | `Penglai_0.5.6_macos_aarch64.dmg` | 等待精确原生/公网证据 |
-| Intel Mac | `Penglai_0.5.6_macos_x64.dmg` | 等待精确原生/公网证据 |
-| Windows x64 | `Penglai_0.5.6_windows_x64_setup.exe` | 等待精确原生/公网证据和简体中文安装器截图 |
+| Apple Silicon，macOS 13+ | `Penglai_0.5.6_macos_aarch64.dmg` | 467,566,184 字节 · `2a9097c791a183fb705d24e9f359a5a6dc2b09d98507a8bc785e763a05abffb3` |
+| Intel Mac | `Penglai_0.5.6_macos_x64.dmg` | 396,796,619 字节 · `b37f1eab02244c2c06b0d6dc220f899ed866463143f3315a99f8d408b2bffea3` |
+| Windows x64 | `Penglai_0.5.6_windows_x64_setup.exe` | 355,959,044 字节 · `b56b163b38f63337f760fd0d2fade3fd36f9a2cb72e00a2932154a693c74c989` · 原生简体中文界面 PASS |
 
-只有三端原生工作流全部通过，并且发布后从公网下载十个 Release 资产，重新核对精确
-文件集、大小、SHA-256、源码 tag、公开源码树、升级 manifest 和 Ed25519 分离签名，
-本版本才会关闭发布状态。
+发布后回读已从公网下载十个 Release 资产，并重新核对精确文件集、大小、SHA-256、
+源码 tag、公开源码树、升级 manifest 和 Ed25519 分离签名。
 
 0.5.1 到 0.5.5 可以从 **设置 → 蓬莱 → 更新** 检查 0.5 系列签名版本，
 也可以用同平台安装包手动覆盖。它不会静默升级。0.5.0 没有生产升级信任链，只能

--- a/docs/PUBLICATION_0.5.6.md
+++ b/docs/PUBLICATION_0.5.6.md
@@ -1,6 +1,6 @@
 # PenglaiAgent 0.5.6 publication contract
 
-Status: `CANDIDATE` until immutable public readback succeeds.
+Status: `PUBLIC_READBACK_PASS`.
 
 Owner authorized source changes, real testing, push, PR, merge, three-target
 native builds, tag, GitHub Release, README, website, and bilingual public copy
@@ -20,7 +20,12 @@ declared by `release-contract.json`, and no others. The signed update manifest
 uses sequence `5`, binds GitHub asset IDs, installer sizes/hashes/signatures,
 the release-manifest digest, and the deterministic public-export tree.
 
-Publication is complete only when GitHub reports an immutable stable `v0.5.6`
-Release and `pnpm readback:release v0.5.6` downloads and verifies all ten public
-assets. README, website, and publication evidence may say “released” only after
-that result exists.
+The exact candidate source is
+`75bbd591c61b757dfe015e54e40ad21ccf9ab94b`, with public-export tree
+`2a5b725aaaab1af7b651dbbe5b2d5558bb3c9ab15bde53c24d077896e37cdd79`
+(735 files). Native run
+[`32795706687`](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/32795706687)
+passed on Apple Silicon, Intel Mac, and Windows x64. The immutable stable
+[`v0.5.6`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.6)
+Release is public, and `pnpm readback:release v0.5.6` passed for all ten public
+assets, tag-to-source identity, updater metadata, and detached signatures.

--- a/docs/PUBLICATION_MANIFEST_0.5.6.md
+++ b/docs/PUBLICATION_MANIFEST_0.5.6.md
@@ -1,29 +1,39 @@
 # PUBLICATION_MANIFEST 0.5.6
 
-Status: `CANDIDATE`
+Status: `PUBLIC_READBACK_PASS`
 
 | Field | Value |
 | --- | --- |
 | productVersion | `0.5.6` |
 | DSH | `0.1.1-rc.2` |
 | trustTier | `community-verified` |
-| source SHA | recorded after exact candidate freeze |
-| public export tree | recorded after clean-room export |
+| source SHA | `75bbd591c61b757dfe015e54e40ad21ccf9ab94b` |
+| public export tree | `2a5b725aaaab1af7b651dbbe5b2d5558bb3c9ab15bde53c24d077896e37cdd79` (735 files) |
 | repository | `kevinchennewbee/PenglaiAgent` |
-| tag / Release | `v0.5.6`, pending immutable readback |
-| native run | recorded after all three matching native jobs pass |
+| tag / Release | [`v0.5.6`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.6), immutable and Latest |
+| native run | [`32795706687`](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/32795706687), all three matching native jobs PASS |
 | publication channel | `stable-v0.5.6` |
 
 | Target | Exact installer | Bytes | SHA-256 |
 | --- | --- | ---: | --- |
-| Apple Silicon | `Penglai_0.5.6_macos_aarch64.dmg` | recorded from accepted bytes | recorded from accepted bytes |
-| Intel Mac | `Penglai_0.5.6_macos_x64.dmg` | recorded from accepted bytes | recorded from accepted bytes |
-| Windows x64 | `Penglai_0.5.6_windows_x64_setup.exe` | recorded from accepted bytes | recorded from accepted bytes |
+| Apple Silicon | `Penglai_0.5.6_macos_aarch64.dmg` | 467566184 | `2a9097c791a183fb705d24e9f359a5a6dc2b09d98507a8bc785e763a05abffb3` |
+| Intel Mac | `Penglai_0.5.6_macos_x64.dmg` | 396796619 | `b37f1eab02244c2c06b0d6dc220f899ed866463143f3315a99f8d408b2bffea3` |
+| Windows x64 | `Penglai_0.5.6_windows_x64_setup.exe` | 355959044 | `b56b163b38f63337f760fd0d2fade3fd36f9a2cb72e00a2932154a693c74c989` |
 
 The exact Release set is those three installers plus
 `update-manifest-v1.json`, `update-manifest-v1.json.sig`,
 `release-manifest.json`, `SBOM.cdx.json`, `THIRD_PARTY_NOTICES.txt`,
 `SHA256SUMS`, and `public-export-manifest.json`.
 
-Candidate placeholders are intentionally not predicted. They are replaced only
-with values observed from the exact native workflow and immutable public bytes.
+The three installer rows are the exact bytes accepted from rebuilt native run
+`32795706687`; all three passed clean export, installer/source identity,
+Electron fuses, installed welcome, and first-party plugin lifecycle checks.
+Windows also passed the native Simplified Chinese installer UI gate. The same
+exact bytes were downloaded from the immutable public Release and matched.
+Update manifest sequence `5` binds the observed GitHub
+asset IDs, sizes, hashes, installer signatures, source identity, public-export
+tree, and release-manifest digest.
+
+`pnpm readback:release v0.5.6` passed for the exact ten-asset set,
+tag-to-source identity, public-export identity, GitHub sizes/digests,
+`SHA256SUMS`, the signed update manifest, and each installer signature.

--- a/docs/RELEASE_NOTES_0.5.6.md
+++ b/docs/RELEASE_NOTES_0.5.6.md
@@ -3,11 +3,28 @@
 Trust tier: `community-verified`. Official DeepSeek Harness `0.1.1-rc.2`
 remains the only agent core. This release is not silent auto-update.
 
+## Exact candidate / 精确候选
+
+- Source / 源码: `75bbd591c61b757dfe015e54e40ad21ccf9ab94b`
+- Public export / 公开源码树: `2a5b725aaaab1af7b651dbbe5b2d5558bb3c9ab15bde53c24d077896e37cdd79` (735 files)
+- Native run / 三端原生任务: [32795706687](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/32795706687)
+- Apple Silicon: 467,566,184 bytes · `2a9097c791a183fb705d24e9f359a5a6dc2b09d98507a8bc785e763a05abffb3`
+- Intel Mac: 396,796,619 bytes · `b37f1eab02244c2c06b0d6dc220f899ed866463143f3315a99f8d408b2bffea3`
+- Windows x64: 355,959,044 bytes · `b56b163b38f63337f760fd0d2fade3fd36f9a2cb72e00a2932154a693c74c989`
+
+The exact ten public assets are immutable and the post-publication readback
+passed. / 十个精确公网资产已经不可变，发布后回读已通过。
+
 ## English
 
 Penglai 0.5.6 focuses on the places where a feature could appear present in a
 settings page without completing the real user action: automatic memory,
 owner-approved writes, file handoff, speech playback, and messaging availability.
+
+The first-run model test and first conversation now wait for the official
+durable `turn/end`, use a bounded first-reply budget, and run in an official
+per-Session no-tools scope. A model can no longer strand the setup wizard by
+choosing an approval-gated tool that the wizard cannot present.
 
 ### Memory now works without a magic phrase
 

--- a/packages/release-identity/src/public-docs.test.ts
+++ b/packages/release-identity/src/public-docs.test.ts
@@ -40,7 +40,7 @@ test("R50-PREP-008 publication manifest lists the exact three-target release", (
   assert.match(md, /Penglai_0\.5\.6_windows_x64_setup\.exe/);
   assert.match(md, /public-export-manifest\.json/);
   assert.match(md, /kevinchennewbee\/PenglaiAgent/);
-  assert.match(md, /CANDIDATE|IMMUTABLE/);
+  assert.match(md, /CANDIDATE|IMMUTABLE|PUBLIC_READBACK_PASS/);
   assert.doesNotMatch(md, /UNFROZEN/);
   assert.match(md, /community-verified/);
   recordAssertion({


### PR DESCRIPTION
Publishes the verified 0.5.6 README and bilingual evidence, and runs the live signed-catalog verifier on a supported Penglai host. Release v0.5.6 is already immutable and passed the ten-asset public readback.