### PR TITLE
release: close out Penglai 0.5.7 publication

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -7,6 +7,11 @@ on:
         description: Immutable Release tag that must already exist (example v0.5.7)
         required: true
         type: string
+      deploy_site:
+        description: Push the verified website to the gh-pages branch
+        required: true
+        default: true
+        type: boolean
 
 permissions:
   contents: write
@@ -30,6 +35,24 @@ jobs:
           corepack enable
           corepack prepare pnpm@10.14.0 --activate
           pnpm install --frozen-lockfile
+          pnpm build
           pnpm readback:release v0.5.7
-      - name: This workflow must not run from Grok Build
-        run: echo "Manual production deploy only after Codex merge and public readback."
+      - name: Deploy verified website
+        if: ${{ inputs.deploy_site }}
+        env:
+          DEPLOY_TAG: ${{ inputs.tag }}
+        run: |
+          site_dir="${RUNNER_TEMP}/penglai-gh-pages"
+          git fetch origin gh-pages
+          git worktree add --detach "$site_dir" origin/gh-pages
+          rsync -a --delete --exclude .git website/ "$site_dir/"
+          touch "$site_dir/.nojekyll"
+          git -C "$site_dir" config user.name "github-actions[bot]"
+          git -C "$site_dir" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "$site_dir" add -A
+          if git -C "$site_dir" diff --cached --quiet; then
+            echo "Website is already current for ${DEPLOY_TAG}."
+          else
+            git -C "$site_dir" commit -m "website: deploy ${DEPLOY_TAG} from ${GITHUB_SHA}"
+            git -C "$site_dir" push origin HEAD:gh-pages
+          fi

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center"><strong>DeepSeek Harness, ready to live on a personal computer.</strong></p>
 
 <p align="center">
-  <a href="docs/RELEASE_NOTES_0.5.7.md"><img src="https://img.shields.io/badge/candidate-0.5.7-0f766e?style=flat-square" alt="Penglai 0.5.7 candidate"></a>
+  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.7"><img src="https://img.shields.io/badge/release-0.5.7-0f766e?style=flat-square" alt="Penglai 0.5.7 release"></a>
   <a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://img.shields.io/badge/DSH-0.1.1--rc.2-7c3aed?style=flat-square" alt="DeepSeek Harness 0.1.1-rc.2"></a>
   <img src="https://img.shields.io/badge/targets-Apple%20Silicon%20%7C%20Intel%20Mac%20%7C%20Windows%20x64-0f766e?style=flat-square" alt="Apple Silicon, Intel Mac, and Windows x64">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-16a34a?style=flat-square" alt="MIT License"></a>
@@ -19,17 +19,16 @@
   <a href="#english">English</a> ·
   <a href="#中文">中文</a> ·
   <a href="https://penglai.pages.dev">Website</a> ·
-  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.6">Last public download (0.5.6)</a> ·
+  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.7">Download 0.5.7</a> ·
   <a href="docs/RELEASE_NOTES_0.5.7.md">0.5.7 notes</a> ·
   <a href="AGENTS.md">For AI contributors</a> ·
   <a href="SECURITY.md">Security</a>
 </p>
 
-> Penglai 0.5.7 is a development candidate on branch `0.5.7`. Official DSH
-> remains `0.1.1-rc.2`. Installer sizes and SHA-256 are filled only after the
-> public `v0.5.7` readback. The last immutable public Release is
-> [`v0.5.6`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.6).
-> macOS remains ad-hoc signed and not notarized; Windows has no Authenticode.
+> Penglai 0.5.7 is an immutable public Release built from
+> `ce01d4dea59af72422071e357760a040f19b8e3d`. Public byte, SHA-256, and updater
+> signature readback passed. Official DSH remains `0.1.1-rc.2`. macOS remains
+> ad-hoc signed and not notarized; Windows has no Authenticode.
 
 <p align="center">
   <img src=".github/assets/0.5.5/plugin-center.png" width="49%" alt="Penglai 0.5.5 Plugin Center in the installed DSH settings">
