### PR TITLE
fix: verify fresh upgrade startup and align current release documentation

### DIFF
--- a/PRODUCT_CONSTITUTION.md
+++ b/PRODUCT_CONSTITUTION.md
@@ -1,6 +1,6 @@
 # 蓬莱产品宪法
 
-> 生效日期：2026-08-16；历次公开边界记录于决策日志。2026-08-24 Owner 授权公开发布 **Penglai 0.5.6**。2026-08-27 Owner 授权发布 **Penglai 0.5.7**，并决定不随包分发 WhatsApp 社区协议 runtime，以避免其 GPL 传递依赖带来的发行风险。2026-08-28 Owner 进一步决定：**Penglai 永久不再支持、接入、展示、实验或规划 WhatsApp**。2026-08-29 Owner 固定 0.5.8 的 DSH 源码基线为 `dsh-v0.1.2-alpha.1` / `cd5ef8148158c3a752a658978873241fdf8e2bbc`。2026-08-30 Owner 决定 0.5.8 使用该固定官方源码建立可复现本地包闭包，不等待官方 npm，并授权完成三端发布。2026-08-31 Owner 决定 **Penglai 0.5.9** 整体迁移到官方 npm `alpha` 通道的 DSH `0.1.2-alpha.2` 完整 cohort，并要求同步全部第一方插件与插件中心，在完整门禁后合并、构建三端并发布；已经公开的 0.5.8 保持不可变。本文是仓库内最高产品约束。用户最新明确指令高于本文；方向改变时必须先同步本文和决策日志，再开始编码。
+> 生效日期：2026-08-16；历次公开边界记录于决策日志。2026-08-24 Owner 授权公开发布 **Penglai 0.5.6**。2026-08-27 Owner 授权发布 **Penglai 0.5.7**，并决定不随包分发 WhatsApp 社区协议 runtime，以避免其 GPL 传递依赖带来的发行风险。2026-08-28 Owner 进一步决定：**Penglai 永久不再支持、接入、展示、实验或规划 WhatsApp**。2026-08-29 Owner 固定 0.5.8 的 DSH 源码基线为 `dsh-v0.1.2-alpha.1` / `cd5ef8148158c3a752a658978873241fdf8e2bbc`。2026-08-30 Owner 决定 0.5.8 使用该固定官方源码建立可复现本地包闭包，不等待官方 npm，并授权完成三端发布。2026-08-31 Owner 决定 **Penglai 0.5.9** 整体迁移到官方 npm `alpha` 通道的 DSH `0.1.2-alpha.2` 完整 cohort，并要求同步全部第一方插件与插件中心，在完整门禁后合并、构建三端并发布；已经公开的 0.5.8 保持不可变。2026-09-03 Owner 授权 **Penglai 0.5.10** 完整开发、正常测试、推送与 PR 合并、三端原生构建、完整发布及 README/官网收尾，固定官方 DSH `0.1.2-rc.1` npm cohort；明确排除两小时测试。本地操作 SOP 不进入公开仓库。本文是仓库内最高产品约束。用户最新明确指令高于本文；方向改变时必须先同步本文和决策日志，再开始编码。
 
 ## 一句话定义
 
@@ -39,8 +39,8 @@
 
 ## 当前发行边界
 
-- 当前不可变公开版本是 **Penglai v0.5.8**，基于官方 DSH `0.1.2-alpha.1`；当前开发与发布目标是 **Penglai v0.5.9**，基于官方 DSH `0.1.2-alpha.2` npm cohort。蓬莱办公与蓬莱记忆为 required-builtin DSH 插件；消息连接、语音识别、语音生成、主动陪伴随包但默认关闭。机器可读候选身份只来自 `packages/release-identity/src/pins.ts` 与 `release-contract.json`，公开下载事实只来自不可变 GitHub Release 回读。
-- 三个 target key 全仓统一：`darwin-aarch64`、`darwin-x86_64`、`win32-x86_64`。0.5.9 目标安装包分别为 `Penglai_0.5.9_macos_aarch64.dmg`、`Penglai_0.5.9_macos_x64.dmg`、`Penglai_0.5.9_windows_x64_setup.exe`。禁止把 ARM Electron 改名成 Intel 包；禁止把 Windows 预检或交叉编译写成 native PASS。
+- 当前产品与发布契约为 **Penglai v0.5.10**，基于官方 DSH `0.1.2-rc.1` npm cohort。蓬莱办公与蓬莱记忆为 required-builtin DSH 插件；消息连接、语音识别、语音生成、主动陪伴随包但默认关闭。机器可读候选身份来自 `packages/release-identity/src/pins.ts` 与 `release-contract.json`；该目标不代表已经公开，公开下载事实只来自不可变 GitHub Release 回读。
+- 三个 target key 全仓统一：`darwin-aarch64`、`darwin-x86_64`、`win32-x86_64`。0.5.10 目标安装包分别为 `Penglai_0.5.10_macos_aarch64.dmg`、`Penglai_0.5.10_macos_x64.dmg`、`Penglai_0.5.10_windows_x64_setup.exe`。禁止把 ARM Electron 改名成 Intel 包；禁止把 Windows 预检或交叉编译写成 native PASS。
 - 0.5.0 已发布的 Apple Silicon 客户端只能手动覆盖安装到 0.5.1；0.5.1 之后同平台才走 PUDP。不得声称 0.5.0 可一键升级。Intel/Windows 在 0.5.0 没有客户端，视为全新安装。
 - PPDP 是 0.5.1 产品能力，不是未来 TODO：签名目录、受限 GitHub 资产下载、默认禁用、主进程 Owner capability、DSH loader/profile 事务、inventory 回读。
 - 本地语音与第一方插件合同：`@penglai/asr`、`@penglai/moss-tts` 必须进入真实 DSH loader/Center，并服务 DSH Web 与 live 微信/飞书的受支持能力。会话 Read 朗读原文，不冒充翻译。`@penglai/office` 与 `@penglai/memory` 是 required-builtin；`@penglai/im`、`@penglai/asr`、`@penglai/moss-tts`、`@penglai/companion` 随包且默认关闭。旧 `@penglai/context` 只用于迁移。Goal/Todo/Skills/MCP/Web/图片 Attachments/Schedule/TokenMeter 使用 official DSH；rc.2 没有 generic file Turn API 时不得用 DOM hack 或第二会话引擎补齐。
@@ -49,7 +49,7 @@
 - community trust tier 不变：macOS ad-hoc / not notarized；Windows 无 Authenticode/SmartScreen 声誉。安装包及更新/插件清单仍须有 SHA-256、SBOM/notices，并诚实提示系统信誉警告。Penglai 自己的 Ed25519 更新/插件签名必须使用。
 - GitHub Actions 与 required CodeQL 当前可用，但不能替代安装包验收。Apple Silicon 本机可产生 darwin-aarch64 候选；Intel 与 Windows 的 native PASS 必须来自对应原生 runner。交叉构建或 Rosetta 只能作为补充证据。
 - 默认“智能整理 Workspace”：自动 curator 必须走 official Agent、禁用工具、Host 封闭校验，只能把安全项目事实写入 exact Workspace；个人/全局记忆仍需 Owner 确认，召回不得跨 Workspace。
-- Owner 已授权 0.5.9 在 `0.5.9-preview` 开发与分批推送，并在完整审核与必需门禁通过后创建 PR、合并 `main`、从同一干净 main SHA 完成三端原生构建与 `v0.5.9` 公开发布。README 观察值和官网只能在不可变公网字节回读通过后更新。仍不得把临时 API key、聊天正文、二维码、账号身份、私有路径、profile、凭据或私钥上传到 GitHub、写入 evidence 或安装包。
+- Owner 已授权 0.5.10 功能分支开发与推送，在完整审核和正常门禁通过后创建 PR、合并 main，从同一干净 main SHA 完成三端原生构建及完整十项附件发布，随后更新 README、官网与公开文档。两小时测试不运行，也不是补充待办。临时 API key、聊天正文、二维码、账号身份、私有路径、profile、凭据或私钥仍不得上传。
 
 0.5.8 的预览方向不改写已经公开的 0.5.7 tag、Release、附件或历史文档。迁移到新 DSH 时必须从现行源代码与产品表面移除 WhatsApp 的说明卡、channel identity、连接路径、adapter/runtime 接线、Baileys/libsignal 依赖以及任何支持或路线图声明；Git 历史与明确标注为历史的发行审计记录继续保留。移除完成后需用 catalog、依赖闭包、lockfile、SBOM、许可证、安装包内容和用户界面反向证明 WhatsApp 不再属于 Penglai。
 
