### PR TITLE
Fix 0.5.8 website release gate

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Immutable Release tag that must already exist (example v0.5.7)
+        description: Immutable Release tag that must already exist (example v0.5.8)
         required: true
         type: string
       deploy_site:
@@ -27,16 +27,16 @@ jobs:
           node-version: 22.22.2
       - name: Require the requested tag
         run: |
-          test "${{ inputs.tag }}" = "v0.5.7"
+          test "${{ inputs.tag }}" = "v0.5.8"
       - name: Public readback
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           corepack enable
-          corepack prepare pnpm@10.14.0 --activate
+          corepack prepare pnpm@11.7.0 --activate
           pnpm install --frozen-lockfile
           pnpm build
-          pnpm readback:release v0.5.7
+          pnpm readback:release "${{ inputs.tag }}"
       - name: Deploy verified website
         if: ${{ inputs.deploy_site }}
         env:

--- a/scripts/verify-contracts.mjs
+++ b/scripts/verify-contracts.mjs
@@ -8,7 +8,9 @@ import {
   PINNED_DSH_CLOSURE_MANIFEST_SHA256,
   PINNED_DSH_COMMIT,
   PINNED_DSH_TARBALL_SHA256,
+  PINNED_PNPM,
   PRODUCT_VERSION,
+  PUBLICATION_TARGET,
 } from "./lib/product.mjs";
 
 const lock = readFileSync(join(ROOT, "pnpm-lock.yaml"), "utf8");
@@ -94,6 +96,17 @@ try {
 } catch (err) {
   console.error("release-contract invalid", err);
   process.exit(1);
+}
+const deployWorkflow = readFileSync(join(ROOT, ".github/workflows/deploy-website.yml"), "utf8");
+for (const required of [
+  `test "\${{ inputs.tag }}" = "${PUBLICATION_TARGET.tag}"`,
+  `corepack prepare pnpm@${PINNED_PNPM} --activate`,
+  `pnpm readback:release "\${{ inputs.tag }}"`,
+]) {
+  if (!deployWorkflow.includes(required)) {
+    console.error("website deployment workflow is not bound to the current release contract", required);
+    process.exit(1);
+  }
 }
 const makers = spawnSync(process.execPath, ["--import", "tsx", join(ROOT, "scripts/probe-makers.mjs")], {
   cwd: ROOT,


### PR DESCRIPTION
## What changed\n- require the immutable v0.5.8 tag in the website deployment workflow\n- use the repository-pinned pnpm 11.7.0\n- read back the exact workflow input tag before deployment\n- add a contract gate so future version bumps cannot leave this workflow stale\n\n## Verification\n- pnpm verify:contracts\n- pnpm format:check\n- git diff --check\n\nThis must merge before native packaging so all three clients remain bound to one final main SHA.