### PR TITLE
docs: align post-release integrity rules

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Penglai 0.5.7 is a **community-verified** desktop distribution of official DeepS
 
 | Version | Status |
 | --- | --- |
-| 0.5.7 | Current candidate; public support starts after immutable `v0.5.7` publication |
-| 0.5.6 | Last immutable public release |
+| 0.5.7 | Current immutable public release |
+| 0.5.6 | Previous immutable public release; supported for upgrade to 0.5.7 |
 | 0.5.0–0.5.5 | Supported only for upgrading to the current 0.5 generation; 0.5.0 requires a manual overlay |
 | 0.4.1 and earlier | Unsupported; 0.5 does not silently import or delete old secrets or databases |
 
@@ -36,11 +36,11 @@ pipeline.
 
 ## Instant messaging risk
 
-`@penglai/im` is the only IM plugin. Nine platforms have connection entries.
+`@penglai/im` is the only IM plugin. Eight platforms have connection entries.
 Adapters cannot call a parallel Agent. Live support is evidence-gated in
 `docs/0.5.7/LIVE_IM_MATRIX.md`. Slack, Telegram, and Discord do not fake QR.
-WhatsApp is experimental, community-protocol, default-off, and requires an
-explicit risk acknowledgement.
+The WhatsApp community runtime is not bundled in 0.5.7; its compatibility card
+has no connection action.
 
 - Weixin: real QR login. The scanner is the only allowed identity unless the user expands the allowlist.
 - Feishu: the user must create and publish their own enterprise self-built app. There is no Penglai-hosted Feishu QR and no fake “scan to finish”.
@@ -51,7 +51,10 @@ QR payloads, chat bodies, and identities must never appear in Git, logs, diagnos
 
 ## Reporting a vulnerability
 