@@ -82,3 +82,5 @@
 - 是否把下载目录、renderer `confirmed: true` 或未进入 DSH inventory 的包写成插件已启用？
 
 只要存在一个“是”，该候选就不是本产品定义下的蓬莱。
+
+0.5.10 固定官方 DSH `dsh-v0.1.2-rc.1` / `a66e4702047846cdaa10c66c9d3df3951f5ea70d`，消费完整 254 包官方 npm cohort，验证原始 tarball、registry 签名、源码 manifest 与冻结依赖。消息、预算和陪伴回放使用官方 `snapshotEvents()`；0.5.8、0.5.9 升级均保留旧 Home，并在独立 rc.1 代际健康检查通过后切换。正常测试、三端原生证据、完整草稿验签、不可变公开字节和双语文档/官网分别取证；历史发行记录不改写。

--- a/docs/ACCEPTANCE.md
+++ b/docs/ACCEPTANCE.md
@@ -1,30 +1,30 @@
 # Penglai 0.5.x 三端基础验收合同
 
-> 当前 0.5.7 在本合同的 R50/R55 能力类别基础上增加
-> `docs/0.5.7/ACCEPTANCE_DELTA.md`。本文保留历史机器可解析 Hard ID，精确版本、
+> 当前 0.5.10 在本合同的 R50/R55 能力类别基础上增加
+> `docs/0.5.10/ACCEPTANCE_DELTA.md`。本文保留历史机器可解析 Hard ID，精确版本、
 > 文件名与公开目标以 `release-contract.json` 为准；任何旧版本字样都不能覆盖当前
-> 0.5.7 机器身份。
+> 0.5.10 机器身份。
 
 ## 1. 判定对象与结论
 
-当前唯一验收对象是一个 exact `Penglai 0.5.7` release set：同一 clean source、同一 deterministic public-export tree、Apple Silicon DMG、Intel Mac DMG、Windows x64 Setup、配套 manifests/SBOM/notices。三个安装包必须来自同一 source SHA；交叉构建只能作为预检，不能替代对应原生 runner。0.5.7 的自动记忆、Owner Broker、Artifact、IM 可用性、TTS 与隐私增量必须同时通过 delta 合同。
+当前唯一验收对象是一个 exact `Penglai 0.5.10` release set：同一 clean source、同一 deterministic public-export tree、Apple Silicon DMG、Intel Mac DMG、Windows x64 Setup、配套 manifests/SBOM/notices。三个安装包必须来自同一 source SHA；交叉构建只能作为预检，不能替代对应原生 runner。自动记忆、Owner Broker、Artifact、IM、TTS 与隐私既有能力继续适用，并叠加 0.5.10 的 rc.1 npm cohort、Session 快照与两代 Home 升级合同。
 
 允许结论：
 
 - `PASS`：所有适用的自动化、native、installed 与 public-release Hard PASS，exact set冻结。
-- `OWNER_ACCEPTANCE_PENDING`：需要所有者账号或长时间运行的补充验收尚未发生；不得冒充 PASS，也不覆盖已完成的自动化/native/public 证据。
+- `OWNER_ACCEPTANCE_PENDING`：需要所有者账号的补充验收尚未发生；不得冒充 PASS，也不覆盖已完成的自动化/native/public 证据。
 - `FAIL`：任一适用发布 Hard FAIL、STALE、MISSING、伪造或产品偏航；已执行的补充验收若发现真实失败，也必须单独处置。
 
 `SKIP`、`BLOCKED`、`NOT_RUN`、`WAIVED`、`UNKNOWN`、`INCOMPLETE`都不是PASS。本版没有条件豁免。community trust tier中的`notarized=false`是候选定义的受验事实，不是被豁免的OS信任门。
 
 ## 2. Evidence 规则
 
-以下每一行都是对应证据类别内的 Hard assertion。registry 继续保留 R50/R55 的机器可解析 ID，并由 0.5.7 delta 增加本轮产品门；基础表预期共 **330** 个唯一 ID。实现必须动态解析，不能把计数写成散落的完成映射。每个ID必须指向真实runner的具体assertion，包含candidate/source/export/target/artifact/runner native/时间/exit/result digest。不能通过文件名、字符串存在或一个smoke扇出PASS。需要所有者账号或长时间运行的 live/soak assertion 属补充验收：缺失不能冒充 PASS，也不作为自动化发布聚合的永久阻塞项。
+以下每一行都是对应证据类别内的 Hard assertion。registry 继续保留 R50/R55 的机器可解析 ID，并由 0.5.10 delta 增加本轮产品门；基础表预期共 **330** 个唯一 ID。实现必须动态解析，不能把计数写成散落的完成映射。每个ID必须指向真实runner的具体assertion，包含candidate/source/export/target/artifact/runner native/时间/exit/result digest。不能通过文件名、字符串存在或一个smoke扇出PASS。需要所有者账号的 live/soak assertion 属补充验收：缺失不能冒充 PASS，也不作为自动化发布聚合的永久阻塞项。
 
 平台标记：
 
 - `all`：平台类门禁展开为全部三个目标；非平台类门禁只执行一次源码/聚合检查。
-- `mac-arm`、`mac-x64`、`win-x64`：分别绑定三个 exact native artifact，均参与 0.5.7 PASS。
+- `mac-arm`、`mac-x64`、`win-x64`：分别绑定三个 exact native artifact，均参与 0.5.10 PASS。
 - `live`：真实账户最后集中执行。
 - `aggregate`：release-set/public-export聚合。
 
@@ -34,14 +34,14 @@
 
 | ID | 要求 | Runner |
 | --- | --- | --- |
-| `R50-TRUTH-001` | root/workspace/desktop/profile/plugin/release contract版本全部为当前 `release-contract.json` 的 0.5.7 | contract/all |
+| `R50-TRUTH-001` | root/workspace/desktop/profile/plugin/release contract版本全部为当前 `release-contract.json` 的 0.5.10 | contract/all |
 | `R50-TRUTH-002` | candidateKind、trustTier、generation、三个target与三个exact filename一致 | contract/all |
 | `R50-TRUTH-003` | 旧alpha artifact/evidence/READY全部STALE并被verifier拒绝 | failure/all |
 | `R50-TRUTH-004` | UNFROZEN identity不得携带artifact/signature/live/READY | unit/all |
 | `R50-TRUTH-005` | release branch/PR 可审计且不 force；合并前不创建公开 tag，合并后 main 必须保持 exact candidate source | git/aggregate |
 | `R50-TRUTH-006` | candidate freeze 时 HEAD 已推送、dirty=false；公开 freeze 时 `origin/main` 必须等于同一 source SHA | git/aggregate |
 | `R50-TRUTH-007` | 任一适用发布硬子门FAIL/INCOMPLETE/STALE都使verify:release non-zero；补充验收另列 | fault/all |
-| `R50-TRUTH-008` | repo=`kevinchennewbee/PenglaiAgent`、tag/release=`v0.5.7`，且发布前 updater Release 不得冒充已公开 | manifest/aggregate |
+| `R50-TRUTH-008` | repo=`kevinchennewbee/PenglaiAgent`、tag/release=`v0.5.10`，且发布前 updater Release 不得冒充已公开 | manifest/aggregate |
 
 ### B. DSH唯一核心与 capability parity（8）
 
@@ -66,7 +66,7 @@
 | `R50-UI-004` |light/dark/system三态覆盖全部Penglai UI | visual/all |
 | `R50-UI-005` |system主题运行时变化即时响应并持久 | installed/all |
 | `R50-UI-006` |品牌overlay不阻断DSH导航、Models、Workspace、Session、设置 | parity/all |
-| `R50-UI-007` | About 显示 0.5.7、DSH/target/trust/data/license 准确 | installed/all |
+| `R50-UI-007` | About 显示 0.5.10、DSH/target/trust/data/license 准确 | installed/all |
 | `R50-UI-008` |UI/README不出现已公证、Authenticode或silent auto-update误述 | content/aggregate |
 
 ### D. 首次引导、多API、Workspace与Turn（12）
