### PR TITLE
test: isolate verifier fixtures from native release evidence

### DIFF
--- a/packages/release-identity/src/verifier-process.test.ts
+++ b/packages/release-identity/src/verifier-process.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -13,23 +13,41 @@ function lastJson(text: string): { verdict?: string } {
   return JSON.parse(line) as { verdict?: string };
 }
 
-test("closure verifier exits INCOMPLETE when its closure credential is absent", () => {
-  const staging = mkdtempSync(join(tmpdir(), "penglai-missing-closure-"));
-  const result = spawnSync(process.execPath, ["--import", "tsx", "scripts/verify-closure.mjs", "--staging", staging], {
-    cwd: root,
+function currentReports(command: string): Array<Buffer | undefined> {
+  return ["", "-darwin-aarch64", "-darwin-x86_64", "-win32-x86_64"].map((suffix) => {
+    const path = join(root, "evidence/generated", `${command}${suffix}.json`);
+    return existsSync(path) ? readFileSync(path) : undefined;
+  });
+}
+
+test("closure verifier exits INCOMPLETE without changing native release evidence", (t) => {
+  const fixture = mkdtempSync(join(tmpdir(), "penglai-missing-closure-"));
+  t.after(() => rmSync(fixture, { recursive: true, force: true }));
+  const before = currentReports("verify-closure");
+  const staging = join(fixture, "empty-staging");
+  mkdirSync(staging);
+  const result = spawnSync(process.execPath, ["--import", import.meta.resolve("tsx"), join(root, "scripts/verify-closure.mjs"), "--staging", staging], {
+    cwd: fixture,
     encoding: "utf8",
   });
   assert.equal(result.status, 2);
   assert.equal(lastJson(result.stderr || result.stdout).verdict, "INCOMPLETE");
+  assert.deepEqual(currentReports("verify-closure"), before);
+  const report = JSON.parse(readFileSync(join(fixture, "evidence/generated/verify-closure.json"), "utf8")) as { verdict?: string };
+  assert.equal(report.verdict, "INCOMPLETE");
 });
 
-test("profile verifier overwrites stale PASS and exits INCOMPLETE without a closure", () => {
-  const staging = mkdtempSync(join(tmpdir(), "penglai-missing-profile-"));
-  const report = join(root, "evidence/generated/verify-profile.json");
+test("profile verifier overwrites only its isolated stale fixture report", (t) => {
+  const fixture = mkdtempSync(join(tmpdir(), "penglai-missing-profile-"));
+  t.after(() => rmSync(fixture, { recursive: true, force: true }));
+  const before = currentReports("verify-profile");
+  const staging = join(fixture, "empty-staging");
+  mkdirSync(staging);
+  const report = join(fixture, "evidence/generated/verify-profile.json");
   mkdirSync(dirname(report), { recursive: true });
   writeFileSync(report, `${JSON.stringify({ command: "verify:profile", verdict: "PASS", staleFixture: true })}\n`);
-  const result = spawnSync(process.execPath, ["--import", "tsx", "scripts/verify-profile.mjs", "--staging", staging], {
-    cwd: root,
+  const result = spawnSync(process.execPath, ["--import", import.meta.resolve("tsx"), join(root, "scripts/verify-profile.mjs"), "--staging", staging], {
+    cwd: fixture,
     encoding: "utf8",
   });
   assert.equal(result.status, 2);
@@ -37,4 +55,5 @@ test("profile verifier overwrites stale PASS and exits INCOMPLETE without a clos
   const current = JSON.parse(readFileSync(report, "utf8")) as { verdict?: string; staleFixture?: boolean };
   assert.equal(current.verdict, "INCOMPLETE");
   assert.equal(current.staleFixture, undefined);
+  assert.deepEqual(currentReports("verify-profile"), before);
 });


### PR DESCRIPTION
The complete release aggregate reruns the source unit suite after downloading native evidence. Two negative verifier tests wrote INCOMPLETE records into the repository evidence directory, replacing valid ARM closure/profile results and making the aggregate fail as stale.

Run each negative verifier in its own temporary working directory, load the actual verifier and TypeScript loader by absolute location, and assert that generic and all three target-specific release reports remain byte-for-byte unchanged. The stale-PASS replacement test still verifies a real subprocess and nonzero exit, within its isolated fixture.

Validation: formatting, typecheck and both verifier subprocess tests pass. The full unit suite passes with 13 real downloaded ARM evidence records preserved byte-for-byte. All three native jobs in run 33764971866 passed; that run is retained as a failed aggregate and will not be published. Rebuild all three final artifacts from the new clean main commit after merge.