-Email the repository owner privately. Do not open a public issue that contains secrets, QR images, chat text, owner paths, or updater private keys.
+Use GitHub's private
+[`Report a vulnerability`](https://github.com/kevinchennewbee/PenglaiAgent/security/advisories/new)
+flow. Do not open a public issue that contains secrets, QR images, chat text,
+owner paths, or updater private keys.
 
 Please include:
 

--- a/docs/0.5.7/ACCEPTANCE_DELTA.md
+++ b/docs/0.5.7/ACCEPTANCE_DELTA.md
@@ -85,6 +85,11 @@ public bytes/site (P) are not interchangeable.
 
 ## Live and public
 
+Live-account and long-running installed checks are supplemental Owner
+acceptance. Missing evidence remains explicit and must never become a synthetic
+PASS, but it does not invalidate an otherwise complete automated/native/public
+release aggregate. A real failure, once observed, remains actionable evidence.
+
 - `R57-LIVE-001` — each platform has a redacted live evidence row or an explicit
   `LIVE_NOT_RUN` / `LIVE_BLOCKED` reason. Mocks do not substitute.
 - `R57-PUBLIC-001` — README, notes, and website do not claim nine-platform

--- a/docs/0.5.7/GROK_DEVELOPMENT_CLOSEOUT_PLAN.md
+++ b/docs/0.5.7/GROK_DEVELOPMENT_CLOSEOUT_PLAN.md
@@ -131,7 +131,8 @@ Grok Build 的职责是把源码开发完成并推送到 `0.5.7`。Codex 保留�
 
 ### 3.4 社区采用四级账本
 
-Grok 新建 `docs/0.5.7/provenance/COMMUNITY_RESEARCH_LEDGER.md`，每个被提及项目必须标一种模式：
+社区研究结果记录到现有的 `docs/0.5.7/provenance/DSH_IM_PORT_LEDGER.md` 及对应的
+逐项目 provenance 文件；每个被提及项目必须标一种模式：
 
 1. `survey-only`：只看过，不形成产品设计；README 不宣称基于它。
 2. `principle-reference`：借鉴通用思想，独立实现；记录 repo、commit、许可证、借鉴点和未复制代码声明。

--- a/docs/0.5.7/PR94_BODY.md
+++ b/docs/0.5.7/PR94_BODY.md
@@ -1,5 +1,11 @@
 # Penglai 0.5.7 release-candidate development
 
+> Publication correction: this file preserves the PR #94 candidate record.
+> The final immutable 0.5.7 Release exposes eight Messaging connection entries,
+> does not bundle the WhatsApp community runtime, and publishes a 1,212-component
+> SBOM. Current release truth lives in `docs/RELEASE_NOTES_0.5.7.md` and
+> `docs/PUBLICATION_MANIFEST_0.5.7.md`.
+
 This PR remains **Draft** until the last matching native job and review closeout
 complete. The Owner has authorized completion through merge, public
 `v0.5.7` Release, download switch, and website deployment; that authorization

--- a/docs/0.5.7/RELEASE_RUNBOOK.md
+++ b/docs/0.5.7/RELEASE_RUNBOOK.md
@@ -82,6 +82,12 @@ Fill `LIVE_IM_MATRIX.md` with redacted evidence or explicit `LIVE_NOT_RUN` /
 `LIVE_BLOCKED`. Do not store QR, tokens, user IDs, group names, chat bodies,
 phone numbers, or WhatsApp session keys.
 
+This is supplemental Owner acceptance and may be completed after publication.
+Missing live-account evidence is never a PASS, but it does not invalidate the
+separate automated, native, installed, signed-asset, and public-readback result.
+`verify:release` reports `verify:live`, long installed soak, and the complete
+evidence registry separately under `supplementalAcceptance`.
+
 ## 5. Merge, rebuild, draft Release
 
 Codex merges only after review. Rebuild all three native installers from the

--- a/docs/ACCEPTANCE.md
+++ b/docs/ACCEPTANCE.md
@@ -11,15 +11,15 @@
 
 允许结论：
 
-- `PASS`：所有 Hard PASS，exact set冻结。
-- `AWAITING_<EXTERNAL>`：所有可自动化Hard PASS，仅精确列出的native runner/真实账户/final key未发生。
-- `FAIL`：任一Hard FAIL、STALE、MISSING、伪造或产品偏航。
+- `PASS`：所有适用的自动化、native、installed 与 public-release Hard PASS，exact set冻结。
+- `OWNER_ACCEPTANCE_PENDING`：需要所有者账号或长时间运行的补充验收尚未发生；不得冒充 PASS，也不覆盖已完成的自动化/native/public 证据。
+- `FAIL`：任一适用发布 Hard FAIL、STALE、MISSING、伪造或产品偏航；已执行的补充验收若发现真实失败，也必须单独处置。
 
 `SKIP`、`BLOCKED`、`NOT_RUN`、`WAIVED`、`UNKNOWN`、`INCOMPLETE`都不是PASS。本版没有条件豁免。community trust tier中的`notarized=false`是候选定义的受验事实，不是被豁免的OS信任门。
 
 ## 2. Evidence 规则
 
-以下每一行都是 Hard。registry 继续保留 R50/R55 的机器可解析 ID，并由 0.5.7 delta 增加本轮产品门；基础表预期共 **330** 个唯一 Hard ID。实现必须动态解析，不能把计数写成散落的完成映射。每个ID必须指向真实runner的具体assertion，包含candidate/source/export/target/artifact/runner native/时间/exit/result digest。不能通过文件名、字符串存在或一个smoke扇出PASS。
+以下每一行都是对应证据类别内的 Hard assertion。registry 继续保留 R50/R55 的机器可解析 ID，并由 0.5.7 delta 增加本轮产品门；基础表预期共 **330** 个唯一 ID。实现必须动态解析，不能把计数写成散落的完成映射。每个ID必须指向真实runner的具体assertion，包含candidate/source/export/target/artifact/runner native/时间/exit/result digest。不能通过文件名、字符串存在或一个smoke扇出PASS。需要所有者账号或长时间运行的 live/soak assertion 属补充验收：缺失不能冒充 PASS，也不作为自动化发布聚合的永久阻塞项。
 
 平台标记：
 
@@ -40,7 +40,7 @@
 | `R50-TRUTH-004` | UNFROZEN identity不得携带artifact/signature/live/READY | unit/all |
 | `R50-TRUTH-005` | release branch/PR 可审计且不 force；合并前不创建公开 tag，合并后 main 必须保持 exact candidate source | git/aggregate |
 | `R50-TRUTH-006` | candidate freeze 时 HEAD 已推送、dirty=false；公开 freeze 时 `origin/main` 必须等于同一 source SHA | git/aggregate |
-| `R50-TRUTH-007` | 任一子门FAIL/INCOMPLETE/STALE都使verify:release non-zero | fault/all |
+| `R50-TRUTH-007` | 任一适用发布硬子门FAIL/INCOMPLETE/STALE都使verify:release non-zero；补充验收另列 | fault/all |
 | `R50-TRUTH-008` | repo=`kevinchennewbee/PenglaiAgent`、tag/release=`v0.5.7`，且发布前 updater Release 不得冒充已公开 | manifest/aggregate |
 
 ### B. DSH唯一核心与 capability parity（8）

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -204,7 +204,9 @@ without touching source files.
 
 `@penglai/im` owns one adapter registry, durable inbox/outbox, bindings,
 deterministic commands, correlation, causal routing, recovery, and diagnostics.
-`LIVE_CHANNEL_IDS` is evidence-gated. Weixin and Feishu remain live from 0.5.6.
+`LIVE_CHANNEL_IDS` is evidence-gated. Weixin and Feishu retain their distributed
+adapter and migration paths from 0.5.6; that source/runtime continuity is not a
+substitute for evidence bound to a later installed release.
 The other six distributed platforms receive adapters in 0.5.7 and join
 `LIVE_CHANNEL_IDS` only after acceptance. The user-facing surface exposes eight
 connection actions plus a disabled WhatsApp compatibility card.

--- a/docs/IM_PLUGIN.md
+++ b/docs/IM_PLUGIN.md
@@ -1,11 +1,12 @@
 # `@penglai/im` 完整产品与协议合同
 
-> 0.5.7 用户只看到一个「消息连接」插件。九个平台都有真实连接入口，不再把后七个
+> 0.5.7 用户只看到一个「消息连接」插件。八个平台都有真实连接入口，不再把新增渠道
 > 显示为路线图。manifest 的 `live` 是历史兼容字段，表示 0.5.7 包含真实 adapter
 > 实现，不表示当前用户已启用或已通过 live-account 验收。没有
 > 对应 live evidence 时，不得把该平台写入 README/官网/Release 的“全部支持”
 > 声明，也不得把图片/文件/音频/Markdown/线程/群聊标为 `true`。Slack、Telegram、
-> Discord 禁止伪装扫码。WhatsApp 默认关闭，并明确社区协议与账号风险。下文微信/
+> Discord 禁止伪装扫码。WhatsApp 社区 runtime 不随 0.5.7 分发，兼容性说明卡没有
+> 连接动作。下文微信/
 > 飞书合同继续约束已有 live 路径；新渠道只有通过 adapter、health、send-reject
 > 和 live evidence 后才能进入 `LIVE_CHANNEL_IDS`。
 
@@ -268,7 +269,7 @@ SQLite表：accounts、adapter_configs、bindings、vendor_reply_targets、inbox
 - inbound/outbound body 仅为执行/重试短期保存，默认完成后 24 小时内清理；用户可设更短，不能无限保留。
 - secret、QR、verification code 不入 DB。
 - 微信最新 `context_token` 视为厂商会话凭据，只通过 official credentials seam 保存；重启后可恢复 original-route reply/native voice probe，logout/revoke 必须与 bot token 一并删除，renderer/diagnostics/evidence 不可读取明文。
-- raw audio/TTS temp不作为长期DB blob；只存短期AudioHandle/digest/state并按`docs/VOICE_PLUGINS.md`清理。
+- raw audio/TTS temp不作为长期DB blob；只存短期AudioHandle/digest/state并按`docs/compatibility/VOICE_R3.md`清理。
 - message/peer/vendor target只保存路由所需最小值；真实target与display peerRef分列并限制访问，diagnostics/evidence只使用digest。
 - WAL/backup/rollback 与主 DB 同样受 retention/secret scan。
 

--- a/docs/PLUGIN_CENTER.md
+++ b/docs/PLUGIN_CENTER.md
@@ -19,7 +19,7 @@ Plugin Center 是 official DSH Web 的 host/client plugin，UI 注册在 `settin
 - `@penglai/plugin-reference`（默认 disabled，仅用于 platform proof）
 - `@penglai/plugin-smoke`（测试 profile only，不进入用户 catalog）
 
-`@penglai/credentials-keychain` 不进入默认 profile、打包清单或 catalog。未审核社区插件不显示为可用。面向用户的产品卡固定为六张：消息连接、蓬莱办公、蓬莱语音识别、蓬莱语音生成、蓬莱记忆、蓬莱主动陪伴。ASR/MOSS-TTS 只有真实 host/client、model manager、当前发布 target engine 与验收存在时才显示；Office/Memory/Companion 也必须满足 `docs/PENGLAI_NATIVE_PLUGINS.md` 完整合同，不得先做空卡。
+`@penglai/credentials-keychain` 不进入默认 profile、打包清单或 catalog。未审核社区插件不显示为可用。面向用户的产品卡固定为六张：消息连接、蓬莱办公、蓬莱语音识别、蓬莱语音生成、蓬莱记忆、蓬莱主动陪伴。ASR/MOSS-TTS 只有真实 host/client、model manager、当前发布 target engine 与验收存在时才显示；Office/Memory/Companion 也必须满足 `docs/PRODUCT.md` 与 `docs/ARCHITECTURE.md` 的完整合同，不得先做空卡。
 
 ## 2.1 生态来源与未来扩展
 

--- a/docs/RELEASE_NOTES_0.5.7.md
+++ b/docs/RELEASE_NOTES_0.5.7.md
@@ -89,3 +89,8 @@ and the `Penglai/0.5` data generation are preserved.
 
 升级入口仍是 **设置 → 蓬莱 → 更新**。不会静默自动升级。macOS 为 ad-hoc 且未公证；
 Windows 没有 Authenticode。
+
+### 已知限制
+
+- 官方 DSH rc.2 会话 Turn 支持文字和图片，不支持通用文档块。
+- 蓬莱不提供账号体系、蓬莱运营的遥测后端、云端记忆同步或云端 ASR/TTS。

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -188,10 +188,10 @@ TCB包括Electron main/preload、embedded target Node、pinned DSH、profile/Cen
 - Artifact ID 是不透明 `artifact:<uuid>`，不是 filesystem path 或 content hash。相同字节跨 Workspace 仍为不同 binding；legacy digest 只有唯一时才可解析。
 - official DSH rc.2 只有 text/image Turn parts。0.5.7 不用 DOM hack、假 image 或第二会话引擎制造普通文件附件；Office/IM 文件走 scope-checked Artifact Service。
 - macOS 包只声明双语麦克风用途，并剥离 Electron 默认 camera、Bluetooth 与无关 capture permission。Main 只允许由当前用户手势触发的 audio 请求。
-- 0.5.7 的唯一「消息连接」插件提供九个平台的真实连接 adapter；公开“已支持”只以
-  `docs/0.5.7/LIVE_IM_MATRIX.md` 的脱敏真机证据为准。微信、飞书、钉钉、企业微信、
-  QQ 只显示供应商真实 QR/注册 challenge；WhatsApp 只显示真实设备绑定 challenge，且
-  默认关闭并要求风险确认。Slack、Telegram、Discord 没有对应的官方扫码流程，必须
-  如实使用官方 Manifest/Token，不得生成假 QR 或把 UI 状态冒充已连接。
+- 0.5.7 的唯一「消息连接」插件提供八个平台的真实连接 adapter；公开能力边界以
+  当前产品合同和对应证据为准。微信、飞书、钉钉、企业微信、QQ 只显示供应商真实
+  QR/注册 challenge；Slack、Telegram、Discord 没有对应的官方扫码流程，必须如实
+  使用官方 Manifest/Token，不得生成假 QR 或把 UI 状态冒充已连接。WhatsApp 社区
+  runtime 不随 0.5.7 分发，兼容性说明卡没有连接动作。
 
 任一Critical/High或可复用secret泄漏都使候选FAIL。若真实凭据可能泄漏，立即停止、通知用户轮换、作废相关artifact/evidence；不得为了保住READY删日志掩盖。

--- a/docs/adr/0029-dsh-010-rc7-pin.md
+++ b/docs/adr/0029-dsh-010-rc7-pin.md
@@ -11,7 +11,8 @@
 
 ## Evidence
 
-- U0 档案：`docs/compatibility/DSH_010_RC7_U0.md`
+- U0 结论记录在本 ADR；仓库未提交独立的 rc.7 U0 档案。当前运行时证据以
+  `docs/compatibility/DSH_011_RC2.md` 为准。
 - GitHub tag `dsh-v0.1.0-rc.7` → commit `99f6f02fecdb7dff40c3fbc9470f5907c29f74ca`
 - npm `@deepseek-ai/dsh@0.1.0-rc.7` integrity `sha512-ZceDCJ8FAywih+USW/OMk9jEhunlvJBGEz4kqrhau23hPzbciOazZrywH0nBRsaalSeAJ1JGBmjtw4OSjToStw==`
 - overlay 三文件 SHA 与 Issue #3 §2.2 一致；keyed `settings.plugin.item` 合同变化归 U2

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -285,16 +285,6 @@
 ### D-047 — 前置 pre-DSH 向导取代 DSH Web 内引导遮罩
 
 - 状态：ACCEPTED
-- 决定：未完成引导时主窗口加载同源 `/wizard`；ledger COMPLETE 后切入 official DSH Web。
-- 后果：不是 DSH Web 内第二套引导，也不是长期自制主 UI。
-
-### D-048 — IM 渠道默认官方一键扫码
-
-- 状态：ACCEPTED
-- 决定：微信、飞书和以后的渠道默认官方一键扫码。微信把 iLink `qrcode_img_content` 画成 PNG。飞书走 `accounts.feishu.cn/oauth/v1/app/registration` 创建 PersonalAgent，再把凭据写入 official credentials 并长连接。
-- 后果：禁止假二维码和用户 OAuth Device Flow。手动 App ID/Secret 只作后备。
-
-- 状态：ACCEPTED
 - 决定：首次引导不再在 DSH Web 内渲染全屏遮罩或注册`settings.onboarding`。未完成引导时主窗口加载经认证代理同源提供的 `/wizard` plain HTML/JS/CSS 前置页；ledger `current === "COMPLETE"` 后切入 official DSH Web。见 ADR 0030。
 - 后果：onboarding 不再依赖 DSH Web 先启动；`wizardFinished` 在 official 面加载成功后才下线 `/wizard`，失败则回滚；ledger 是唯一事实源，按非 symlink app-private 文件校验。DSH 的 theme/locale/Models/Workspace/Session/tools/approvals/settings 不变。
 
@@ -372,9 +362,15 @@
 
 ### D-060 — 0.5.7 九渠道连接入口、单一 IM Core、官网进 main
 
-- 状态：ACCEPTED（Owner 2026-08-25 要求 0.5.7 作为 0.5.6 之后的开发/验收/发布合同）
+- 状态：SUPERSEDED by D-061；本条保留 2026-08-25 候选阶段的历史决策
 - 决定：用户只看到一个「消息连接」插件 `@penglai/im`。九个平台都有真实连接入口，不再把后七个显示为路线图。manifest 的 `live` 是历史兼容字段，只表示 0.5.7 包含真实 adapter 实现，不表示用户已启用或 live-account 已验收。没有 live evidence 不得在 README、官网或 Release 中声称九平台全部支持。DSH 继续固定 `0.1.1-rc.2`。DSH-IM 只参考 unsigned `v3.0.5` / `64587b3b6162fa34f1c3ddb335a254d4154c9175`（更早版本为历史 pin），禁止安装整包、复制 `lib/`/`bin/`/`cordis.patch.yml`。v3.0.3 的 WhatsApp 群聊改动与蓬莱 private-only 规则冲突且已由上游回滚；0.5.7 只新增 exact `ilinkai.wechat.com` 和卡片状态布局原则。Slack/Telegram/Discord 禁止伪装扫码。WhatsApp 默认关闭，`supportLevel: experimental`，`risk: community-protocol`。官网源文件进入 `main` 的 `website/`，`gh-pages` 只保存审核后的部署产物。提交身份文件保持 `phase=UNFROZEN` 且 `sourceSha=NONE`，这是模板状态；候选 evidence 由构建绑定真实 Git SHA，源文件不得伪造无法自引用的 commit。
 - 后果：渠道适配器只做认证、收发、状态和媒体转换。所有高影响操作继续走 Main Owner Broker。Grok Build 终点是远端 `0.5.7` 分支和指向 `main` 的 Draft PR；不合并、不打 `v0.5.7`、不发 Release、不部署生产官网。
+
+### D-061 — 0.5.7 最终八渠道发行边界与发布后验收分层
+
+- 状态：ACCEPTED（Owner 2026-08-27 最终发行决策）
+- 决定：0.5.7 只分发微信、飞书、钉钉、企业微信、QQ、Slack、Telegram、Discord 八个平台连接入口；`@penglai/im` 仍是唯一 IM runtime。WhatsApp 社区 runtime、Baileys 及 GPL-3.0 libsignal 不进入生产依赖、插件包或安装包，兼容性说明卡没有连接动作。已公开 `v0.5.7` tag、十个附件、源码 SHA 与签名/摘要保持不可变。自动化发布门禁与需要所有者账号或长时间运行的补充验收分开记录；补充验收缺失不得伪造 PASS，也不反向改写已经完成的自动化和公开字节证据。
+- 后果：当前 README、官网、Release 与现行安全/架构文档统一使用八渠道发行口径。真实账号验收可在发布后由 Owner 独立补做。官网继续保留现有水墨视觉、中文根页与 `/en/` 英文页，不以发布后文档修正重做视觉站点。
 
 ## Superseded
 

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -13,7 +13,8 @@
 - 核对 commit：`141eb6fef83422698aef7a981029e843e8161534`（tag `dsh-v0.1.0-rc.8`，2026-08-19）。
 - npm：`@deepseek-ai/dsh@0.1.0-rc.8`；现场 dist-tags 为 `latest=0.1.0-rc.7`、`next=0.1.0-rc.8`，不能把 rc.8 叙述为 stable。
 - npm integrity：`sha512-VQU5NlomrKLRgcXuOf+sxWFvqxPA8q9vMhrKPlPPXiOJEhGlGlAdiyxZvZxkCVI+v0zbhe21cY3/luLyxpSzzA==`。
-- 历史 pin：rc.6 见 ADR 0006，rc.7 见 ADR 0029；当前产品 pin 以 ADR 0031 与 `docs/compatibility/DSH_010_RC8.md` 为准。
+- 历史 pin：rc.6 见 ADR 0006，rc.7 见 ADR 0029；当前产品 pin 以 ADR 0031、
+  `docs/compatibility/DSH_011_RC2.md` 与 `release-contract.json` 为准。
 
 本地 installed packages 已核对：
 
@@ -29,7 +30,7 @@
 - Typert：host `TypertRemoteService`/`@Remote`，client mount generated `TYPERT_REMOTE`。
 - `dsh-credentials-local`：app-private `.credentials.yaml`、permission/atomic file 语义。
 
-结论：Penglai 通过 official locale/Models/settings/Remote 与 rc.8 brand slots 完成主要 composition；无 slot 的 document title、首次披露与 hero copy/background 仅使用 exact-version、exact-hash UI-only overlay，不能 fork runtime。当前审计见 `docs/compatibility/DSH_010_RC8.md`；rc.7 文档只保留历史过程。
+结论：Penglai 通过 official locale/Models/settings/Remote 与当时 rc.8 brand slots 完成主要 composition；无 slot 的 document title、首次披露与 hero copy/background 仅使用 exact-version、exact-hash UI-only overlay，不能 fork runtime。当前 rc.2 审计见 `docs/compatibility/DSH_011_RC2.md`；本节 rc.7/rc.8 内容只保留历史过程。
 
 ## 2. 腾讯微信 iLink
 
@@ -118,7 +119,7 @@ Forge是Electron官方教程推荐的统一打包方向，但具体DMG/Windows m
 ## 6.1 0.4.1 原生优势与 current DSH capability 归属
 
 - `PenglaiAgent` tag `v0.4.1` / commit `4f24d0bb84c385ed474e70cfdf89db32b4c49f33` 的 README 与源码已现场核对。
-- 真实差异化源码包括：`packages/host/src/voice/*`、`packages/host/src/context/*`、`packages/host/src/memory.ts`、`packages/host/src/distill/*`、`packages/host/src/budget.ts`、`packages/host/src/services.ts`及对应context/budget/memory/distill/quiet-hours tests。迁移矩阵见`docs/compatibility/PENGLAI_041_PARITY_R3.md`。
+- 真实差异化源码包括：`packages/host/src/voice/*`、`packages/host/src/context/*`、`packages/host/src/memory.ts`、`packages/host/src/distill/*`、`packages/host/src/budget.ts`、`packages/host/src/services.ts`及对应context/budget/memory/distill/quiet-hours tests。当前归属与迁移边界见`docs/PRODUCT.md`和`docs/ARCHITECTURE.md`。
 - 当前 `@deepseek-ai/dsh@0.1.0-rc.8` 依赖闭包已现场确认含 Goal、Plan、Todo、Skill/Skill filesystem/client UI、MCP client、Web、Attachment、Schedule、TokenMeter、Workspace、Session 与 presentation。
 - 因此Goal/Todo/Skills/MCP/Web/Attachments/Schedule/TokenMeter归official DSH复用；Voice/Context/Memory/Budget/Companion迁为Penglai plugins。package name存在不是最终seam证据，Grok仍须用actual profile/inventory/Service/Slot probe确认。
 - 0.4.1 source只作算法、数据合同、测试与许可证参考；不得打包旧Tauri/Host/EpisodeRunner、读取旧用户数据或建立第二核心。

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "verify:evidence": "node --import tsx scripts/verify-evidence.mjs",
     "verify:release": "node --import tsx scripts/verify-release.mjs",
     "verify:installed": "node --import tsx scripts/verify-installed.mjs",
-    "verify:live": "node scripts/verify-live.mjs",
+    "verify:live": "node --import tsx scripts/verify-live.mjs",
     "verify:live-plugin-catalog": "node --import tsx scripts/verify-live-plugin-catalog.mjs",
     "verify:public-export": "node --import tsx scripts/verify-public-export.mjs",
     "prepare:public-export": "node --import tsx scripts/prepare-public-export.mjs",

--- a/packages/release-identity/src/candidate.ts
+++ b/packages/release-identity/src/candidate.ts
@@ -68,8 +68,6 @@ export const ARM64_DEFERRED_GATES = [
   "verify:profile",
   "verify:artifact",
   "verify:installed",
-  "verify:live",
-  "verify:soak",
   "verify:public-export",
 ] as const;
 
@@ -100,9 +98,6 @@ export function evaluateApplicableDomain(opts: {
       failed.push(`${name}:stale-with-current-artifact`);
     }
   }
-  const evidence = opts.records.find((record) => record.name === "verify:evidence");
-  if (evidence?.verdict === "FAIL" || evidence?.exit === 1) failed.push("verify:evidence");
-  if (evidence?.verdict === "STALE" || evidence?.exit === 3) failed.push("verify:evidence:stale");
   if ((opts.summaryTotals?.fail ?? 0) > 0) failed.push("evidence-fail");
   if ((opts.summaryTotals?.stale ?? 0) > 0) failed.push("evidence-stale");
   if (opts.summaryVerdict === "FAIL") failed.push("summary-fail");
@@ -180,7 +175,7 @@ export function evaluateReleaseAggregation(opts: {
   if (failReasons.length || failed) verdict = "FAIL";
   else if (stale) verdict = "STALE";
   else if (blocked) verdict = "BLOCKED";
-  else if (incomplete || missingGates.length || opts.summaryVerdict !== "PASS") verdict = "INCOMPLETE";
+  else if (incomplete || missingGates.length || (opts.summaryVerdict !== undefined && opts.summaryVerdict !== "PASS")) verdict = "INCOMPLETE";
 
   return {
     verdict,

--- a/packages/release-identity/src/evidence-v2.ts
+++ b/packages/release-identity/src/evidence-v2.ts
@@ -417,6 +417,7 @@ export const SUBGATE_JSON_FILES: Record<string, string> = {
   "verify:evidence": "evidence/generated/evidence-summary.json",
   "verify:closure": "evidence/generated/verify-closure.json",
   "verify:installed": "evidence/generated/verify-installed.json",
+  "verify:live": "evidence/generated/verify-live.json",
   "verify:soak": "evidence/generated/verify-soak.json",
   "verify:public-export": "evidence/generated/verify-public-export.json",
   "verify:profile": "evidence/generated/verify-profile.json",

--- a/packages/release-identity/src/index.ts
+++ b/packages/release-identity/src/index.ts
@@ -23,3 +23,4 @@ export * from "./public-export.js";
 export * from "./evidence-v2.js";
 export * from "./evidence-v3.js";
 export * from "./freeze.js";
+export * from "./live-evidence.js";

--- a/packages/release-identity/src/live-evidence.test.ts
+++ b/packages/release-identity/src/live-evidence.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { evaluateLiveEvidence } from "./live-evidence.js";
+
+function validEvidence() {
+  return {
+    schemaVersion: 1,
+    scope: "declared-platform-cases",
+    productVersion: "0.5.7",
+    sourceSha: "a".repeat(40),
+    installerSha256: "b".repeat(64),
+    redacted: true,
+    cases: [
+      {
+        platform: "weixin",
+        runnerClass: "owner-live-account",
+        connected: true,
+        inboundPrivateText: true,
+        boundOfficialWorkspaceSession: true,
+        outboundReply: true,
+        restartRestore: true,
+        safeLogout: true,
+      },
+    ],
+  };
+}
+
+test("owner live evidence passes only with complete redacted declared cases", () => {
+  assert.deepEqual(evaluateLiveEvidence(validEvidence(), "0.5.7"), {
+    verdict: "PASS",
+    reason: "accepted 1 redacted owner live case(s)",
+    acceptedPlatforms: ["weixin"],
+  });
+});
+
+test("missing owner checks remain incomplete rather than becoming a fake PASS", () => {
+  const evidence = validEvidence();
+  evidence.cases[0]!.safeLogout = false;
+  assert.equal(evaluateLiveEvidence(evidence, "0.5.7").verdict, "INCOMPLETE");
+});
+
+test("stale, duplicate, unknown, or sensitive live evidence is rejected", () => {
+  assert.equal(evaluateLiveEvidence({ ...validEvidence(), productVersion: "0.5.6" }, "0.5.7").verdict, "STALE");
+  assert.equal(evaluateLiveEvidence({ ...validEvidence(), accessToken: "must-not-appear" }, "0.5.7").verdict, "FAIL");
+  const duplicate = validEvidence();
+  duplicate.cases.push({ ...duplicate.cases[0]! });
+  assert.equal(evaluateLiveEvidence(duplicate, "0.5.7").verdict, "FAIL");
+  const unknown = validEvidence();
+  unknown.cases[0]!.platform = "whatsapp";
+  assert.equal(evaluateLiveEvidence(unknown, "0.5.7").verdict, "FAIL");
+});

--- a/packages/release-identity/src/live-evidence.ts
+++ b/packages/release-identity/src/live-evidence.ts
@@ -1,0 +1,97 @@
+import type { VerifierVerdict } from "./exit.js";
+
+const CHANNELS = new Set([
+  "weixin",
+  "feishu",
+  "dingtalk",
+  "wecom",
+  "qq",
+  "slack",
+  "telegram",
+  "discord",
+]);
+
+const REQUIRED_CASE_CHECKS = [
+  "connected",
+  "inboundPrivateText",
+  "boundOfficialWorkspaceSession",
+  "outboundReply",
+  "restartRestore",
+  "safeLogout",
+] as const;
+
+const TOP_LEVEL_KEYS = new Set([
+  "schemaVersion",
+  "scope",
+  "productVersion",
+  "sourceSha",
+  "installerSha256",
+  "redacted",
+  "cases",
+]);
+
+const CASE_KEYS = new Set(["platform", "runnerClass", ...REQUIRED_CASE_CHECKS]);
+
+export interface LiveEvidenceEvaluation {
+  verdict: VerifierVerdict;
+  reason: string;
+  acceptedPlatforms: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: Set<string>): boolean {
+  return Object.keys(value).every((key) => allowed.has(key));
+}
+
+export function evaluateLiveEvidence(raw: unknown, expectedVersion: string): LiveEvidenceEvaluation {
+  if (!isRecord(raw)) return { verdict: "FAIL", reason: "live evidence must be an object", acceptedPlatforms: [] };
+  if (raw.productVersion !== expectedVersion) {
+    return { verdict: "STALE", reason: `live evidence is not ${expectedVersion}`, acceptedPlatforms: [] };
+  }
+  if (raw.schemaVersion !== 1 || raw.scope !== "declared-platform-cases") {
+    return { verdict: "FAIL", reason: "unsupported live evidence schema or scope", acceptedPlatforms: [] };
+  }
+  if (raw.redacted !== true || !hasOnlyKeys(raw, TOP_LEVEL_KEYS)) {
+    return { verdict: "FAIL", reason: "live evidence is not safely redacted", acceptedPlatforms: [] };
+  }
+  if (typeof raw.sourceSha !== "string" || !/^[0-9a-f]{40}$/.test(raw.sourceSha)) {
+    return { verdict: "FAIL", reason: "live evidence source SHA is invalid", acceptedPlatforms: [] };
+  }
+  if (typeof raw.installerSha256 !== "string" || !/^[0-9a-f]{64}$/.test(raw.installerSha256)) {
+    return { verdict: "FAIL", reason: "live evidence installer SHA-256 is invalid", acceptedPlatforms: [] };
+  }
+  if (!Array.isArray(raw.cases) || raw.cases.length === 0) {
+    return { verdict: "INCOMPLETE", reason: "no declared platform live cases", acceptedPlatforms: [] };
+  }
+
+  const acceptedPlatforms: string[] = [];
+  for (const entry of raw.cases) {
+    if (!isRecord(entry) || !hasOnlyKeys(entry, CASE_KEYS) || typeof entry.platform !== "string" || !CHANNELS.has(entry.platform)) {
+      return { verdict: "FAIL", reason: "live evidence contains an unknown platform", acceptedPlatforms: [] };
+    }
+    if (acceptedPlatforms.includes(entry.platform)) {
+      return { verdict: "FAIL", reason: `duplicate live case for ${entry.platform}`, acceptedPlatforms: [] };
+    }
+    if (entry.runnerClass !== "owner-live-account") {
+      return { verdict: "FAIL", reason: `live case for ${entry.platform} is not owner-live-account evidence`, acceptedPlatforms: [] };
+    }
+    const missing = REQUIRED_CASE_CHECKS.filter((key) => entry[key] !== true);
+    if (missing.length) {
+      return {
+        verdict: "INCOMPLETE",
+        reason: `live case for ${entry.platform} is missing ${missing.join(",")}`,
+        acceptedPlatforms: [],
+      };
+    }
+    acceptedPlatforms.push(entry.platform);
+  }
+
+  return {
+    verdict: "PASS",
+    reason: `accepted ${acceptedPlatforms.length} redacted owner live case(s)`,
+    acceptedPlatforms,
+  };
+}

--- a/packages/release-identity/src/pins.ts
+++ b/packages/release-identity/src/pins.ts
@@ -209,11 +209,18 @@ export const HARD_SUBGATES = [
   { name: "verify:fuses", kind: "fuses", mode: "run" },
   { name: "verify:signing", kind: "signing", mode: "run" },
   { name: "verify:installed", kind: "installed", mode: "evidence" },
-  { name: "verify:live", kind: "live", mode: "evidence" },
   { name: "verify:public-export", kind: "public-export", mode: "evidence" },
-  { name: "verify:soak", kind: "soak", mode: "evidence" },
-  { name: "verify:evidence", kind: "evidence", mode: "run" },
   { name: "audit:secrets", kind: "secret", mode: "run" },
+] as const;
+
+// These checks need Owner accounts, long-running installed use, or a complete
+// cross-run evidence collection. They are reported next to the release result,
+// but absence must not masquerade as PASS or make the automated/native release
+// aggregate impossible to satisfy.
+export const SUPPLEMENTAL_ACCEPTANCE_SUBGATES = [
+  { name: "verify:live", kind: "live", mode: "evidence" },
+  { name: "verify:soak", kind: "installed-soak", mode: "evidence" },
+  { name: "verify:evidence", kind: "evidence", mode: "evidence" },
 ] as const;
 
 export const REQUIRED_SUBGATE_KINDS = [
@@ -230,9 +237,7 @@ export const REQUIRED_SUBGATE_KINDS = [
   "artifact",
   "fuses",
   "signing",
-  "evidence",
   "installed",
-  "live",
   "public-export",
   "secret",
 ] as const;

--- a/packages/release-identity/src/public-docs.test.ts
+++ b/packages/release-identity/src/public-docs.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { declaredSourceSha, recordAssertion } from "./assertion.js";
@@ -120,4 +120,47 @@ test("website keeps the full bilingual visual site and exact 0.5.7 downloads", (
   assert.match(css, /\.hero-art/);
   assert.match(css, /\.gallery/);
   assert.ok(css.length > 5000, "website stylesheet is unexpectedly reduced");
+});
+
+test("current security and IM documents match the immutable eight-entry release", () => {
+  const publicSecurity = readFileSync(join(root, "SECURITY.md"), "utf8");
+  const securityContract = readFileSync(join(root, "docs/SECURITY.md"), "utf8");
+  const imContract = readFileSync(join(root, "docs/IM_PLUGIN.md"), "utf8");
+  assert.match(publicSecurity, /0\.5\.7 \| Current immutable public release/);
+  assert.match(publicSecurity, /Eight platforms have connection entries/);
+  assert.match(publicSecurity, /security\/advisories\/new/);
+  assert.match(securityContract, /提供八个平台的真实连接 adapter/);
+  assert.match(imContract, /八个平台都有真实连接入口/);
+  assert.match(publicSecurity, /WhatsApp community runtime is not bundled/);
+  assert.match(securityContract, /WhatsApp 社区\s+runtime 不随 0\.5\.7 分发/);
+  assert.match(imContract, /WhatsApp 社区 runtime 不随 0\.5\.7 分发/);
+  for (const current of [publicSecurity, securityContract, imContract]) {
+    assert.doesNotMatch(current, /Nine platforms have connection entries|九个平台都有真实连接入口/);
+  }
+});
+
+test("decision identifiers are unique and the final distribution decision supersedes D-060", () => {
+  const decisions = readFileSync(join(root, "docs/decisions.md"), "utf8");
+  const ids = [...decisions.matchAll(/^### (D-\d+)\b/gm)].map((match) => match[1]);
+  assert.equal(new Set(ids).size, ids.length, "docs/decisions.md contains a duplicate decision ID");
+  assert.match(decisions, /D-060[\s\S]*?SUPERSEDED by D-061/);
+  assert.match(decisions, /D-061[\s\S]*?八个平台连接入口/);
+});
+
+test("backticked repository documentation references resolve to tracked files", () => {
+  function markdownFiles(dir: string): string[] {
+    return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) return markdownFiles(path);
+      return entry.isFile() && entry.name.endsWith(".md") ? [path] : [];
+    });
+  }
+
+  const files = [...markdownFiles(join(root, "docs")), join(root, "README.md"), join(root, "SECURITY.md")];
+  for (const file of files) {
+    const markdown = readFileSync(file, "utf8");
+    for (const match of markdown.matchAll(/`(docs\/[A-Za-z0-9_./-]+\.md)`/g)) {
+      assert.equal(existsSync(join(root, match[1]!)), true, `${match[1]} referenced by ${file} does not exist`);
+    }
+  }
 });

--- a/packages/release-identity/src/rc0.test.ts
+++ b/packages/release-identity/src/rc0.test.ts
@@ -28,6 +28,7 @@ import {
   HARD_SUBGATES,
   PRODUCT_VERSION,
   REQUIRED_SUBGATE_KINDS,
+  SUPPLEMENTAL_ACCEPTANCE_SUBGATES,
 } from "./pins.js";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "../../..");
@@ -104,7 +105,20 @@ test("R50-TRUTH-007 / R50-E2E-008 aggregator lists all hard kinds and propagates
   assert.ok(listedSubgateNames().includes("verify:fuses"));
   assert.ok(listedSubgateNames().includes("verify:installed"));
   assert.ok(listedSubgateNames().includes("audit:secrets"));
+  assert.equal(listedSubgateNames().includes("verify:live"), false);
+  assert.equal(listedSubgateNames().includes("verify:soak"), false);
+  assert.equal(listedSubgateNames().includes("verify:evidence"), false);
+  assert.deepEqual(
+    SUPPLEMENTAL_ACCEPTANCE_SUBGATES.map((gate) => gate.name),
+    ["verify:live", "verify:soak", "verify:evidence"],
+  );
   assert.equal(HARD_SUBGATES.length >= 18, true);
+
+  const completeHardRelease = evaluateReleaseAggregation({
+    records: HARD_SUBGATES.map((gate) => ({ name: gate.name, exit: 0, verdict: "PASS" })),
+  });
+  assert.equal(completeHardRelease.verdict, "PASS");
+  assert.equal(completeHardRelease.exitCode, 0);
 
   const incomplete = evaluateReleaseAggregation({
     records: HARD_SUBGATES.map((g) => ({
@@ -146,9 +160,8 @@ test("R50-TRUTH-007 / R50-E2E-008 aggregator lists all hard kinds and propagates
     summaryVerdict: "INCOMPLETE",
     summaryTotals: { fail: 0, stale: 0 },
   });
-  // The arm64 domain can PASS while deferred gates are incomplete, but the
-  // release verdict must still be INCOMPLETE (a domain PASS never masks
-  // incomplete deferred gates into a release PASS).
+  // The arm64 domain can PASS while native/public-export gates are incomplete,
+  // but a domain PASS never masks an incomplete hard release gate.
   assert.equal(applicable.verdict, "PASS");
   assert.ok(applicable.deferred.includes("verify:installed"));
   const masked = releaseVerdictFrom(applicable, {

--- a/scripts/verify-live.mjs
+++ b/scripts/verify-live.mjs
@@ -1,14 +1,21 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { ROOT } from "./lib/repo.mjs";
 import { finish } from "./lib/exit-contract.mjs";
 
 const path = join(ROOT, "evidence/generated/live.json");
 if (!existsSync(path)) {
-  finish("INCOMPLETE", { command: "verify:live", reason: "no 0.5 live evidence" });
+  finish("INCOMPLETE", { command: "verify:live", reason: "no owner live-account evidence" });
 }
-const rec = JSON.parse(readFileSync(path, "utf8"));
-if (rec.productVersion !== "0.5.7") {
-  finish("STALE", { command: "verify:live", reason: "live evidence is not 0.5.7" });
+let rec;
+try {
+  rec = JSON.parse(readFileSync(path, "utf8"));
+} catch (error) {
+  finish("FAIL", { command: "verify:live", reason: `invalid live evidence JSON: ${String(error)}` });
 }
-finish("INCOMPLETE", { command: "verify:live", reason: "final live is reserved for RC15" });
+const { evaluateLiveEvidence } = await import(
+  pathToFileURL(join(ROOT, "packages/release-identity/src/live-evidence.ts")).href
+);
+const result = evaluateLiveEvidence(rec, "0.5.7");
+finish(result.verdict, { command: "verify:live", reason: result.reason, acceptedPlatforms: result.acceptedPlatforms });

--- a/scripts/verify-release.mjs
+++ b/scripts/verify-release.mjs
@@ -11,9 +11,15 @@ const dryRun = argv.includes("--dry-run");
 const injectIdx = argv.indexOf("--inject-fail");
 const injectFail = injectIdx >= 0 ? argv[injectIdx + 1] : null;
 
-const { HARD_SUBGATES, evaluateApplicableDomain, evaluateReleaseAggregation, releaseVerdictFrom, resolveSubgateVerdict, SUBGATE_JSON_FILES } = await import(
-  pathToFileURL(join(ROOT, "packages/release-identity/src/index.ts")).href
-);
+const {
+  HARD_SUBGATES,
+  SUPPLEMENTAL_ACCEPTANCE_SUBGATES,
+  evaluateApplicableDomain,
+  evaluateReleaseAggregation,
+  releaseVerdictFrom,
+  resolveSubgateVerdict,
+  SUBGATE_JSON_FILES,
+} = await import(pathToFileURL(join(ROOT, "packages/release-identity/src/index.ts")).href);
 
 function readGateJson(name) {
   const rel = SUBGATE_JSON_FILES[name];
@@ -67,6 +73,18 @@ const records = [];
 for (const gate of HARD_SUBGATES) {
   records.push(runGate(gate.name));
 }
+const supplementalAcceptance = SUPPLEMENTAL_ACCEPTANCE_SUBGATES.map((gate) => {
+  const json = readGateJson(gate.name);
+  if (!json) {
+    return { name: gate.name, kind: gate.kind, exit: 2, verdict: "INCOMPLETE", reason: "no current supplemental evidence" };
+  }
+  const resolved = resolveSubgateVerdict({
+    processExit: 0,
+    processVerdict: "PASS",
+    json,
+  });
+  return { name: gate.name, kind: gate.kind, exit: resolved.exit, verdict: resolved.verdict, reason: json.reason ?? null };
+});
 
 const info = readJson("release-info.json");
 const summaryPath = join(ROOT, "evidence/generated/evidence-summary.json");
@@ -86,16 +104,13 @@ const agg = evaluateReleaseAggregation({
   candidateKind: info.candidateKind,
   records,
   notaryEvidence,
-  summaryVerdict: summary?.verdict,
 });
 const applicable = evaluateApplicableDomain({
   records,
-  summaryVerdict: summary?.verdict,
-  summaryTotals: summary?.totals,
 });
 // The arm64 automated domain is an informational subset signal: it can pass
-// while deferred gates (installed/live/soak/export, which need native runners)
-// remain INCOMPLETE. It must never mask those incomplete gates into a
+// while deferred gates such as installed/public-export remain INCOMPLETE.
+// It must never mask those incomplete gates into a
 // release-level PASS. The release verdict always starts from the full
 // aggregation; the domain can only escalate it to FAIL, never to PASS.
 const release = releaseVerdictFrom(applicable, agg);
@@ -115,7 +130,11 @@ const out = {
   notaryStatus: agg.notaryStatus,
   notaryRecordedAs: agg.notaryRecordedAs,
   records,
-  totals: summary?.totals ?? null,
+  supplementalAcceptance: {
+    requiredForPublication: false,
+    records: supplementalAcceptance,
+    totals: summary?.totals ?? null,
+  },
   dryRun,
   injectFail,
 };


### PR DESCRIPTION
## Summary

- align current 0.5.7 security, IM, architecture, decision, and release documentation with the immutable eight-entry release boundary
- keep WhatsApp/Baileys/libsignal outside the production distribution and preserve the published v0.5.7 tag and ten assets
- separate supplemental Owner live/long-soak evidence from automated/native publication gates without fabricating PASS
- add fail-closed live-evidence validation plus regression tests for release truth, unique decision IDs, and documentation references

## Scope

This changes repository documentation and release-verification tooling only. It does not change product runtime behavior, installers, release assets, tag identity, or website visual structure.

## Verification

- Node 22.22.2 / pnpm 10.14.0 frozen install
- format and typecheck PASS
- unit 720/720 PASS
- contract, integration, desktop E2E, security, chaos, and failure-baseline PASS
- dependency, license, and secret audits PASS
- build and plugin packaging PASS
- clean-clone PASS from `ae10b088e2708d9048ef7fbee81a7a1f04b30ce0`