@@ -240,7 +240,7 @@
 | `R50-UPD-009` |新版本 post-verify 只要求核心 runtime/profile/required-plugin/DSH 健康；IM 等可选插件保持默认停用也必须 commit。失败则 rollback/recovery；只有真实安装了更高版本才可把旧 `RECOVERY_REQUIRED` 账本纠正为 current，且不得伪造签名升级 ledger | chaos+installed/all |
 | `R50-UPD-010` |每个update state crash可重放，inbox/outbox不丢不双发 | chaos/all |
 | `R50-UPD-011` |fixture key/server/test payload不进入production artifact | artifact/all |
-| `R50-UPD-012` |三个 native target 的 0.5.7→test-next valid/failure suites PASS，且 Apple Silicon 受支持旧版→公开版 0.5.7 实装升级 PASS | installed/all |
+| `R50-UPD-012` |三个 native target 的 0.5.10→test-next valid/failure suites PASS，且 Apple Silicon 受支持旧版→公开版 0.5.10 实装升级 PASS | installed/all |
 
 ### O. 卸载、数据管理与legacy隔离（10）
 
@@ -270,7 +270,7 @@
 | `R50-REL-007` |contrast/200% zoom/reduced motion/QR替代状态通过 | a11y+visual/all |
 | `R50-REL-008` |cold/warm startup、DSH ready、idle CPU/memory在预算 | perf/all |
 | `R50-REL-009` |queue throughput/backpressure/DB growth在预算 | load/all |
-| `R50-REL-010` |exact installed artifact两小时soak无孤儿/泄漏/失联 | soak/all |
+| `R50-REL-010` |历史长时稳定性项；0.5.10 按 Owner 指令 NOT_APPLICABLE，不运行、不作为待办；正常有限负载回归另行执行 | soak/all |
 
 ### Q. Security、隐私与供应链（12）
 
@@ -406,13 +406,13 @@
 | `R50-COMP-007` |trigger claim/Turn/outbox/delivery durable，sleep/wake/restart/clock jump不重复，disable/logout资源为零 | chaos+installed/all |
 | `R50-COMP-008` |三个exact installed target完成virtual-clock text/voice/quiet-hours/disable suite，live只留opaque trigger证据 | installed+live/all |
 
-### R55. 0.5.5 产品增量（作为 0.5.7 基础继续执行）
+### R55. 0.5.5 产品增量（作为 0.5.10 基础继续执行）
 
 #### Truth / DSH（8）
 
 | ID | 要求 | Runner |
 | --- | --- | --- |
-| `R55-TRUTH-001` | all product/package/release versions exact current 0.5.7 | contract/all |
+| `R55-TRUTH-001` | all product/package/release versions exact current 0.5.10 | contract/all |
 | `R55-TRUTH-002` | DSH exact rc.2 commit/integrity/shasum | contract/all |
 | `R55-TRUTH-003` | only three exact target installers | contract/all |
 | `R55-TRUTH-004` | no package/tag/release drift from the current release contract | contract/all |
@@ -536,4 +536,4 @@
 - 任一平台使用cross/translated/emulated结果冒充native，或Release缺少/多出未验收的三端安装包。
 - verifier INCOMPLETE却exit 0、Hard ID硬编码PASS、旧SHA/evidence复用。
 - ad-hoc候选被称为已公证、Developer ID或系统信任。
-- 未经 Owner 明确授权修改开源仓库或发布；0.5.7 已获授权，但任一必需门禁失败仍一票否决。
+- 未经 Owner 明确授权修改开源仓库或发布；0.5.10 已获授权，但任一必需门禁失败仍一票否决。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# Penglai 0.5.7 architecture
+# Penglai 0.5.10 architecture
 
 ## English
 
@@ -17,7 +17,7 @@ Penglai.app / Penglai.exe
       ├─ plugin-center
       ├─ office ───────────────┐
       ├─ memory + Mnemon       ├─ scoped Artifact Service / Owner Broker
-      ├─ im ─ Weixin / Feishu ┘
+      ├─ im ─ eight adapters ┘
       ├─ asr / moss-tts
       └─ companion / hidden budget control / hidden conformance fixture
 ```
@@ -74,7 +74,9 @@ paths rather than a hard-coded home directory.
 ```text
 <Penglai 0.5 user data>/
 ├─ release/             updater ledger, journals, current identity
-├─ dsh-home/            official settings, profile, credentials, plugins
+├─ dsh-home/            preserved alpha.1 settings and data
+├─ dsh-homes/           isolated alpha.2 and rc.1 generations
+├─ dsh-home-active.json verified active generation pointer
 ├─ owner/               approval broker state and completed-action ledger
 ├─ artifacts/           scoped CAS, bindings, staging, retention index
 ├─ im/                  SQLite, adapter state, inbox/outbox, bindings
@@ -120,9 +122,16 @@ after a real official DSH reply and a successful switch to official DSH Web.
 
 ### 5. Profile composition
 
+The complete official npm cohort contains 254 verified packages pinned to
+`dsh-v0.1.2-rc.1` at `a66e4702047846cdaa10c66c9d3df3951f5ea70d`.
+Official DSH bytes are unmodified; Penglai composes official client slots.
+Session recovery consumers use `snapshotEvents()` and fail on missing capability.
+Both previous Home generations are copied into rc.1 before a health-verified
+activation; rollback restores the previous pointer and preserves its data.
+
 Fresh profile invariants:
 
-- official DSH `0.1.1-rc.2` is pinned with exact npm integrity and source tag;
+- official DSH `0.1.2-rc.1` is pinned with exact npm integrity and source tag;
 - Plugin Center, Office, and Memory are installed and active;
 - IM, ASR, MOSS-TTS, and Companion are present in the installer but disabled;
 - the reference fixture and budget control are internal/hidden; and
@@ -169,7 +178,7 @@ return, and undo use the Owner broker. Destination becomes immutable after the
 first commit. Backup identity includes operation, revision, and source digest.
 The approval is completed after the output mutation or IM return, never before.
 
-Official DSH rc.2 has text/image prompt parts only. Generic composer files are
+Official DSH 0.1.2-rc.1 has text/image prompt parts only. Generic composer files are
 therefore an explicit upstream boundary. Penglai uses official image storage for
 images and the Artifact Service for Office/IM consumers without adding a second
 Turn representation.
@@ -207,9 +216,9 @@ deterministic commands, correlation, causal routing, recovery, and diagnostics.
 `LIVE_CHANNEL_IDS` is evidence-gated. Weixin and Feishu retain their distributed
 adapter and migration paths from 0.5.6; that source/runtime continuity is not a
 substitute for evidence bound to a later installed release.
-The other six distributed platforms receive adapters in 0.5.7 and join
-`LIVE_CHANNEL_IDS` only after acceptance. The user-facing surface exposes eight
-connection actions plus a disabled WhatsApp compatibility card.
+All eight platforms expose real adapters. Entry availability does not prove an
+account connection or delivery; those require the corresponding live evidence.
+WhatsApp has no card, connection action, runtime or planned support.
 
 Inbound sequence:
 
@@ -276,13 +285,13 @@ readback downloads and verifies the immutable bytes again.
 
 ## 中文摘要
 
-0.5.7 仍以 official DSH 为唯一 Agent/模型/工具/审批/Workspace/Session/Turn/UI
+0.5.10 仍以 official DSH 为唯一 Agent/模型/工具/审批/Workspace/Session/Turn/UI
 核心。Electron Main 负责进程、Owner Broker、OS 权限、升级和卸载；renderer 只能用
 窄 preload 与 typed Remote，不能读文件、密钥或任意 IPC。
 
 办公、IM 文件与持久附件统一使用绑定 scope 的 `artifact:<uuid>`；确认与具体动作、
 对象、Workspace/Session、摘要、目标和 revision 绑定，真实写入/发送/事务成功后才完成。
-official DSH rc.2 没有通用 file Turn，0.5.7 不做 DOM hack 或第二会话表示。
+official DSH 0.1.2-rc.1 没有通用 file Turn，0.5.10 不做 DOM hack 或第二会话表示。
 
 记忆在 official `turn/end` 运行禁用工具的 official curator Agent，Host 做封闭格式和
 本地风险校验；安全项目事实只自动写当前 Workspace。`agent/pre-step` 只召回当前
