### PR TITLE
Fix synchronous desktop title ownership for 0.5.8

### DIFF
--- a/apps/desktop/src/product-title.test.ts
+++ b/apps/desktop/src/product-title.test.ts
@@ -44,8 +44,39 @@ test("desktop preload restores the title after upstream updates", () => {
   const dispose = installPenglaiDocumentTitle(documentPort, Observer);
   assert.equal(documentPort.title, "蓬莱 Penglai");
   documentPort.title = "Session — DeepSeek Harness";
+  assert.equal(documentPort.title, "Session — 蓬莱 Penglai");
   mutation?.();
   assert.equal(documentPort.title, "Session — 蓬莱 Penglai");
   dispose();
   assert.equal(disconnected, true);
+});
+
+test("desktop title getter never exposes an upstream mutation before the observer microtask", () => {
+  let rawTitle = "DeepSeek Harness";
+  let mutation: (() => void) | undefined;
+  const prototype = {};
+  Object.defineProperty(prototype, "title", {
+    configurable: true,
+    get: () => rawTitle,
+    set: (value: string) => {
+      rawTitle = value;
+    },
+  });
+  const documentPort = Object.assign(Object.create(prototype), {
+    head: {} as Node,
+    documentElement: {} as Node,
+  }) as { title: string; head: Node; documentElement: Node };
+  class Observer {
+    constructor(callback: () => void) {
+      mutation = callback;
+    }
+    observe() {}
+    disconnect() {}
+  }
+
+  installPenglaiDocumentTitle(documentPort, Observer);
+  rawTitle = "Settings — DeepSeek Harness";
+  assert.equal(documentPort.title, "Settings — 蓬莱 Penglai");
+  mutation?.();
+  assert.equal(rawTitle, "Settings — 蓬莱 Penglai");
 });

--- a/apps/desktop/src/product-title.ts
+++ b/apps/desktop/src/product-title.ts
@@ -20,19 +20,72 @@ type ProductTitleObserverConstructor = new (
   callback: () => void,
 ) => ProductTitleObserver;
 
+interface ProductTitleGuard {
+  sync(): void;
+  dispose(): void;
+}
+
+function inheritedTitleDescriptor(
+  documentPort: ProductTitleDocument,
+): PropertyDescriptor | undefined {
+  let current = Object.getPrototypeOf(documentPort) as object | null;
+  while (current) {
+    const descriptor = Object.getOwnPropertyDescriptor(current, "title");
+    if (descriptor) return descriptor;
+    current = Object.getPrototypeOf(current) as object | null;
+  }
+  return undefined;
+}
+
+function installSynchronousTitleGuard(
+  documentPort: ProductTitleDocument,
+): ProductTitleGuard {
+  const own = Object.getOwnPropertyDescriptor(documentPort, "title");
+  const descriptor = own ?? inheritedTitleDescriptor(documentPort);
+  let fallback = documentPort.title;
+  const readRaw = descriptor?.get
+    ? () => String(descriptor.get?.call(documentPort) ?? "")
+    : () => fallback;
+  const writeRaw = descriptor?.set
+    ? (value: string) => descriptor.set?.call(documentPort, value)
+    : (value: string) => {
+        fallback = value;
+      };
+  const sync = (): void => writeRaw(penglaiDocumentTitle(readRaw()));
+  try {
+    Object.defineProperty(documentPort, "title", {
+      configurable: true,
+      enumerable: own?.enumerable ?? descriptor?.enumerable ?? true,
+      get: () => penglaiDocumentTitle(readRaw()),
+      set: (value: unknown) => writeRaw(penglaiDocumentTitle(String(value ?? ""))),
+    });
+  } catch {
+    return {
+      sync: () => {
+        documentPort.title = penglaiDocumentTitle(documentPort.title);
+      },
+      dispose: () => undefined,
+    };
+  }
+  return {
+    sync,
+    dispose: () => {
+      if (own) Object.defineProperty(documentPort, "title", own);
+      else delete (documentPort as Partial<ProductTitleDocument>).title;
+    },
+  };
+}
+
 /** Keep the distribution-owned document title branded without changing DSH package bytes. */
 export function installPenglaiDocumentTitle(
   documentPort: ProductTitleDocument,
   Observer: ProductTitleObserverConstructor,
 ): () => void {
   let observer: ProductTitleObserver | undefined;
-  const sync = (): void => {
-    const next = penglaiDocumentTitle(documentPort.title);
-    if (next !== documentPort.title) documentPort.title = next;
-  };
+  const guard = installSynchronousTitleGuard(documentPort);
   const attach = (): void => {
-    sync();
-    observer = new Observer(sync);
+    guard.sync();
+    observer = new Observer(guard.sync);
     observer.observe(documentPort.head ?? documentPort.documentElement, {
       childList: true,
       subtree: true,
@@ -40,5 +93,8 @@ export function installPenglaiDocumentTitle(
     });
   };
   attach();
-  return () => observer?.disconnect();
+  return () => {
+    observer?.disconnect();
+    guard.dispose();
+  };
 }


### PR DESCRIPTION
Outcome: closes the last macOS installed-plugin gate failure without changing DSH package bytes or weakening the strict title assertion. Cause: the native window title was already owned by Penglai, and a MutationObserver repaired later DOM title changes, but the DOM title could expose the upstream product identity between a write and the observer microtask. Both Mac architectures caught that transient while every plugin lifecycle check passed. Fix: install a synchronous accessor guard in the isolated preload; upstream title writes are translated before storage, reads never expose the upstream identity, and the observer remains as the direct title-element mutation backstop. Verification: focused desktop title and installed-walk tests 23/23 pass; typecheck, format, and diff checks pass; native run 33300712720 reached the complete seven-plugin lifecycle on both Mac architectures and failed only the upstream-window-title assertion.