### PR TITLE
fix(release): ignore downloaded upgrade fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist/
 evidence/
 .tmp/
 .tmp-public-export/
+.previous/
 .tmp-installed-from-dmg/
 .tmp-installed-e2e/
 .tmp-installed-*/


### PR DESCRIPTION
The native workflow downloads the immutable 0.5.8 installer into .previous before running the clean-candidate lifecycle verifier. Ignore that dedicated temporary directory so the exact main source remains clean while the upgrade/uninstall gate runs.