@@ -290,8 +299,7 @@ Workspace 与明确个人记忆，绝不跨 Workspace。资料撤销删派生索
 
 IM 始终只有一个 `@penglai/im` 控制平面。微信、飞书、钉钉、企业微信和 QQ 只在
 供应商协议真实提供时显示 QR/device-link；Slack、Telegram、Discord 使用官方
-Manifest/Token，不伪造二维码。WhatsApp runtime 不随 0.5.7 分发，说明卡没有连接
-动作。ASR 麦克风需要当前手势并只申请 audio；TTS 试听和 Read 共用一个可观测播放
+Manifest/Token，不伪造二维码。WhatsApp 不展示、不支持、不列为规划，也不捆绑运行时。ASR 麦克风需要当前手势并只申请 audio；TTS 试听和 Read 共用一个可观测播放
 状态机，Read 朗读原文。
 
 三端安装包必须来自同一干净 SHA 和 public-export tree，在对应原生 runner 验收。

--- a/docs/IM_PLUGIN.md
+++ b/docs/IM_PLUGIN.md
@@ -1,11 +1,11 @@
 # `@penglai/im` 完整产品与协议合同
 
-> 0.5.8 用户只看到一个「消息连接」插件。八个平台都有真实连接入口，不再把新增渠道
-> 显示为路线图。manifest 的 `live` 是历史兼容字段，表示 0.5.8 包含真实 adapter
+> 0.5.10 用户只看到一个「消息连接」插件。八个平台都有真实连接入口，不再把新增渠道
+> 显示为路线图。manifest 的 `live` 是历史兼容字段，表示 0.5.10 包含真实 adapter
 > 实现，不表示当前用户已启用或已通过 live-account 验收。没有
 > 对应 live evidence 时，不得把该平台写入 README/官网/Release 的“全部支持”
 > 声明，也不得把图片/文件/音频/Markdown/线程/群聊标为 `true`。Slack、Telegram、
-> Discord 禁止伪装扫码。WhatsApp 在 0.5.8 中不展示、不支持、不列为规划，也不捆绑
+> Discord 禁止伪装扫码。WhatsApp 在 0.5.10 中不展示、不支持、不列为规划，也不捆绑
 > 运行时。下文微信/
 > 飞书合同继续约束已有 live 路径；新渠道只有通过 adapter、health、send-reject
 > 和 live evidence 后才能进入 `LIVE_CHANNEL_IDS`。
@@ -18,7 +18,7 @@
 
 ## 2. 默认行为
 
-- fresh 0.5.8 profile 离线携带并登记 `@penglai/im`，但默认 `disabled`，不会进入 active loader roster，也不会启动 adapter 网络活动。
+- fresh 0.5.10 profile 离线携带并登记 `@penglai/im`，但默认 `disabled`，不会进入 active loader roster，也不会启动 adapter 网络活动。
 - 用户在 Center 明确选择“安装并启用”后，package transaction 才写入 profile、启用 loader，并验证 actual active/healthy；此后未配置 adapter 时不联网、不启动 auth poll。
 - 未配置 adapter 时不联网、不启动 auth poll，但 Remote/UI/diagnostics 可用。
 - official Models API key 测试、default model 和 Workspace 就绪后，onboarding 自动进入“连接消息渠道”步骤。
@@ -29,7 +29,7 @@
 
 ## 3. UI 结构
 
-UI 位于 official DSH Web 的“设置 → 蓬莱 → 消息连接”嵌套子菜单，不是另一个窗口或内容区第三列。`@penglai/im` 使用 official `settings.section` 与保留的 `penglai-*` section id 注册自己的页面；固定的 DSH 0.1.2-alpha.1 源码没有父子 section schema且会丢弃未知 option，因此 exact-hash settings renderer overlay 只按该 id 命名空间渲染嵌套组，不改变 DSH settings/Agent/runtime。停用 IM 只移除 active 页面与相关 host 资源，不影响 DSH 或其他蓬莱插件。首次启用后，Center 明示状态并应用内 reload client roster，随后子菜单出现“消息连接”，其微信/飞书页只提供厂商真实支持的连接流程。
+UI 通过 official DSH Web 的设置 section 提供消息连接页面，不另建窗口或第二套设置引擎。`@penglai/im` 使用 official `settings.section` 与保留的 `penglai-*` section id 注册自己的页面；固定的 DSH `0.1.2-rc.1` 使用未经修改的官方 npm 字节，页面通过官方 client slots、connection generation 与 typed Remote 组合，不再应用旧版 settings renderer overlay。停用 IM 只移除 active 页面与相关 host 资源，不影响 DSH 或其他蓬莱插件。首次启用后，Center 明示状态并应用内 reload client roster，随后子菜单出现“消息连接”，其微信/飞书页只提供厂商真实支持的连接流程。
 
 “绑定”页必须为每个真实 binding 提供可视化 `inputMode`、`replyMode` 与 MOSS `voiceId` 控件；它们与 `/语音`、`/声音` 写入同一个 IM core 持久策略。ASR/TTS 未安装或模型未 ready 时显示实际能力状态并安全降级，不能显示假开关。微信原生语音必须先从该页发送 live probe，再由用户确认客户端里确实出现可播放气泡；仅 API 成功不自动启用。
 
@@ -304,4 +304,4 @@ SQLite表：accounts、adapter_configs、bindings、vendor_reply_targets、inbox
 
 ## 15. 明确非目标
 
-群聊、视频、未审核富卡片、飞书 OAuth Device Flow、Penglai 托管应用、云路由、遥测，以及 adapter 独立 Agent runtime 均不在 0.5.8。图片必须走 official image store；普通文件必须走 scope-checked Artifact Service，不能把任意媒体伪装成文本或图片进入模型。
+群聊、视频、未审核富卡片、飞书 OAuth Device Flow、Penglai 托管应用、云路由、遥测，以及 adapter 独立 Agent runtime 均不在 0.5.10。图片必须走 official image store；普通文件必须走 scope-checked Artifact Service，不能把任意媒体伪装成文本或图片进入模型。

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -1,4 +1,4 @@
-# Penglai 0.5.7 product contract
+# Penglai 0.5.10 product contract
 
 ## English
 
@@ -11,8 +11,8 @@ first run, process supervision, local data boundaries, assisted updates,
 uninstall, and a reviewed set of DSH plugins. It does not ship a second agent,
 provider gateway, session store, or chat page.
 
-Version 0.5.7 targets Apple Silicon, Intel Mac, and Windows x64 with official DSH
-`0.1.1-rc.2`. A fresh user brings a provider credential, selects an official
+Version 0.5.10 targets Apple Silicon, Intel Mac, and Windows x64 with official DSH
+`0.1.2-rc.1`. A fresh user brings a provider credential, selects an official
 model and Workspace, receives a real first DSH reply, and then uses the official
 DSH Web interface.
 
@@ -20,9 +20,9 @@ DSH Web interface.
 
 | Device | Exact installer |
 | --- | --- |
-| Apple Silicon, macOS 13+ | `Penglai_0.5.7_macos_aarch64.dmg` |
-| Intel Mac, macOS 13+ | `Penglai_0.5.7_macos_x64.dmg` |
-| Windows 10+ x64 | `Penglai_0.5.7_windows_x64_setup.exe` |
+| Apple Silicon, macOS 13+ | `Penglai_0.5.10_macos_aarch64.dmg` |
+| Intel Mac, macOS 13+ | `Penglai_0.5.10_macos_x64.dmg` |
+| Windows 10+ x64 | `Penglai_0.5.10_windows_x64_setup.exe` |
 
 The app contains its target Electron, Node, DSH closure, profile seed, bundled
 plugins, licenses, and integrity metadata. It never falls back to a system Node,
@@ -36,7 +36,7 @@ and installed test on the matching native platform.
 | Plugin Center | Active | Shows real DSH loader state and signed catalog transactions |
 | Penglai Office | Active | Inspect, create, plan edits, preview, commit, export/return, and undo DOCX/XLSX/PPTX/PDF |
 | Penglai Memory | Active | Automatic current-Workspace memory, explicit personal memory, authorised sources, provenance, and graph views |
