### PR TITLE
fix(release): build aggregate verifier dependencies

### DIFF
--- a/.github/workflows/native-release-candidate.yml
+++ b/.github/workflows/native-release-candidate.yml
@@ -401,6 +401,7 @@ jobs:
           corepack enable
           corepack prepare pnpm@11.7.0 --activate
           pnpm install --frozen-lockfile
+          pnpm build
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: penglai-0.5.9-darwin-aarch64


### PR DESCRIPTION
Build workspace packages on the three-target aggregate runner before executing installed evidence verifiers. The preceding native run proved all three target jobs green; only aggregation failed because @penglai/contracts/dist had not been built.