### PR TITLE
Fix installed 0.5.8 title ownership under context isolation

### DIFF
--- a/apps/desktop/src/preload-bridge.ts
+++ b/apps/desktop/src/preload-bridge.ts
@@ -1,12 +1,16 @@
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, webFrame } from "electron";
 import { PRELOAD_API } from "./preload.js";
-import { installPenglaiDocumentTitle } from "./product-title.js";
+import {
+  installPenglaiDocumentTitle,
+  PENGLAI_MAIN_WORLD_TITLE_GUARD,
+} from "./product-title.js";
 import {
   applyRecoveryDiagnostic,
   RECOVERY_DIAGNOSTIC_CHANNEL,
 } from "./recovery-diagnostic.js";
 
 installPenglaiDocumentTitle(document, MutationObserver);
+void webFrame.executeJavaScript(PENGLAI_MAIN_WORLD_TITLE_GUARD);
 ipcRenderer.on(RECOVERY_DIAGNOSTIC_CHANNEL, (_event, payload: unknown) => {
   applyRecoveryDiagnostic(document, payload);
 });

--- a/apps/desktop/src/product-title.test.ts
+++ b/apps/desktop/src/product-title.test.ts
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   installPenglaiDocumentTitle,
+  PENGLAI_MAIN_WORLD_TITLE_GUARD,
   penglaiDocumentTitle,
 } from "./product-title.js";
+import vm from "node:vm";
 
 test("desktop title replaces only the upstream product identity", () => {
   assert.equal(penglaiDocumentTitle(""), "蓬莱 Penglai");
@@ -79,4 +81,45 @@ test("desktop title getter never exposes an upstream mutation before the observe
   assert.equal(documentPort.title, "Settings — 蓬莱 Penglai");
   mutation?.();
   assert.equal(rawTitle, "Settings — 蓬莱 Penglai");
+});
+
+test("main-world title guard owns synchronous DSH page writes under context isolation", () => {
+  let rawTitle = "DeepSeek Harness";
+  let mutation: (() => void) | undefined;
+  const prototype = {};
+  Object.defineProperty(prototype, "title", {
+    configurable: true,
+    enumerable: true,
+    get: () => rawTitle,
+    set: (value: string) => {
+      rawTitle = value;
+    },
+  });
+  const documentPort = Object.assign(Object.create(prototype), {
+    head: {},
+    documentElement: {},
+  }) as { title: string; head: object; documentElement: object };
+  class Observer {
+    constructor(callback: () => void) {
+      mutation = callback;
+    }
+    observe() {}
+  }
+
+  vm.runInNewContext(PENGLAI_MAIN_WORLD_TITLE_GUARD, {
+    document: documentPort,
+    MutationObserver: Observer,
+  });
+  vm.runInNewContext(PENGLAI_MAIN_WORLD_TITLE_GUARD, {
+    document: documentPort,
+    MutationObserver: Observer,
+  });
+  assert.equal(documentPort.title, "蓬莱 Penglai");
+  documentPort.title = "Settings — DeepSeek Harness";
+  assert.equal(rawTitle, "Settings — 蓬莱 Penglai");
+  assert.equal(documentPort.title, "Settings — 蓬莱 Penglai");
+  rawTitle = "Plugins — DeepSeek Harness";
+  assert.equal(documentPort.title, "Plugins — 蓬莱 Penglai");
+  mutation?.();
+  assert.equal(rawTitle, "Plugins — 蓬莱 Penglai");
 });

--- a/apps/desktop/src/product-title.ts
+++ b/apps/desktop/src/product-title.ts
@@ -1,5 +1,60 @@
 export const PENGLAI_DESKTOP_TITLE = "蓬莱 Penglai";
 
+/**
+ * Context isolation gives the preload and DSH page separate JavaScript worlds.
+ * Keep this static bootstrap self-contained so it can be installed in the page
+ * world without granting that world any Electron capability.
+ */
+export const PENGLAI_MAIN_WORLD_TITLE_GUARD = `(() => {
+  const productTitle = ${JSON.stringify(PENGLAI_DESKTOP_TITLE)};
+  const rewrite = (value) => {
+    const current = String(value ?? "");
+    return current.trim()
+      ? current.replace(/DeepSeek Harness/gi, productTitle)
+      : productTitle;
+  };
+  if (Object.prototype.hasOwnProperty.call(document, "__penglaiTitleGuard")) {
+    document.title = rewrite(document.title);
+    return;
+  }
+  let owner = document;
+  let descriptor;
+  while (owner && !descriptor) {
+    descriptor = Object.getOwnPropertyDescriptor(owner, "title");
+    owner = Object.getPrototypeOf(owner);
+  }
+  let fallback = document.title;
+  const readRaw = descriptor && descriptor.get
+    ? () => String(descriptor.get.call(document) ?? "")
+    : () => fallback;
+  const writeRaw = descriptor && descriptor.set
+    ? (value) => descriptor.set.call(document, value)
+    : (value) => { fallback = value; };
+  const sync = () => {
+    const current = readRaw();
+    const branded = rewrite(current);
+    if (branded !== current) writeRaw(branded);
+  };
+  Object.defineProperty(document, "title", {
+    configurable: false,
+    enumerable: descriptor ? descriptor.enumerable : true,
+    get: () => rewrite(readRaw()),
+    set: (value) => writeRaw(rewrite(value)),
+  });
+  Object.defineProperty(document, "__penglaiTitleGuard", {
+    configurable: false,
+    enumerable: false,
+    value: true,
+    writable: false,
+  });
+  sync();
+  new MutationObserver(sync).observe(document.head || document.documentElement, {
+    childList: true,
+    subtree: true,
+    characterData: true,
+  });
+})()`;
+
 export function penglaiDocumentTitle(current: string): string {
   if (!current.trim()) return PENGLAI_DESKTOP_TITLE;
   return current.replace(/DeepSeek Harness/gi, PENGLAI_DESKTOP_TITLE);
@@ -51,13 +106,18 @@ function installSynchronousTitleGuard(
     : (value: string) => {
         fallback = value;
       };
-  const sync = (): void => writeRaw(penglaiDocumentTitle(readRaw()));
+  const sync = (): void => {
+    const current = readRaw();
+    const branded = penglaiDocumentTitle(current);
+    if (branded !== current) writeRaw(branded);
+  };
   try {
     Object.defineProperty(documentPort, "title", {
       configurable: true,
       enumerable: own?.enumerable ?? descriptor?.enumerable ?? true,
       get: () => penglaiDocumentTitle(readRaw()),
-      set: (value: unknown) => writeRaw(penglaiDocumentTitle(String(value ?? ""))),
+      set: (value: unknown) =>
+        writeRaw(penglaiDocumentTitle(String(value ?? ""))),
     });
   } catch {
     return {


### PR DESCRIPTION
## What changed\n- install a static title guard inside the DSH page world while keeping context isolation enabled\n- expose no Electron capability to the page and leave official DSH package bytes unchanged\n- keep the existing preload-world/native-window defenses as independent layers\n- add a regression test for synchronous DSH title writes and repeated bootstrap\n\n## Why\nNative Apple Silicon and Intel evidence reached the installed first-party plugin lifecycle but the strict browser walk still observed the upstream title. The prior preload-only guard lived in Electron's isolated world, so it could not synchronously intercept page-world writes.\n\n## Local verification\n- pnpm typecheck\n- pnpm test:e2e (88/88)\n- pnpm test:security (15/15)\n- pnpm build\n- pnpm format:check\n- git diff --check