-| Mobile Messaging | Disabled | Live Weixin and Feishu adapters only |
+| Mobile Messaging | Disabled | Eight adapters; account connectivity is reported only with actual evidence |
 | Speech Recognition | Disabled | Local SenseVoice transcription after explicit model installation and microphone action |
 | Voice Generation | Disabled | Local MOSS-TTS preview, conversation Read, and supported channel audio |
 | Companion | Disabled | Opt-in scheduled contact with quiet hours, budget, and an exact IM route |
@@ -91,7 +91,7 @@ Write, export, return, and undo approval binds the exact job, source/result
 digest, destination, Workspace, Session, and revision. Approval completes only
 after the mutation or delivery succeeds.
 
-Official DSH rc.2 conversation Turns support text and images, not generic file
+Official DSH 0.1.2-rc.1 conversation Turns support text and images, not generic file
 blocks. Penglai therefore does not claim ordinary composer DOCX/XLSX/PPTX/PDF
 attachments. Official images continue through the official image store. Files
 received through live IM or selected through Office use the scoped artifact
@@ -103,10 +103,8 @@ service without DOM injection or a second conversation engine.
 commands, causal routing, persistence, recovery, outbox, and adapter lifecycle.
 Adapters cannot call a parallel agent or guess the current Workspace/Session.
 
-Eight platforms have connection entry points in 0.5.7. Slack, Telegram, and
-Discord use official token/manifest flows and must not fake QR. The WhatsApp
-community runtime and its GPL transitive dependency are not distributed in
-0.5.7; its compatibility card has no connection action. Binding, rebinding,
+Eight platforms have connection entry points in 0.5.10. Slack, Telegram, and
+Discord use official token/manifest flows and must not fake QR. WhatsApp is not displayed, supported, planned, or bundled in 0.5.10. Binding, rebinding,
 and removal require an Owner approval bound to the exact channel, account,
 peer, Workspace, and Session.
 
@@ -165,10 +163,13 @@ macOS is ad-hoc signed and not notarized. Windows has no Authenticode.
 Gatekeeper or SmartScreen may warn. Penglai Ed25519 signatures protect updater
 and plugin bytes but do not provide Apple or Microsoft publisher identity.
 
-0.5.7 succeeds only when one clean source SHA produces all three native
+0.5.10 succeeds only when one clean source SHA produces all three native
 installers, source/security/privacy gates pass, installed evidence exists on
-each matching runner, the Apple Silicon provider path receives a real first
-Turn, and the immutable ten-asset Release passes public byte-for-byte readback.
+each matching runner, and the immutable ten-asset Release passes public
+byte-for-byte readback. Credential-free gates do not establish an external model
+reply or account delivery. Account-based results are recorded only when executed.
+Normal functional tests apply; a two-hour installed soak is not required or pending.
+See [the current acceptance delta](0.5.10/ACCEPTANCE_DELTA.md).
 
 ## 中文
 
@@ -179,7 +180,7 @@ Agent、模型、工具、审批、Workspace、Session、Turn 和会话 UI。蓬
 首次引导、进程监管、本地数据边界、辅助升级、卸载和经过审核的 DSH 插件，不另造
 Agent、模型网关、Session 存储或聊天页。
 
-0.5.7 固定 DSH `0.1.1-rc.2`，支持 Apple 芯片、Intel Mac 和 Windows x64。
+0.5.10 固定 DSH `0.1.2-rc.1`，支持 Apple 芯片、Intel Mac 和 Windows x64。
 用户自备模型密钥，选择 official 模型和 Workspace，收到第一条真实 DSH 回复后进入
 official DSH Web。
 
@@ -211,15 +212,14 @@ official Agent 沿用当前供应商和模型，输出由 Host 封闭校验。�
 symlink/device/directory、加密/宏、可执行文件、嵌套压缩和 scope 都由 Host 校验。
 
 写入、导出、回传、撤销确认会绑定 job、摘要、目标、Workspace、Session 和 revision，
-只有真实动作成功后才完成。official DSH rc.2 会话 Turn 只支持文字和图片，因此 0.5.7
+只有真实动作成功后才完成。official DSH 0.1.2-rc.1 会话 Turn 只支持文字和图片，因此 0.5.10
 不宣称输入框能直接发普通 DOCX/XLSX/PPTX/PDF。official 图片不变；IM 收到的文件或
 蓬莱办公选择的 Workspace 文件走 artifact service，不做 DOM hack 或第二会话引擎。
 
 ### 5. IM 与语音
 
-`@penglai/im` 是唯一消息插件。0.5.7 提供八个平台连接入口。Slack、Telegram、
-Discord 走官方 Token/Manifest，禁止伪装扫码。WhatsApp 社区协议 runtime 及其 GPL
-传递依赖不随 0.5.7 分发；兼容性说明卡没有连接动作。
+`@penglai/im` 是唯一消息插件。0.5.10 提供八个平台连接入口。Slack、Telegram、
+Discord 走官方 Token/Manifest，禁止伪装扫码。WhatsApp 不展示、不支持、不列为规划，也不捆绑运行时。
 
 ASR/TTS 代码随包，大模型权重只在用户明确操作后下载。麦克风必须由当前用户手势触发，
 只申请 audio；相机、视频、蓝牙和无关 capture 权限不进入产品声明。设置页试听与会话
@@ -244,6 +244,7 @@ patch 之后硬性禁用该行，因此 owned DSH 进程不会创建 SDK provide
 0.5.0 仍需手动覆盖。默认卸载保留用户数据，完整删除必须按精确类别确认，不能删除
 Workspace、授权源、home/root、旧代数据或越界链接。
 
-macOS 为 ad-hoc 签名且未公证；Windows 没有 Authenticode。0.5.7 只有在同一干净
-源码 SHA 的三端原生包、三端安装证据、真实模型 Turn、隐私门禁和不可变十资产公网
-回读全部成立时，才算发布完成。
+macOS 为 ad-hoc 签名且未公证；Windows 没有 Authenticode。0.5.10 只有在同一干净
+源码 SHA 的三端原生包、三端安装证据、隐私门禁和不可变十资产公网回读全部成立，
+且当前 README 与双语官网同步后，才算完成正常发布。无凭据测试不能证明真实模型
+Turn 或账号消息送达；账号验证只记录实际执行结果。两小时测试不运行，也不是待办。

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,4 +1,4 @@
-# Penglai 0.5.8 安全与隐私合同
+# Penglai 0.5.10 安全与隐私合同
 
 ## 1. 信任目标
 
@@ -60,7 +60,7 @@ TCB包括Electron main/preload、embedded target Node、pinned DSH、profile/Cen
 - 同OS用户高权限本地进程可能读取文件，UI/文档必须诚实。
 - permission/ACL invalid、corrupt、write denied、resolve failed全部fail closed；无env/MemoryVault/SQLite/Keychain fallback。
 - 0.4.1 credential不读取、迁移或删除。
-- official DSH 0.1.2-alpha.1 源码内含 session-telemetry adapter 和预配置的 DeepSeek OTLP 地址。
+- official DSH 0.1.2-rc.1 源码内含 session-telemetry adapter 和预配置的 DeepSeek OTLP 地址。
   蓬莱不运营该后端；owned DSH 的封闭环境白名单固定注入
   `DSH_TELEMETRY_DISABLED=1`，且不转发 `DSH_TELEMETRY_MODE` 或
   `DSH_TELEMETRY_OTLP_URL`。DSH 会在 profile patch 之后禁用该行，不创建 telemetry
@@ -182,16 +182,16 @@ TCB包括Electron main/preload、embedded target Node、pinned DSH、profile/Cen
 - secret/body/QR/owner-path scan覆盖repo/public-export/app/DMG/Setup/log/DB/diagnostics/evidence。
 - Context grant escape/document bomb/source-delete、Memory scope/global-consent、Budget concurrency/clock/IM bypass、Companion quiet-hours/no-tools/dedupe/route/resource-zero。
 