@@ -56,12 +55,11 @@ actually usable: packaging, process supervision, onboarding, local paths,
 upgrades, uninstall, product identity, and plugin distribution. There is no
 second Penglai agent hiding beside DSH and no replacement chat page.
 
-Version 0.5.7 keeps those completed actions and adds eight platform connectors
+Version 0.5.7 keeps those completed actions and adds eight platform connection entries
 under one Messaging plugin. Workspace memory can be curated and recalled
 automatically, high-impact writes use one action-bound Owner broker, Office and
 IM files use scoped opaque artifact references, and TTS buttons follow real
-playback state. Live support claims follow
-[`docs/0.5.7/LIVE_IM_MATRIX.md`](docs/0.5.7/LIVE_IM_MATRIX.md).
+playback state.
 
 ## What ships in 0.5.7
 
@@ -107,8 +105,7 @@ are copied from those verified bundled bytes when the user enables them. The
 large SenseVoice and MOSS-TTS model weights are the exception: they download
 only after an explicit action, from pinned revisions with size and SHA-256
 checks. Mnemon and the Office Chinese font are already bundled. LibreOffice is
-used by maintainers as an independent Office verifier; it is not required on a
-user's machine.
+neither a product runtime dependency nor a release-gate dependency.
 
 ## Office that can do work, not just read files
 
@@ -196,16 +193,19 @@ go Back, retry a failed credential, resume after restart, and reject the app's
 own data or installation directory as a Workspace. Finishing the wizard means a
 real model reply was received, not merely that a health endpoint answered.
 
-The 0.5.7 release contract contains exactly three native installers. Bytes and
-SHA-256 are filled only after public readback of immutable `v0.5.7`:
+The immutable [0.5.7 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.7)
+contains exactly three native installers. All were built from the same source SHA
+and passed [native installed-product gates](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33067739020)
+and [public readback](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33071811058):
 
