### PR TITLE
Fix Windows native release gates for 0.5.8

### DIFF
--- a/.github/workflows/native-release-candidate.yml
+++ b/.github/workflows/native-release-candidate.yml
@@ -177,6 +177,11 @@ jobs:
         run: pnpm prepare:public-export -- --clean-room
       - name: Build source from the clean checkout
         run: pnpm build
+      - name: Build native Windows security helper for regression gates
+        shell: cmd
+        run: |
+          call "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          pnpm build:windows-host
       - name: Source and onboarding regression gates
         shell: bash
         run: |

--- a/packages/runtime/src/dsh-supervisor-alpha-auth.test.ts
+++ b/packages/runtime/src/dsh-supervisor-alpha-auth.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 import {
   EmbeddedDshSupervisor,
@@ -10,6 +11,15 @@ import {
   resolveUserLayout,
   runtimePluginTarget,
 } from "./index.js";
+
+function installBuiltWindowsHost(appRoot: string): void {
+  if (process.platform !== "win32") return;
+  const built = fileURLToPath(new URL("../../../dist/native-win32-x86_64/penglai-windows-host.exe", import.meta.url));
+  assert.equal(existsSync(built), true, "native Windows regression gates must compile the security helper first");
+  const helperDir = join(appRoot, "runtime", "helpers");
+  mkdirSync(helperDir, { recursive: true });
+  copyFileSync(built, join(helperDir, "penglai-windows-host.exe"));
+}
 
 test("embedded supervisor privately exchanges alpha browser auth and keeps steady-state probes authenticated", async () => {
   const app = mkdtempSync(join(tmpdir(), "penglai-alpha-auth-app-"));
@@ -68,6 +78,7 @@ test("embedded supervisor privately exchanges alpha browser auth and keeps stead
       size: Buffer.byteLength(fakeDsh),
     }],
   }));
+  installBuiltWindowsHost(app);
   ensurePrivateHome(user, app);
   const supervisor = new EmbeddedDshSupervisor({
     appRoot: app,

--- a/packages/runtime/src/runtime.test.ts
+++ b/packages/runtime/src/runtime.test.ts
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import { createServer } from "node:http";
 import {
   chmodSync,
+  copyFileSync,
   existsSync,
   lstatSync,
   mkdtempSync,
@@ -15,6 +16,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   activatePrivateProfile,
   assertAbsoluteExecutable,
@@ -42,6 +44,15 @@ import {
   windowsOwnedProcessEnvironment,
 } from "./index.js";
 import { writeTestTarGz } from "../../../scripts/lib/test-tar-fixture.mjs";
+
+function installBuiltWindowsHost(appRoot: string): void {
+  if (process.platform !== "win32") return;
+  const built = fileURLToPath(new URL("../../../dist/native-win32-x86_64/penglai-windows-host.exe", import.meta.url));
+  assert.equal(existsSync(built), true, "native Windows regression gates must compile the security helper first");
+  const helperDir = join(appRoot, "runtime", "helpers");
+  mkdirSync(helperDir, { recursive: true });
+  copyFileSync(built, join(helperDir, "penglai-windows-host.exe"));
+}
 
 test("embedded DSH Web never opens the operating-system browser", () => {
   assert.deepEqual(dshWebArgs(3080), [
@@ -362,6 +373,7 @@ test("embedded supervisor restarts a live process whose official HTTP route hang
     files: [{ path: "runtime/dsh/lib/bin.js", sha256: digest, size: Buffer.byteLength(fakeDsh) }],
   }));
   writeFileSync(modePath, "healthy\n");
+  installBuiltWindowsHost(app);
   ensurePrivateHome(user, app);
   const recoveryStates: string[] = [];
   const supervisor = new EmbeddedDshSupervisor({

--- a/scripts/lib/dsh-local-dependency-map.test.mjs
+++ b/scripts/lib/dsh-local-dependency-map.test.mjs
@@ -82,7 +82,7 @@ test("pnpm fetcher verifies bytes before delegating to the local tarball fetcher
     },
   );
   assert.equal(result, "verified-local-tarball");
-  assert.match(delegated.spec.tarball, /third_party\/dsh\/0\.1\.2-alpha\.1\/dsh\//);
+  assert.match(delegated.spec.tarball.replaceAll("\\", "/"), /third_party\/dsh\/0\.1\.2-alpha\.1\/dsh\//);
   assert.match(delegated.spec.integrity, /^sha512-/);
 });
 

--- a/scripts/lib/release-pins-source.mjs
+++ b/scripts/lib/release-pins-source.mjs
@@ -78,7 +78,10 @@ function releaseTargets(source) {
 }
 
 export function readReleaseIdentityPins(root = ROOT) {
-  const source = readFileSync(join(root, RELEASE_PINS_SOURCE), "utf8");
+  const source = readFileSync(join(root, RELEASE_PINS_SOURCE), "utf8").replace(
+    /\r\n?/g,
+    "\n",
+  );
   const publicationBlock = objectBlock(source, "PUBLICATION_TARGET");
   return Object.freeze({
     productName: stringPin(source, "PRODUCT_NAME"),

--- a/scripts/lib/release-pins-source.test.mjs
+++ b/scripts/lib/release-pins-source.test.mjs
@@ -31,6 +31,18 @@ test("release identity copies resolve from the one authoritative pins source", (
   );
 });
 
+test("release identity parsing is invariant across LF and CRLF checkouts", () => {
+  const root = mkdtempSync(join(tmpdir(), "penglai-release-pins-crlf-"));
+  const target = join(root, RELEASE_PINS_SOURCE);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, readFileForTest().replace(/\n/g, "\r\n"));
+  try {
+    assert.deepEqual(readReleaseIdentityPins(root), readReleaseIdentityPins());
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("version verifier consumes the authority instead of declaring a second expected version", () => {
   const source = readFileSync(
     new URL("../verify-versions.mjs", import.meta.url),


### PR DESCRIPTION
## Outcome

Makes the final 0.5.8 Windows candidate run its regression suite against Windows-native paths and ACL behavior without skipping or weakening gates.

## Changes

- normalize CRLF before reading the single release-pin authority
- normalize the verified local DSH tarball path in its platform-invariant assertion
- compile the real Windows security helper before regression gates
- install that compiled helper into Supervisor test app roots so Windows ACL convergence remains real

## Verification

- 811/811 unit tests pass locally
- focused 40/40 cross-platform and Supervisor tests pass
- typecheck, repository format check, workflow lint, and diff checks pass
- clean public export already passed on Windows in native run 33300712720 before these later gate failures