-## 18. 0.5.8 权限与附件增量
+## 18. 0.5.10 权限与附件增量
 
 - Renderer 的 `ownerConfirmed`、布尔值、UUID 外形或模型文本都不是权限。Office、Memory、IM、Plugin Center 和 artifact persistence 统一消费 Main Owner Broker receipt；receipt 绑定 action/object/Workspace/Session/digest/destination/revision，真实动作成功后才 complete。
 - Artifact ID 是不透明 `artifact:<uuid>`，不是 filesystem path 或 content hash。相同字节跨 Workspace 仍为不同 binding；legacy digest 只有唯一时才可解析。
-- official DSH 0.1.2-alpha.1 的通用会话附件能力只按真实接口与安装证据声明。0.5.8 不用 DOM hack、假 image 或第二会话引擎制造普通文件附件；Office/IM 文件走 scope-checked Artifact Service。
+- official DSH 0.1.2-rc.1 的通用会话附件能力只按真实接口与安装证据声明。0.5.10 不用 DOM hack、假 image 或第二会话引擎制造普通文件附件；Office/IM 文件走 scope-checked Artifact Service。
 - macOS 包只声明双语麦克风用途，并剥离 Electron 默认 camera、Bluetooth 与无关 capture permission。Main 只允许由当前用户手势触发的 audio 请求。
-- 0.5.8 的唯一「消息连接」插件提供八个平台的真实连接 adapter；公开能力边界以
+- 0.5.10 的唯一「消息连接」插件提供八个平台的真实连接 adapter；公开能力边界以
   当前产品合同和对应证据为准。微信、飞书、钉钉、企业微信、QQ 只显示供应商真实
   QR/注册 challenge；Slack、Telegram、Discord 没有对应的官方扫码流程，必须如实
   使用官方 Manifest/Token，不得生成假 QR 或把 UI 状态冒充已连接。WhatsApp 在
-  0.5.8 中不展示、不支持、不列为规划，也不捆绑运行时。
+  0.5.10 中不展示、不支持、不列为规划，也不捆绑运行时。
 
 任一Critical/High或可复用secret泄漏都使候选FAIL。若真实凭据可能泄漏，立即停止、通知用户轮换、作废相关artifact/evidence；不得为了保住READY删日志掩盖。

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -396,6 +396,14 @@
 - 决定：Penglai 0.5.9 使用官方 npm `alpha` dist-tag 的精确 DSH `0.1.2-alpha.2`，对应 tag `dsh-v0.1.2-alpha.2` 与 commit `0a53fb55bea101816fa226bb964ae2bed71c343b`。发行输入必须是固定并带 registry integrity 的完整 257 包 DSH/vendor/Landlock cohort，不得混装 alpha.1，不得用源码路径、Git 依赖或本地重打包替代。依赖图、lockfile、runtime closure、profile、release identity、全部第一方插件与插件中心必须原子迁移；RemoteError、会话 projection、独立 DSH Home generation、连接生命周期、插件 inventory/事务/回滚及用户可见错误脱敏都须重新取证。alpha.2 是完整可消费的官方预发布版，不得宣称为 stable。
 - 后果：Owner 授权删除旧预览分支后在 `0.5.9-preview` 分批开发与推送；全部适用的源代码、合同、集成、安全、供应链、clean closure、installed/live/soak 与三端原生门禁通过后，创建 PR、合并 `main`，从同一干净 main SHA 构建并发布 v0.5.9。0.5.8 tag、附件、README/官网公开事实保持不可变；0.5.9 的 README、双语官网、Release Notes、摘要、大小与下载链接只能在不可变 GitHub Release 公网字节回读通过后写入并部署。
 
+### D-066 — 0.5.10 固定 rc.1 官方包、正常测试与完整发布
+
+- 日期：2026-09-03。
+- 决定：固定官方 DSH `0.1.2-rc.1`，tag `dsh-v0.1.2-rc.1`，commit `a66e4702047846cdaa10c66c9d3df3951f5ea70d`。完整 254 包 npm cohort、原始 tarball、registry 签名、固定源码 manifest 与可选间接依赖原子核对。
+- 适配：Session 快照用于消息恢复、预算和陪伴；0.5.8 / 0.5.9 的 Home 保留并复制到独立 rc.1 代际，健康检查后切换，回滚恢复旧指针。
+- 发布：Owner 已授权正常测试、推送、PR 合并、同一干净 main SHA 的三端原生构建与安装验证、十项完整签名附件、不可变公开回读、README 和双语官网收尾。两小时测试不执行，也不是待补证据。真实账号通信仅按实际执行结果声明。
+- 文档：开发期不能拿历史 0.5.8 文档断言充当当前发布 PASS；发布后的当前 README、SECURITY、站点与发布清单必须独立校验。本地操作 SOP 不公开。历史版本决议继续作为历史记录保留。
+
 ## Superseded
 
 已从执行面移出的决议正文：`D-014`、`D-020`、`D-021`、`D-025`、`D-030`。它们仍保留编号以便审计，但不得再当当前产品合同。