-| Platform | Release asset | Native installed evidence |
-| --- | --- | --- |
-| Apple Silicon, macOS 13+ | `Penglai_0.5.7_macos_aarch64.dmg` | pending public readback |
-| Intel Mac | `Penglai_0.5.7_macos_x64.dmg` | pending public readback |
-| Windows x64 | `Penglai_0.5.7_windows_x64_setup.exe` | pending public readback |
+| Platform | Release asset | Bytes | SHA-256 |
+| --- | --- | ---: | --- |
+| Apple Silicon, macOS 13+ | [`Penglai_0.5.7_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_aarch64.dmg) | 474,383,101 | `bfbaec4b9f4b627abd41e793abae6b68246d0f00d8e9c5ca003d079e1e3667c8` |
+| Intel Mac | [`Penglai_0.5.7_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_x64.dmg) | 401,056,681 | `ab696fc92a2b1af538eed6008c8389ddc945d9dce39d85b16053cf60d8e2655e` |
+| Windows x64 | [`Penglai_0.5.7_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_windows_x64_setup.exe) | 355,918,104 | `cb4687e621d951d6d8ba4cf8428f4723f35c9827fa70ac542d4d3d928d5d882a` |
 
-The last immutable public set remains [`v0.5.6`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.6).
+The exact ten-file Release also includes signed update metadata, SHA-256 sums,
+the 1,212-component SBOM, third-party notices, and the public-export manifest.
 
 Penglai 0.5.1 through 0.5.6 can check the signed 0.5 line from **Settings →
 Penglai → Updates** after `v0.5.7` is public, or use a same-platform manual
@@ -328,8 +328,7 @@ Turn 和会话界面都归 DSH。蓬莱负责那些不太耀眼、却决定桌�
 
 0.5.7 继续让这些动作真正完成，并在唯一的「消息连接」插件下提供八个平台的
 连接入口。Workspace 记忆可以自动整理和召回，高影响动作统一经过 Owner
-Broker，办公与 IM 文件使用不透明 artifact。公开“支持”声明只以
-[`LIVE_IM_MATRIX.md`](docs/0.5.7/LIVE_IM_MATRIX.md) 为准。
+Broker，办公与 IM 文件使用不透明 artifact。
 
 ## 0.5.7 带来了什么
 
@@ -371,7 +370,7 @@ Broker，办公与 IM 文件使用不透明 artifact。公开“支持”声明�
 用户启用可选插件时，客户端从安装包内经过验证的字节安装到 app-private DSH profile。
 唯一需要另行下载的是体积较大的 SenseVoice 和 MOSS-TTS 模型，而且必须由用户主动
 点击，下载时校验固定 revision、大小和 SHA-256。Mnemon 与办公中文字体已经随包。
-LibreOffice 只是维护者用来交叉验证办公文件的工具，不是用户依赖。
+LibreOffice 既不是产品运行依赖，也不是正式发布门禁依赖。
 
 ## 蓬莱办公不是只读阅读器
 
@@ -441,16 +440,19 @@ SenseVoice 和 MOSS-TTS 默认关闭，是因为模型文件较大。语音识�
 真实 DSH Turn。它支持返回、密钥失败后重试、重启后续接，也会拒绝把应用数据目录
 或安装目录选作 Workspace。只有模型真的回复了，才算完成，不会拿健康接口冒充。
 
-0.5.7 发布契约固定三个原生安装包。大小和 SHA-256 只在公网回读 `v0.5.7` 之后
-填写：
+不可变的 [0.5.7 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.7)
+固定三个原生安装包。它们来自同一源码提交，并已通过
+[三端原生安装门禁](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33067739020)
+和[公网回读](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33071811058)：
 
-| 平台 | 正式文件 | 原生安装证据 |
-| --- | --- | --- |
-| Apple Silicon，macOS 13+ | `Penglai_0.5.7_macos_aarch64.dmg` | 待公网回读 |
-| Intel Mac | `Penglai_0.5.7_macos_x64.dmg` | 待公网回读 |
-| Windows x64 | `Penglai_0.5.7_windows_x64_setup.exe` | 待公网回读 |
+| 平台 | 正式文件 | 字节数 | SHA-256 |
+| --- | --- | ---: | --- |
+| Apple Silicon，macOS 13+ | [`Penglai_0.5.7_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_aarch64.dmg) | 474,383,101 | `bfbaec4b9f4b627abd41e793abae6b68246d0f00d8e9c5ca003d079e1e3667c8` |
+| Intel Mac | [`Penglai_0.5.7_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_x64.dmg) | 401,056,681 | `ab696fc92a2b1af538eed6008c8389ddc945d9dce39d85b16053cf60d8e2655e` |
+| Windows x64 | [`Penglai_0.5.7_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_windows_x64_setup.exe) | 355,918,104 | `cb4687e621d951d6d8ba4cf8428f4723f35c9827fa70ac542d4d3d928d5d882a` |
 
-上一份不可变公网资产仍是 [`v0.5.6`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.6)。
+准确的十文件 Release 还包含签名更新元数据、SHA-256 清单、1212 组件 SBOM、
+第三方声明和公开导出清单。
 
 0.5.1 到 0.5.6 可以在 `v0.5.7` 公开发布后从 **设置 → 蓬莱 → 更新** 检查 0.5
 系列签名版本，也可以用同平台安装包手动覆盖。它不会静默升级。0.5.0 没有生产

--- a/docs/PUBLICATION_0.5.7.md
+++ b/docs/PUBLICATION_0.5.7.md
@@ -1,13 +1,11 @@
 # PenglaiAgent 0.5.7 publication contract
 
-Status: `CANDIDATE`.
+Status: `PUBLIC_READBACK_PASS`.
 
