### PR TITLE
site: restore Beijing HTTPS mirrors for 0.5.7

### DIFF
--- a/packages/release-identity/src/public-docs.test.ts
+++ b/packages/release-identity/src/public-docs.test.ts
@@ -115,7 +115,11 @@ test("website keeps the full bilingual visual site and exact 0.5.7 downloads", (
     assert.match(html, /bfbaec4b9f4b627abd41e793abae6b68246d0f00d8e9c5ca003d079e1e3667c8/);
     assert.match(html, /ab696fc92a2b1af538eed6008c8389ddc945d9dce39d85b16053cf60d8e2655e/);
     assert.match(html, /cb4687e621d951d6d8ba4cf8428f4723f35c9827fa70ac542d4d3d928d5d882a/);
+    assert.match(html, /https:\/\/82\.156\.107\.151\/releases\/v0\.5\.7\/Penglai_0\.5\.7_macos_aarch64\.dmg/);
+    assert.match(html, /https:\/\/82\.156\.107\.151\/releases\/v0\.5\.7\/Penglai_0\.5\.7_macos_x64\.dmg/);
+    assert.match(html, /https:\/\/82\.156\.107\.151\/releases\/v0\.5\.7\/Penglai_0\.5\.7_windows_x64_setup\.exe/);
     assert.doesNotMatch(html, /releases\/download\/v0\.5\.6/);
+    assert.doesNotMatch(html, /releases\/v0\.5\.5/);
   }
   assert.match(css, /\.hero-art/);
   assert.match(css, /\.gallery/);

--- a/website/en/index.html
+++ b/website/en/index.html
@@ -106,9 +106,15 @@
       <p class="eyebrow">Penglai 0.5.7</p>
       <h2>Choose your computer.</h2>
       <div class="download-grid">
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_aarch64.dmg"><strong>macOS · Apple Silicon</strong><span>452.4 MiB · M1 / M2 / M3 / M4 / M5</span><code>bfbaec4b9f4b627abd41e793abae6b68246d0f00d8e9c5ca003d079e1e3667c8</code></a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_x64.dmg"><strong>macOS · Intel</strong><span>382.5 MiB · x86_64 Mac</span><code>ab696fc92a2b1af538eed6008c8389ddc945d9dce39d85b16053cf60d8e2655e</code></a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_windows_x64_setup.exe"><strong>Windows · x64</strong><span>339.4 MiB · 64-bit installer</span><code>cb4687e621d951d6d8ba4cf8428f4723f35c9827fa70ac542d4d3d928d5d882a</code></a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_aarch64.dmg"><strong>macOS · Apple Silicon</strong><span>GitHub · 452.4 MiB · M1 / M2 / M3 / M4 / M5</span><code>bfbaec4b9f4b627abd41e793abae6b68246d0f00d8e9c5ca003d079e1e3667c8</code></a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_x64.dmg"><strong>macOS · Intel</strong><span>GitHub · 382.5 MiB · x86_64 Mac</span><code>ab696fc92a2b1af538eed6008c8389ddc945d9dce39d85b16053cf60d8e2655e</code></a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_windows_x64_setup.exe"><strong>Windows · x64</strong><span>GitHub · 339.4 MiB · 64-bit installer</span><code>cb4687e621d951d6d8ba4cf8428f4723f35c9827fa70ac542d4d3d928d5d882a</code></a>
+      </div>
+      <p class="quiet">If GitHub is slow from mainland China, use the Beijing mirror of the same installers. Verify against GitHub SHA256SUMS. In-app updates still use GitHub.</p>
+      <div class="download-grid download-grid-mirror">
+        <a href="https://82.156.107.151/releases/v0.5.7/Penglai_0.5.7_macos_aarch64.dmg"><strong>China mirror · Apple Silicon</strong><span>Beijing HTTPS · 452.4 MiB</span><code>bfbaec4b9f4b627abd41e793abae6b68246d0f00d8e9c5ca003d079e1e3667c8</code></a>
+        <a href="https://82.156.107.151/releases/v0.5.7/Penglai_0.5.7_macos_x64.dmg"><strong>China mirror · Intel</strong><span>Beijing HTTPS · 382.5 MiB</span><code>ab696fc92a2b1af538eed6008c8389ddc945d9dce39d85b16053cf60d8e2655e</code></a>
+        <a href="https://82.156.107.151/releases/v0.5.7/Penglai_0.5.7_windows_x64_setup.exe"><strong>China mirror · Windows x64</strong><span>Beijing HTTPS · 339.4 MiB</span><code>cb4687e621d951d6d8ba4cf8428f4723f35c9827fa70ac542d4d3d928d5d882a</code></a>
       </div>
       <p class="quiet">The immutable GitHub Release is the public download source for 0.5.7. All three installers come from source <code>ce01d4dea59af72422071e357760a040f19b8e3d</code>. Full SHA256SUMS, SBOM, third-party notices, and signed update metadata are available on the same page. Updates are never silent.</p>
       <div class="actions centered">

--- a/website/index.html
+++ b/website/index.html
@@ -106,9 +106,15 @@
       <p class="eyebrow">Penglai 0.5.7</p>
       <h2>选择你的电脑。</h2>
       <div class="download-grid">
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_aarch64.dmg"><strong>macOS · Apple 芯片</strong><span>452.4 MiB · M1 / M2 / M3 / M4 / M5</span><code>bfbaec4b9f4b627abd41e793abae6b68246d0f00d8e9c5ca003d079e1e3667c8</code></a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_x64.dmg"><strong>macOS · Intel</strong><span>382.5 MiB · x86_64 Mac</span><code>ab696fc92a2b1af538eed6008c8389ddc945d9dce39d85b16053cf60d8e2655e</code></a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_windows_x64_setup.exe"><strong>Windows · x64</strong><span>339.4 MiB · 64 位安装器</span><code>cb4687e621d951d6d8ba4cf8428f4723f35c9827fa70ac542d4d3d928d5d882a</code></a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_aarch64.dmg"><strong>macOS · Apple 芯片</strong><span>GitHub · 452.4 MiB · M1 / M2 / M3 / M4 / M5</span><code>bfbaec4b9f4b627abd41e793abae6b68246d0f00d8e9c5ca003d079e1e3667c8</code></a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_macos_x64.dmg"><strong>macOS · Intel</strong><span>GitHub · 382.5 MiB · x86_64 Mac</span><code>ab696fc92a2b1af538eed6008c8389ddc945d9dce39d85b16053cf60d8e2655e</code></a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.7/Penglai_0.5.7_windows_x64_setup.exe"><strong>Windows · x64</strong><span>GitHub · 339.4 MiB · 64 位安装器</span><code>cb4687e621d951d6d8ba4cf8428f4723f35c9827fa70ac542d4d3d928d5d882a</code></a>
+      </div>
+      <p class="quiet">国内访问 GitHub 较慢时，可下载同一份安装包的北京镜像。校验以 GitHub 的 SHA256SUMS 为准；应用内更新仍走 GitHub。</p>
+      <div class="download-grid download-grid-mirror">
+        <a href="https://82.156.107.151/releases/v0.5.7/Penglai_0.5.7_macos_aarch64.dmg"><strong>国内镜像 · Apple 芯片</strong><span>北京 HTTPS · 452.4 MiB</span><code>bfbaec4b9f4b627abd41e793abae6b68246d0f00d8e9c5ca003d079e1e3667c8</code></a>
+        <a href="https://82.156.107.151/releases/v0.5.7/Penglai_0.5.7_macos_x64.dmg"><strong>国内镜像 · Intel</strong><span>北京 HTTPS · 382.5 MiB</span><code>ab696fc92a2b1af538eed6008c8389ddc945d9dce39d85b16053cf60d8e2655e</code></a>
+        <a href="https://82.156.107.151/releases/v0.5.7/Penglai_0.5.7_windows_x64_setup.exe"><strong>国内镜像 · Windows x64</strong><span>北京 HTTPS · 339.4 MiB</span><code>cb4687e621d951d6d8ba4cf8428f4723f35c9827fa70ac542d4d3d928d5d882a</code></a>
       </div>
       <p class="quiet">0.5.7 当前以不可变 GitHub Release 为公开下载源，三个安装包来自源码 <code>ce01d4dea59af72422071e357760a040f19b8e3d</code>。完整 SHA256SUMS、SBOM、第三方声明与签名元数据同页提供；更新不会静默执行。</p>
       <div class="actions centered">


### PR DESCRIPTION
## Summary
- GitHub remains the canonical 0.5.7 download source.
- Restore the bilingual Beijing HTTPS installer mirrors on the official website, using the same three immutable 0.5.7 clients.
- Keep the existing SHA-256 values on both GitHub and China-mirror cards. In-app updates still use GitHub.

The Beijing host already serves the exact public 0.5.7 bytes:

| Asset | Bytes | SHA-256 |
| --- | ---: | --- |
| `Penglai_0.5.7_macos_aarch64.dmg` | 474,383,101 | `bfbaec4b9f4b627abd41e793abae6b68246d0f00d8e9c5ca003d079e1e3667c8` |
| `Penglai_0.5.7_macos_x64.dmg` | 401,056,681 | `ab696fc92a2b1af538eed6008c8389ddc945d9dce39d85b16053cf60d8e2655e` |
| `Penglai_0.5.7_windows_x64_setup.exe` | 355,918,104 | `cb4687e621d951d6d8ba4cf8428f4723f35c9827fa70ac542d4d3d928d5d882a` |

Mirror URLs:

- `https://82.156.107.151/releases/v0.5.7/Penglai_0.5.7_macos_aarch64.dmg`
- `https://82.156.107.151/releases/v0.5.7/Penglai_0.5.7_macos_x64.dmg`
- `https://82.156.107.151/releases/v0.5.7/Penglai_0.5.7_windows_x64_setup.exe`

## Test plan
- [x] `node --import tsx --test packages/release-identity/src/public-docs.test.ts`
- [x] Public HEAD/Range checks against the Beijing HTTPS mirror
- [ ] After merge, dispatch `Deploy website` for `v0.5.7`
- [ ] Recheck Chinese and English homepages for GitHub + Beijing download cards