--- a/packages/release-identity/src/public-docs.test.ts
+++ b/packages/release-identity/src/public-docs.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { declaredSourceSha, recordAssertion } from "./assertion.js";
+import { PRODUCT_VERSION, PINNED_DSH } from "./pins.js";
 import {
   assertCommittedTemplateIdentity,
   assertObservedReleaseFacts,
@@ -12,7 +12,7 @@ import {
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "../../..");
 
-test("R50-PREP-007 release notes state fresh install, trust, upgrade and uninstall", () => {
+test("historical 0.5.8 release notes preserve their original release facts", () => {
   const notes = readFileSync(join(root, "docs/RELEASE_NOTES_0.5.8.md"), "utf8");
   assert.match(notes, /Settings → Penglai →\s*Updates/i);
   assert.match(notes, /0\.5\.1/);
@@ -27,19 +27,10 @@ test("R50-PREP-007 release notes state fresh install, trust, upgrade and uninsta
   assert.match(notes, /WhatsApp is not a 0\.5\.8 product surface/i);
   assert.match(notes, /LIVE_NOT_RUN/);
   assert.doesNotMatch(notes, /already notarized|App Store|zero-config Feishu|全自动升级/);
-  recordAssertion({
-    acceptanceId: "R50-PREP-007",
-    runnerId: "docs",
-    testId: "release-notes-public",
-    assertionId: "fresh-install-trust-upgrade-uninstall",
-    status: "PASS",
-    candidateSourceSha: declaredSourceSha(),
-    exitCode: 0,
-    details: { safe: "0.5.8 notes state the fixed DSH source, three targets, desktop fixes, upgrade, and trust limits" },
-  });
+
 });
 
-test("R50-PREP-008 publication manifest lists the exact three-target release", () => {
+test("historical 0.5.8 manifest preserves its exact three-target release", () => {
   const md = readFileSync(join(root, "docs/PUBLICATION_MANIFEST_0.5.8.md"), "utf8");
   const committed = assertReleaseIdentity(JSON.parse(readFileSync(join(root, "release-info.json"), "utf8")));
   assertCommittedTemplateIdentity(committed);
@@ -66,16 +57,7 @@ test("R50-PREP-008 publication manifest lists the exact three-target release", (
       sha: cell[2]?.replace(/`/g, "").trim(),
     });
   }
-  recordAssertion({
-    acceptanceId: "R50-PREP-008",
-    runnerId: "manifest",
-    testId: "publication-manifest-public",
-    assertionId: "exact-three-target-assets",
-    status: "PASS",
-    candidateSourceSha: declaredSourceSha(),
-    exitCode: 0,
-    details: { safe: "0.5.8 publication manifest lists three installers and the authorized public destination" },
-  });
+
 });
 
 test("fuse policy disables RunAsNode and inspect and forbids dryRun green", () => {
@@ -89,7 +71,7 @@ test("fuse policy disables RunAsNode and inspect and forbids dryRun green", () =
   assert.match(verify, /packaged-electron-framework-bytes/);
 });
 
-test("website keeps the full bilingual visual site and exact 0.5.8 downloads", () => {
+test("website keeps the full bilingual visual site during publication preparation", () => {
   const zh = readFileSync(join(root, "website/index.html"), "utf8");
   const en = readFileSync(join(root, "website/en/index.html"), "utf8");
   const css = readFileSync(join(root, "website/styles/main.css"), "utf8");
@@ -111,38 +93,65 @@ test("website keeps the full bilingual visual site and exact 0.5.8 downloads", (
   for (const html of [zh, en]) {
     assert.match(html, /shots\/banner-v1\.png/);
     assert.match(html, /shots\/0\.5\.5\/plugin-center\.png/);
-    assert.match(html, /Penglai_0\.5\.8_macos_aarch64\.dmg/);
-    assert.match(html, /Penglai_0\.5\.8_macos_x64\.dmg/);
-    assert.match(html, /Penglai_0\.5\.8_windows_x64_setup\.exe/);
-    assert.match(html, /cc08a1820f92be4fe5a851a4cfd33f02ab48035c8e98f72feacb2fd074a9b992/);
-    assert.match(html, /14d0c4edf572c134d9d71e6dea69a4bcf53b46cf31ed267fe8472c2f1a4c1b00/);
-    assert.match(html, /0a238bec35ea5117619a5112566ba6985f2194873eb60ef7110d1ca21bc1bec5/);
-    assert.match(html, /dsh-v0\.1\.2-alpha\.1/i);
-    assert.match(html, /internal-test notice|内测通知/i);
-    assert.doesNotMatch(html, /82\.156\.107\.151\/releases\/v0\.5\.8/);
-    assert.doesNotMatch(html, /releases\/download\/v0\.5\.6/);
-    assert.doesNotMatch(html, /releases\/v0\.5\.5/);
+
   }
   assert.match(css, /\.hero-art/);
   assert.match(css, /\.gallery/);
   assert.ok(css.length > 5000, "website stylesheet is unexpectedly reduced");
 });
 
-test("current security and IM documents match the immutable 0.5.8 eight-entry release", () => {
-  const publicSecurity = readFileSync(join(root, "SECURITY.md"), "utf8");
-  const securityContract = readFileSync(join(root, "docs/SECURITY.md"), "utf8");
-  const imContract = readFileSync(join(root, "docs/IM_PLUGIN.md"), "utf8");
-  assert.match(publicSecurity, /0\.5\.8 \| Current immutable public release/);
-  assert.match(publicSecurity, /Eight platforms have connection entries/);
-  assert.match(publicSecurity, /security\/advisories\/new/);
-  assert.match(securityContract, /提供八个平台的真实连接 adapter/);
-  assert.match(imContract, /八个平台都有真实连接入口/);
-  assert.match(publicSecurity, /WhatsApp is not displayed, supported, planned, or bundled in 0\.5\.8/);
-  assert.match(securityContract, /WhatsApp 在\s*0\.5\.8 中不展示、不支持、不列为规划，也不捆绑运行时/);
-  assert.match(imContract, /WhatsApp 在 0\.5\.8 中不展示、不支持、不列为规划，也不捆绑/);
-  for (const current of [publicSecurity, securityContract, imContract]) {
-    assert.doesNotMatch(current, /Nine platforms have connection entries|九个平台都有真实连接入口/);
+test("current product, architecture and security contracts use the selected release", () => {
+  const product = readFileSync(join(root, "docs/PRODUCT.md"), "utf8");
+  const architecture = readFileSync(join(root, "docs/ARCHITECTURE.md"), "utf8");
+  const security = readFileSync(join(root, "docs/SECURITY.md"), "utf8");
+  const im = readFileSync(join(root, "docs/IM_PLUGIN.md"), "utf8");
+  for (const text of [product, architecture, security, im]) {
+    assert.ok(text.includes(PRODUCT_VERSION));
+    assert.ok(text.includes(PINNED_DSH));
+    assert.doesNotMatch(text, /disabled WhatsApp compatibility card|说明卡没有连接/);
   }
+  assert.match(security, /提供八个平台的真实连接 adapter/);
+  assert.match(im, /八个平台都有真实连接入口/);
+  assert.match(im, /未经修改的官方 npm 字节/);
+  const constitution = readFileSync(join(root, "PRODUCT_CONSTITUTION.md"), "utf8");
+  assert.ok(constitution.includes(`当前产品与发布契约为 **Penglai v${PRODUCT_VERSION}**`));
+});
+
+const publicationManifestPath = join(root, `docs/PUBLICATION_MANIFEST_${PRODUCT_VERSION}.md`);
+// Publication is a later phase. The deployment verifier requires these files
+// after immutable readback; old documentation must never create a current PASS.
+test("published README, website and security match the current observed manifest", {
+  skip: !existsSync(publicationManifestPath) && "current immutable publication has not occurred",
+}, () => {
+  const manifest = readFileSync(publicationManifestPath, "utf8");
+  const notes = readFileSync(join(root, `docs/RELEASE_NOTES_${PRODUCT_VERSION}.md`), "utf8");
+  const readme = readFileSync(join(root, "README.md"), "utf8");
+  const pages = ["website/index.html", "website/en/index.html"].map((path) => readFileSync(join(root, path), "utf8"));
+  const contract = JSON.parse(readFileSync(join(root, "release-contract.json"), "utf8"));
+  assert.ok(manifest.includes("PUBLIC_READBACK_PASS"));
+  assert.ok(notes.includes(PINNED_DSH));
+  assert.ok(notes.includes("not notarized"));
+  for (const target of contract.targets) {
+    const row = manifest.split(/\r?\n/).find((line) => line.startsWith("|") && line.includes(target.installer));
+    assert.ok(row, `current manifest is missing ${target.installer}`);
+    const cells = row.split("|").map((cell) => cell.trim());
+    const sha = cells.find((cell) => /^`[a-f0-9]{64}`$/.test(cell))?.slice(1, -1);
+    const bytes = cells.find((cell) => /^[1-9][0-9,]*$/.test(cell));
+    assert.ok(sha && bytes, `current manifest lacks exact bytes for ${target.installer}`);
+    for (const content of [readme, ...pages]) {
+      assert.ok(content.includes(PRODUCT_VERSION) && content.includes(PINNED_DSH));
+      assert.ok(content.includes(`https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v${PRODUCT_VERSION}/${target.installer}`));
+      assert.ok(content.includes(sha));
+    }
+    assert.ok(readme.includes(bytes));
+    for (const page of pages) assert.ok(page.includes(`${(Number(bytes.replaceAll(",", "")) / 1048576).toFixed(1)} MiB`));
+  }
+  const security = readFileSync(join(root, "SECURITY.md"), "utf8");
+  assert.ok(security.includes(`${PRODUCT_VERSION} | Current immutable public release`));
+  assert.ok(security.includes(PINNED_DSH));
+  assert.match(security, /Eight platforms have connection entries/);
+  assert.match(security, /security\/advisories\/new/);
+  assert.doesNotMatch([readme, ...pages, security].join("\n"), /two-hour installed soak remain|两小时安装版稳定运行仍/);
 });
 
 test("decision identifiers are unique and the final distribution decision supersedes D-060", () => {

--- a/scripts/lib/installed-boundary.test.mjs
+++ b/scripts/lib/installed-boundary.test.mjs
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { observeFreshInstalledBoot } from "./installed-readiness.mjs";
 import { credentialFreeInstalledChecks, credentialFreeInstalledPass } from "./installed-boundary.mjs";
 import {
   isControlledWindowsInstallerFixture,
@@ -189,3 +190,49 @@ test(
     if (child.exitCode === null) await new Promise((resolve) => child.once("exit", resolve));
   },
 );
+
+
+test("an exited upgrade process cannot reuse the previous application's readiness", async () => {
+  const profile = mkdtempSync(join(tmpdir(), "penglai-upgrade-readiness-"));
+  mkdirSync(join(profile, "plugins"));
+  writeFileSync(join(profile, "gateway.port"), "1234");
+  writeFileSync(join(profile, "plugins", "inventory-snapshot.json"), "{}");
+  writeFileSync(join(profile, "owner.txt"), "preserved");
+  try {
+    const result = await observeFreshInstalledBoot(profile, () => ({
+      child: spawn(process.execPath, ["-e", "process.exit(1)"], { stdio: "ignore" }),
+    }), 2_000);
+    assert.equal(result.freshReadiness, false);
+    assert.equal(result.gateway, false);
+    assert.equal(result.inventory, false);
+    assert.equal(readFileSync(join(profile, "owner.txt"), "utf8"), "preserved");
+  } finally { rmSync(profile, { recursive: true, force: true }); }
+});
+
+test("upgrade readiness requires new publications from the running process", async () => {
+  const profile = mkdtempSync(join(tmpdir(), "penglai-upgrade-ready-"));
+  mkdirSync(join(profile, "plugins"));
+  let child;
+  try {
+    const result = await observeFreshInstalledBoot(profile, () => {
+      child = spawn(process.execPath, ["-e", `
+        const fs = require('node:fs'); const path = require('node:path');
+        const root = process.argv[1];
+        setTimeout(() => {
+          fs.writeFileSync(path.join(root, 'gateway.port'), '1234');
+          fs.writeFileSync(path.join(root, 'plugins/inventory-snapshot.json'), '{}');
+        }, 100);
+        setInterval(() => {}, 1000);
+      `, profile], { stdio: "ignore" });
+      return { child };
+    }, 3_000);
+    assert.equal(result.freshReadiness, true);
+    assert.equal(child.exitCode, null);
+  } finally {
+    if (child && child.exitCode === null) {
+      const closed = new Promise((resolve) => child.once("close", resolve));
+      child.kill(); await closed;
+    }
+    rmSync(profile, { recursive: true, force: true });
+  }
+});

--- a/scripts/lib/installed-readiness.mjs
+++ b/scripts/lib/installed-readiness.mjs
@@ -1,0 +1,23 @@
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+/** Test-fixture launch boundary: persisted readiness belongs to the old process. */
+export async function observeFreshInstalledBoot(userData, launch, timeoutMs = 120_000) {
+  const gatewayPath = join(userData, "gateway.port");
+  const inventoryPath = join(userData, "plugins", "inventory-snapshot.json");
+  for (const path of [gatewayPath, inventoryPath]) rmSync(path, { force: true });
+  const launched = launch();
+  const deadline = Date.now() + timeoutMs;
+  let gateway = false;
+  let inventory = false;
+  while (Date.now() < deadline) {
+    const alive = launched.child.exitCode === null && !launched.child.signalCode;
+    if (!alive) break;
+    gateway = existsSync(gatewayPath);
+    inventory = existsSync(inventoryPath);
+    if (gateway && inventory) return { launched, gateway, inventory, freshReadiness: true };
+    await delay(100);
+  }
+  return { launched, gateway, inventory, freshReadiness: false };
+}

--- a/scripts/verify-native-set.mjs
+++ b/scripts/verify-native-set.mjs
@@ -70,7 +70,7 @@ for (const target of RELEASE_TARGETS) {
   }
   if (command === "verify:upgrade-uninstall") {
     const versions = [...(record.previousVersions ?? [])].sort();
-    if (JSON.stringify(versions) !== JSON.stringify(["0.5.8", "0.5.9"]) || record.upgradePaths?.length !== 2 || record.upgradePaths.some((row) => row.verdict !== "PASS" || row.sourceSha !== source.git.head || row.current?.installerSha256 !== installerEvidence.sha256 || !row.upgradePreservedOwnerData || !row.uninstallPreservedOwnerData || !row.uninstallRemovedApp)) {
+    if (JSON.stringify(versions) !== JSON.stringify(["0.5.8", "0.5.9"]) || record.upgradePaths?.length !== 2 || record.upgradePaths.some((row) => row.verdict !== "PASS" || row.previous?.boot?.freshReadiness !== true || row.current?.boot?.freshReadiness !== true || row.sourceSha !== source.git.head || row.current?.installerSha256 !== installerEvidence.sha256 || !row.upgradePreservedOwnerData || !row.uninstallPreservedOwnerData || !row.uninstallRemovedApp)) {
       finish("INCOMPLETE", { command: "verify:native-set", gate: command, reason: "both native upgrade paths must pass on these installer bytes", target });
     }
   }

--- a/scripts/verify-upgrade-uninstall.mjs
+++ b/scripts/verify-upgrade-uninstall.mjs
@@ -20,9 +20,11 @@ import {
   resourcesInside,
   sha256File,
   stopChild,
-  waitForFile,
 } from "./lib/installed-app.mjs";
 import { ROOT } from "./lib/repo.mjs";
+import { observeFreshInstalledBoot } from "./lib/installed-readiness.mjs";
+import { inspectPackagedCandidate } from "./lib/packaged-candidate.mjs";
+import { sanitizeEvidenceText } from "./lib/evidence-json.mjs";
 import {
   hostMatchesTarget,
   installerForTarget,
@@ -71,22 +73,21 @@ async function boot(app, userData, label) {
   const resources = resourcesInside(app, target);
   const executable = exeInside(app, target);
   if (!executable) fail(`${label} installed Penglai executable missing`);
-  const launched = launchPackaged(executable, resources, userData);
-  const gateway = await waitForFile(join(userData, "gateway.port"), 90_000);
-  const inventory = await waitForFile(
-    join(userData, "plugins", "inventory-snapshot.json"),
-    30_000,
+  const { launched, gateway, inventory, freshReadiness } = await observeFreshInstalledBoot(
+    userData, () => launchPackaged(executable, resources, userData),
   );
   const [code, signal] = await stopChild(launched.child);
-  if (!gateway || !inventory || (code !== 0 && signal === null)) {
+  if (!freshReadiness || !gateway || !inventory || (code !== 0 && signal === null)) {
     fail(`${label} did not boot and exit through the installed runtime`, {
       gateway,
       inventory,
+      freshReadiness,
       code,
       signal,
+      outputTail: sanitizeEvidenceText(launched.output(), 2_000),
     });
   }
-  return { gateway, inventory, exitCode: code, signal };
+  return { gateway, inventory, freshReadiness, exitCode: code, signal };
 }
 
 function installWindows(installer, label) {
@@ -164,8 +165,8 @@ if (pinnedAsset.sha256 !== previousSha256) fail("previous installer differs from
 const currentInstaller = join(ROOT, "dist", installerForTarget(target));
 if (!existsSync(currentInstaller)) fail("current exact installer is missing");
 const currentSha256 = sha256File(currentInstaller);
-const appRoot = requireExactChild(join(ROOT, ".tmp-upgrade-uninstall-app"), ROOT, "app test root");
-const userData = requireExactChild(join(ROOT, ".tmp-upgrade-uninstall-user"), ROOT, "user-data test root");
+const appRoot = requireExactChild(join(ROOT, ".tmp", "upgrade-uninstall", "app"), ROOT, "app test root");
+const userData = requireExactChild(join(ROOT, ".tmp", "upgrade-uninstall", "user"), ROOT, "user-data test root");
 rmSync(userData, { recursive: true, force: true });
 mkdirSync(userData, { recursive: true });
 const sentinel = join(userData, "owner-data-preserved.txt");
@@ -204,6 +205,8 @@ if (target === "win32-x86_64") {
   app = current.app;
 }
 const currentIdentity = assertVersion(app, "0.5.10", "upgraded install");
+const currentPackage = inspectPackagedCandidate({ app, candidateSha: source.git.head, expectedTarget: target });
+if (currentPackage.verdict !== "PASS") fail("upgraded installer source identity mismatch", { currentPackage });
 const currentBoot = await boot(app, userData, "upgraded install");
 if (!existsSync(sentinel)) fail("upgrade did not preserve isolated Owner data");
 


### PR DESCRIPTION
Native upgrade checks reused readiness files left by the previous process and created an unignored fixture directory, so the second supported upgrade path failed the clean-source check. Isolate lifecycle fixtures under `.tmp`, require the running process to publish fresh readiness files, and verify the upgraded installer carries the exact candidate source identity.

Update current product, architecture, security and IM contracts to the 0.5.10 / official DSH 0.1.2-rc.1 boundary. Publication tests retain historical evidence without attributing it to the new candidate and validate current README/site bytes once immutable publication exists. Historical release records remain intact.

Validation: formatting and contracts pass. Full unit suite: 859 passed, two explicitly inapplicable/pre-publication skips, zero failures. A fresh Apple Silicon DMG from d5f76361 passed both 0.5.8 → 0.5.10 and 0.5.9 → 0.5.10 native upgrades and default uninstall; all four old/new boots published fresh readiness and exited cleanly, and fixture user data was preserved. CodeQL passes. Final three-target artifacts will be rebuilt from the resulting clean main SHA.
