### PR TITLE
Exercise Windows supervisors with the bundled Node path

### DIFF
--- a/packages/runtime/src/dsh-supervisor-alpha-auth.test.ts
+++ b/packages/runtime/src/dsh-supervisor-alpha-auth.test.ts
@@ -12,13 +12,18 @@ import {
   runtimePluginTarget,
 } from "./index.js";
 
-function installBuiltWindowsHost(appRoot: string): void {
-  if (process.platform !== "win32") return;
+function installBuiltWindowsRuntime(appRoot: string): string {
+  if (process.platform !== "win32") return process.execPath;
   const built = fileURLToPath(new URL("../../../dist/native-win32-x86_64/penglai-windows-host.exe", import.meta.url));
   assert.equal(existsSync(built), true, "native Windows regression gates must compile the security helper first");
   const helperDir = join(appRoot, "runtime", "helpers");
   mkdirSync(helperDir, { recursive: true });
   copyFileSync(built, join(helperDir, "penglai-windows-host.exe"));
+  const nodeDir = join(appRoot, "runtime", "node");
+  const nodeBin = join(nodeDir, "node.exe");
+  mkdirSync(nodeDir, { recursive: true });
+  copyFileSync(process.execPath, nodeBin);
+  return nodeBin;
 }
 
 test("embedded supervisor privately exchanges alpha browser auth and keeps steady-state probes authenticated", async () => {
@@ -78,11 +83,11 @@ test("embedded supervisor privately exchanges alpha browser auth and keeps stead
       size: Buffer.byteLength(fakeDsh),
     }],
   }));
-  installBuiltWindowsHost(app);
+  const nodeBin = installBuiltWindowsRuntime(app);
   ensurePrivateHome(user, app);
   const supervisor = new EmbeddedDshSupervisor({
     appRoot: app,
-    nodeBin: process.execPath,
+    nodeBin,
     dshEntry,
     profileSeed: join(app, "profile-seed", "web"),
     pluginsDir: join(app, "plugins"),

--- a/packages/runtime/src/runtime.test.ts
+++ b/packages/runtime/src/runtime.test.ts
@@ -45,13 +45,18 @@ import {
 } from "./index.js";
 import { writeTestTarGz } from "../../../scripts/lib/test-tar-fixture.mjs";
 
-function installBuiltWindowsHost(appRoot: string): void {
-  if (process.platform !== "win32") return;
+function installBuiltWindowsRuntime(appRoot: string): string {
+  if (process.platform !== "win32") return process.execPath;
   const built = fileURLToPath(new URL("../../../dist/native-win32-x86_64/penglai-windows-host.exe", import.meta.url));
   assert.equal(existsSync(built), true, "native Windows regression gates must compile the security helper first");
   const helperDir = join(appRoot, "runtime", "helpers");
   mkdirSync(helperDir, { recursive: true });
   copyFileSync(built, join(helperDir, "penglai-windows-host.exe"));
+  const nodeDir = join(appRoot, "runtime", "node");
+  const nodeBin = join(nodeDir, "node.exe");
+  mkdirSync(nodeDir, { recursive: true });
+  copyFileSync(process.execPath, nodeBin);
+  return nodeBin;
 }
 
 test("embedded DSH Web never opens the operating-system browser", () => {
@@ -373,12 +378,12 @@ test("embedded supervisor restarts a live process whose official HTTP route hang
     files: [{ path: "runtime/dsh/lib/bin.js", sha256: digest, size: Buffer.byteLength(fakeDsh) }],
   }));
   writeFileSync(modePath, "healthy\n");
-  installBuiltWindowsHost(app);
+  const nodeBin = installBuiltWindowsRuntime(app);
   ensurePrivateHome(user, app);
   const recoveryStates: string[] = [];
   const supervisor = new EmbeddedDshSupervisor({
     appRoot: app,
-    nodeBin: process.execPath,
+    nodeBin,
     dshEntry,
     profileSeed: join(app, "profile-seed", "web"),
     pluginsDir: join(app, "plugins"),


### PR DESCRIPTION
The final Windows native run compiled and used the real security helper, which then correctly rejected the unit fixture because it tried to launch the CI toolcache Node instead of the bundled absolute runtime/node/node.exe path. This change makes the two cross-platform Supervisor tests reproduce the real packaged layout on Windows by copying both the compiled native helper and the current pinned Node executable into their isolated app root. Production validation remains fail-closed; no gate is skipped. Local typecheck, formatting, and the 31 affected Supervisor tests pass. Native run 33302382763 is the diagnostic evidence.