-Owner authorized 0.5.7 development, real testing, a Draft PR to `main`, Codex
-review, merge, three-target native rebuilds, tag, GitHub Release, README,
-website, and bilingual public copy **only after required gates pass**.
-Authorization does not permit publication with a failed required gate or
-disclosure of credentials, private keys, local paths, QR data, chat bodies,
-account identities, profiles, logs, or private media.
+The immutable `v0.5.7` Release was published from source
+`ce01d4dea59af72422071e357760a040f19b8e3d` after review, three-target native
+rebuilds, and required gates. Public readback verified the exact GitHub bytes,
+SHA-256 values, signed update manifest, and three installer signatures.
 
 Grok Build stops at a Draft PR. It does not merge, create `v0.5.7`, publish a
 Release, or deploy production `gh-pages`.
@@ -23,5 +21,5 @@ runners. The Release contains those three bytes plus the seven metadata assets
 declared by `release-contract.json`, and no others.
 
 Official DSH remains `0.1.1-rc.2`. DSH-IM v3.0.5 is a selective rewrite pin,
-not an installed second runtime. Nine messaging platforms have connection
-entries; live support claims follow `docs/0.5.7/LIVE_IM_MATRIX.md`.
+not an installed second runtime. Eight platforms have connection entries under
+`@penglai/im`; the WhatsApp community runtime is not bundled in 0.5.7.

--- a/docs/PUBLICATION_MANIFEST_0.5.7.md
+++ b/docs/PUBLICATION_MANIFEST_0.5.7.md
@@ -5,6 +5,9 @@ Status: `PUBLIC_READBACK_PASS`
 The immutable public Release was assembled from the clean export of the exact
 source SHA below. GitHub-hosted bytes, SHA-256 values, update-manifest signature,
 and all three installer signatures were downloaded and verified after publication.
+The committed `release-info.json` remains a non-self-referential template with
+`phase=UNFROZEN` and `sourceSha=NONE`; generated build and public manifests bind
+the observed release identity instead.
 
 | Field | Value |
 | --- | --- |

--- a/docs/PUBLICATION_MANIFEST_0.5.7.md
+++ b/docs/PUBLICATION_MANIFEST_0.5.7.md
@@ -1,31 +1,31 @@
 # PUBLICATION_MANIFEST 0.5.7
 
-Status: `CANDIDATE`
+Status: `PUBLIC_READBACK_PASS`
 
-Committed identity is a template. `release-info.json` keeps `phase=UNFROZEN`
-and `sourceSha=NONE` so the source tree does not invent a self-referential
-commit. Candidate evidence is generated at build time and bound to the real
-Git SHA. Observed public SHA, size, and digest are written here only after
-`pnpm readback:release v0.5.7` passes.
+The immutable public Release was assembled from the clean export of the exact
+source SHA below. GitHub-hosted bytes, SHA-256 values, update-manifest signature,
+and all three installer signatures were downloaded and verified after publication.
 
 | Field | Value |
 | --- | --- |
 | productVersion | `0.5.7` |
 | DSH | `0.1.1-rc.2` |
 | trustTier | `community-verified` |
-| source SHA | `NONE` until freeze; public docs wait for readback |
-| public export tree | pending clean-room export |
+| source SHA | `ce01d4dea59af72422071e357760a040f19b8e3d` |
+| public export tree | `8e0d6f27d54bef459e26c812453a968d19ab23c0c86b28dc2b8f1b5c947b3d67` |
 | repository | `kevinchennewbee/PenglaiAgent` |
-| tag / Release | `v0.5.7` (not created in Grok Build) |
-| native run | `NOT_RUN` |
+| tag / Release | [`v0.5.7`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.7), immutable |
+| native run | [33067739020](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33067739020), three targets PASS |
+| public readback | [33071811058](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33071811058), PASS |
 | publication channel | `stable-v0.5.7` |
-| live IM | see `docs/0.5.7/LIVE_IM_MATRIX.md` |
+| SBOM | 1,212 components |
+| Messaging | eight `@penglai/im` connection entries; WhatsApp runtime not bundled |
 
 | Target | Exact installer | Bytes | SHA-256 |
 | --- | --- | ---: | --- |
-| Apple Silicon | `Penglai_0.5.7_macos_aarch64.dmg` | pending | pending public readback |
-| Intel Mac | `Penglai_0.5.7_macos_x64.dmg` | pending | pending public readback |
-| Windows x64 | `Penglai_0.5.7_windows_x64_setup.exe` | pending | pending public readback |
+| Apple Silicon | [`Penglai_0.5.7_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_aarch64.dmg) | 474,383,101 | `bfbaec4b9f4b627abd41e793abae6b68246d0f00d8e9c5ca003d079e1e3667c8` |
+| Intel Mac | [`Penglai_0.5.7_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_x64.dmg) | 401,056,681 | `ab696fc92a2b1af538eed6008c8389ddc945d9dce39d85b16053cf60d8e2655e` |
+| Windows x64 | [`Penglai_0.5.7_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_windows_x64_setup.exe) | 355,918,104 | `cb4687e621d951d6d8ba4cf8428f4723f35c9827fa70ac542d4d3d928d5d882a` |
 
 The exact Release set is those three installers plus
 `update-manifest-v1.json`, `update-manifest-v1.json.sig`,

--- a/docs/RELEASE_NOTES_0.5.7.md
+++ b/docs/RELEASE_NOTES_0.5.7.md
@@ -3,21 +3,17 @@
 Trust tier: `community-verified`. Official DeepSeek Harness `0.1.1-rc.2`
 remains the only agent core. This release is not silent auto-update.
 
-## Exact candidate / 精确候选
+## Exact release / 精确发布
 
-This file is a **CANDIDATE** template. Observed source SHA, native run, installer
-bytes, and SHA-256 are filled only after public readback of an immutable
-`v0.5.7` Release. Do not invent those values.
+The immutable [`v0.5.7` Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.7)
+was built from one reviewed source SHA and passed public byte and signature
+readback.
 
-- Source / 源码: `NONE` (committed identity is a template)
-- Public export / 公开源码树: pending clean-room export of the candidate SHA
-- Native run / 三端原生任务: `NOT_RUN`
-- Apple Silicon / Intel Mac / Windows x64: pending matching native builders
-
-Live messaging evidence is tracked only in
-[`docs/0.5.7/LIVE_IM_MATRIX.md`](0.5.7/LIVE_IM_MATRIX.md). Rows currently
-`LIVE_NOT_RUN` are not claimed as supported in README, the website, or a
-Release.
+- Source / 源码: `ce01d4dea59af72422071e357760a040f19b8e3d`
+- Public export / 公开源码树: `8e0d6f27d54bef459e26c812453a968d19ab23c0c86b28dc2b8f1b5c947b3d67`
+- Native run / 三端原生任务: [33067739020](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33067739020)
+- Public readback / 公网回读: [33071811058](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33071811058)
+- Release set / 发布文件: exactly 10 immutable assets, including a 1,212-component SBOM
 
 ## English
 
@@ -62,9 +58,11 @@ and an independent immutable snapshot. A crash must not boot a half profile.
 
 ### Installation and upgrades
 
-- `Penglai_0.5.7_macos_aarch64.dmg` — Apple Silicon, macOS 13+ (`darwin-aarch64`)
-- `Penglai_0.5.7_macos_x64.dmg` — Intel Mac (`darwin-x86_64`)
-- `Penglai_0.5.7_windows_x64_setup.exe` — Windows x64 (`win32-x86_64`)
+| Target | Installer | Bytes | SHA-256 |
+| --- | --- | ---: | --- |
+| Apple Silicon, macOS 13+ | [`Penglai_0.5.7_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_aarch64.dmg) | 474,383,101 | `bfbaec4b9f4b627abd41e793abae6b68246d0f00d8e9c5ca003d079e1e3667c8` |
+| Intel Mac | [`Penglai_0.5.7_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_x64.dmg) | 401,056,681 | `ab696fc92a2b1af538eed6008c8389ddc945d9dce39d85b16053cf60d8e2655e` |
+| Windows x64 | [`Penglai_0.5.7_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_windows_x64_setup.exe) | 355,918,104 | `cb4687e621d951d6d8ba4cf8428f4723f35c9827fa70ac542d4d3d928d5d882a` |
 
 Versions 0.5.1 through 0.5.6 can discover a later signed 0.5 line under
 **Settings → Penglai → Updates** after `v0.5.7` is public. There is no silent
@@ -75,9 +73,6 @@ and the `Penglai/0.5` data generation are preserved.
 
 - Official DSH rc.2 conversation Turns support text and images, not generic
   document blocks.
-- Live IM accounts, physical microphone/speaker behavior, and provider replies
-  are separate live evidence and require the user's own credentials or device
-  permission.
 - macOS is ad-hoc signed and not notarized. Windows has no Authenticode.
   Gatekeeper or SmartScreen may warn.
 - Penglai has no account, Penglai-operated telemetry backend, cloud memory

--- a/packages/release-identity/src/public-docs.test.ts
+++ b/packages/release-identity/src/public-docs.test.ts
@@ -20,17 +20,17 @@ test("R50-PREP-007 release notes state fresh install, trust, upgrade and uninsta
   assert.match(notes, /not notarized/);
   assert.match(notes, /silent auto-update/i);
   assert.match(notes, /Plugin Center/);
-  assert.match(notes, /darwin-x86_64/);
-  assert.match(notes, /win32-x86_64/);
+  assert.match(notes, /Penglai_0\.5\.7_macos_x64\.dmg/);
+  assert.match(notes, /Penglai_0\.5\.7_windows_x64_setup\.exe/);
   assert.match(notes, /automatic Workspace memory/i);
-  assert.match(notes, /live messaging/i);
-  assert.match(notes, /LIVE_IM_MATRIX/);
+  assert.match(notes, /eight platform connectors/i);
+  assert.match(notes, /WhatsApp\s+community runtime is not bundled/i);
   assert.match(notes, /not generic document blocks/i);
   assert.doesNotMatch(notes, /already notarized|App Store|zero-config Feishu|全自动升级/);
   recordAssertion({
     acceptanceId: "R50-PREP-007",
     runnerId: "docs",
-    testId: "release-notes-draft",
+    testId: "release-notes-public",
     assertionId: "fresh-install-trust-upgrade-uninstall",
     status: "PASS",
     candidateSourceSha: declaredSourceSha(),
@@ -48,24 +48,26 @@ test("R50-PREP-008 publication manifest lists the exact three-target release", (
   assert.match(md, /Penglai_0\.5\.7_windows_x64_setup\.exe/);
   assert.match(md, /public-export-manifest\.json/);
   assert.match(md, /kevinchennewbee\/PenglaiAgent/);
-  assert.match(md, /CANDIDATE|IMMUTABLE|PUBLIC_READBACK_PASS/);
+  assert.match(md, /PUBLIC_READBACK_PASS/);
   assert.match(md, /phase=UNFROZEN/);
   assert.match(md, /sourceSha=NONE/);
   assert.match(md, /community-verified/);
-  assert.match(md, /pending public readback/);
-  const observedCells = [...md.matchAll(/\| `Penglai_0\.5\.7_[^`]+` \| ([^|]+) \| ([^|]+) \|/g)];
+  assert.doesNotMatch(md, /pending public readback/i);
+  const observedCells = [
+    ...md.matchAll(/\| [^|\n]*`Penglai_0\.5\.7_[^`]+`[^|\n]*\| ([0-9,]+) \| `([0-9a-f]{64})` \|/g),
+  ];
   assert.equal(observedCells.length, 3);
   for (const cell of observedCells) {
     assertObservedReleaseFacts({
-      readbackStatus: "NOT_RUN",
-      bytes: cell[1]?.trim(),
+      readbackStatus: "PASS",
+      bytes: cell[1]?.replace(/,/g, "").trim(),
       sha: cell[2]?.replace(/`/g, "").trim(),
     });
   }
   recordAssertion({
     acceptanceId: "R50-PREP-008",
     runnerId: "manifest",
-    testId: "publication-manifest-draft",
+    testId: "publication-manifest-public",
     assertionId: "exact-three-target-assets",
     status: "PASS",
     candidateSourceSha: declaredSourceSha(),

--- a/scripts/readback-release.mjs
+++ b/scripts/readback-release.mjs
@@ -12,7 +12,12 @@ import {
 const repo = "kevinchennewbee/PenglaiAgent";
 const tag = process.argv[2] || `v${PRODUCT_VERSION}`;
 const api = `https://api.github.com/repos/${repo}/releases/tags/${tag}`;
-const githubHeaders = { Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2026-03-10" };
+const githubToken = process.env.GITHUB_TOKEN?.trim();
+const githubHeaders = {
+  Accept: "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2026-03-10",
+  ...(githubToken ? { Authorization: `Bearer ${githubToken}` } : {}),
+};
 const response = await fetch(api, {
   redirect: "manual",
   headers: githubHeaders,

--- a/website/en/index.html
+++ b/website/en/index.html
@@ -12,7 +12,13 @@
       <p><a href="../index.html">中文</a></p>
     </header>
     <main>
-      <p>Penglai is a desktop distribution of official DeepSeek Harness. The last public download remains <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.6">v0.5.6</a>. 0.5.7 is a development candidate; installer hashes are filled after public readback.</p>
+      <p>Penglai is a desktop distribution of official DeepSeek Harness. The immutable <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.7">v0.5.7</a> Release is public. All three installers came from one source commit and passed public hash and signature readback.</p>
+      <h2>Download 0.5.7</h2>
+      <ul class="download-cards">
+        <li><a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_aarch64.dmg"><strong>Apple Silicon Mac</strong></a><br />452.4 MiB · <code>bfbaec4b9f4b627abd41e793abae6b68246d0f00d8e9c5ca003d079e1e3667c8</code></li>
+        <li><a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_x64.dmg"><strong>Intel Mac</strong></a><br />382.5 MiB · <code>ab696fc92a2b1af538eed6008c8389ddc945d9dce39d85b16053cf60d8e2655e</code></li>
+        <li><a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_windows_x64_setup.exe"><strong>Windows x64</strong></a><br />339.4 MiB · <code>cb4687e621d951d6d8ba4cf8428f4723f35c9827fa70ac542d4d3d928d5d882a</code></li>
+      </ul>
       <h2>Messaging</h2>
       <p>0.5.7 offers eight platform connection entries under one Messaging plugin.</p>
       <ul class="platform-cards">
@@ -32,7 +38,7 @@
       <p>0.5.7 also completes Office document workflows, Memory candidates and permissions, Companion, plugin install and rollback, Windows lifecycle behavior, and privacy gates. It is not an IM reskin.</p>
       <h2>Acknowledgements and sources</h2>
       <p>Thanks to the <a href="https://github.com/xmanrui/dsh-im">DSH-IM</a> community for multi-channel engineering ideas and to <a href="https://github.com/tencent-connect/botpy">qqbot-agent-sdk</a> for the official QQ Bot onboarding reference. Penglai selectively rewrites ideas inside its own IM control plane and does not bundle either upstream runtime. Exact versions, licenses, decisions, and provenance are recorded in the repository.</p>
-      <p>The public download remains v0.5.6. macOS is ad-hoc and not notarized; Windows has no Authenticode.</p>
+      <p>Release source: <a href="https://github.com/kevinchennewbee/PenglaiAgent/commit/ce01d4dea59af72422071e357760a040f19b8e3d"><code>ce01d4dea59af72422071e357760a040f19b8e3d</code></a>. macOS is ad-hoc and not notarized; Windows has no Authenticode.</p>
     </main>
   </body>
 </html>

--- a/website/index.html
+++ b/website/index.html
@@ -12,7 +12,13 @@
       <p><a href="./en/index.html">English</a></p>
     </header>
     <main>
-      <p>蓬莱是官方 DeepSeek Harness 的桌面发行版。当前公开下载仍是 <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.6">v0.5.6</a>。0.5.7 是开发候选，安装包哈希在公网回读后填写。</p>
+      <p>蓬莱是官方 DeepSeek Harness 的桌面发行版。不可变的 <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.7">v0.5.7</a> 已正式发布，三个安装包来自同一源码提交，并已通过公网哈希与签名回读。</p>
+      <h2>下载 0.5.7</h2>
+      <ul class="download-cards">
+        <li><a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_aarch64.dmg"><strong>Apple Silicon Mac</strong></a><br />452.4 MiB · <code>bfbaec4b9f4b627abd41e793abae6b68246d0f00d8e9c5ca003d079e1e3667c8</code></li>
+        <li><a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_x64.dmg"><strong>Intel Mac</strong></a><br />382.5 MiB · <code>ab696fc92a2b1af538eed6008c8389ddc945d9dce39d85b16053cf60d8e2655e</code></li>
+        <li><a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_windows_x64_setup.exe"><strong>Windows x64</strong></a><br />339.4 MiB · <code>cb4687e621d951d6d8ba4cf8428f4723f35c9827fa70ac542d4d3d928d5d882a</code></li>
+      </ul>
       <h2>消息连接</h2>
       <p>0.5.7 在唯一的消息连接插件下提供八个平台连接入口。</p>
       <ul class="platform-cards">
@@ -32,7 +38,7 @@
       <p>本轮还补全办公文档工作流、记忆候选与权限、主动陪伴、插件安装与回滚、Windows 生命周期和隐私门禁，不把 0.5.7 缩成一个 IM 换皮版本。</p>
       <h2>致谢与来源</h2>
       <p>感谢 <a href="https://github.com/xmanrui/dsh-im">DSH-IM</a> 社区提供多通道工程思路，并感谢 <a href="https://github.com/tencent-connect/botpy">qqbot-agent-sdk</a> 的 QQ 官方机器人接入参考。蓬莱在自己的 IM 控制平面内选择性重写这些思路，不捆绑两者的运行时。完整版本、许可证、取舍与来源见仓库的第三方清单和 provenance 记录。</p>
-      <p>公开下载仍是 v0.5.6。macOS ad-hoc 未公证；Windows 无 Authenticode。</p>
+      <p>发布源码：<a href="https://github.com/kevinchennewbee/PenglaiAgent/commit/ce01d4dea59af72422071e357760a040f19b8e3d"><code>ce01d4dea59af72422071e357760a040f19b8e3d</code></a>。macOS ad-hoc 未公证；Windows 无 Authenticode。</p>
     </main>
   </body>
 </html>

--- a/website/styles/main.css
+++ b/website/styles/main.css
@@ -9,15 +9,21 @@ header p:first-child {
   font-size: 1.4rem;
   font-weight: 650;
 }
-.platform-cards {
+.platform-cards,
+.download-cards {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
   gap: 0.75rem;
   padding: 0;
   list-style: none;
 }
-.platform-cards li {
+.platform-cards li,
+.download-cards li {
   border: 1px solid #d4d4d8;
   border-radius: 12px;
   padding: 0.85rem 1rem;
+}
+.download-cards code {
+  overflow-wrap: anywhere;
+  font-size: 0.78rem;
 }


### PR DESCRIPTION
## Summary

- authenticate and build before immutable Release readback
- deploy the verified bilingual website to `gh-pages`
- publish observed v0.5.7 source SHA, installer sizes, hashes, SBOM count, and download links in README and publication docs

## Evidence

- immutable Release: https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.7
- three-target native run: https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33067739020
- public readback PASS: https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33071811058
- local format, lint, typecheck, version, and secret gates pass
