### PR TITLE
docs: publish verified 0.5.10 downloads and website facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 <p align="center"><strong>DeepSeek Harness, ready to live on a personal computer.</strong></p>
 
 <p align="center">
-  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.9"><img src="https://img.shields.io/badge/release-0.5.9-0f766e?style=flat-square" alt="Penglai 0.5.9 release"></a>
-  <a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://img.shields.io/badge/DSH-0.1.2--alpha.2-7c3aed?style=flat-square" alt="DeepSeek Harness 0.1.2-alpha.2"></a>
+  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.10"><img src="https://img.shields.io/badge/release-0.5.10-0f766e?style=flat-square" alt="Penglai 0.5.10 release"></a>
+  <a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://img.shields.io/badge/DSH-0.1.2--rc.1-7c3aed?style=flat-square" alt="DeepSeek Harness 0.1.2-rc.1"></a>
   <img src="https://img.shields.io/badge/targets-Apple%20Silicon%20%7C%20Intel%20Mac%20%7C%20Windows%20x64-0f766e?style=flat-square" alt="Apple Silicon, Intel Mac, and Windows x64">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-16a34a?style=flat-square" alt="MIT License"></a>
 </p>
@@ -19,24 +19,26 @@
   <a href="#english">English</a> ·
   <a href="#中文">中文</a> ·
   <a href="https://penglai.pages.dev">Website</a> ·
-  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.9">Download 0.5.9</a> ·
-  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.9">0.5.9 notes</a> ·
+  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.10">Download 0.5.10</a> ·
+  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.10">0.5.10 notes</a> ·
   <a href="AGENTS.md">For AI contributors</a> ·
   <a href="SECURITY.md">Security</a>
 </p>
 
-> Penglai 0.5.9 is an immutable public Release built from
-> `a4c0bec50cb0df26281207e1a19b444b50317604`. It uses official DSH source tag
-> `dsh-v0.1.2-alpha.2` at `0a53fb55bea101816fa226bb964ae2bed71c343b`, rebuilt as
-> a reproducible local package closure. No unofficial npm publication is used.
-> Native install, upgrade, uninstall, public byte, and SHA-256 checks passed. macOS remains
-> ad-hoc signed and not notarized; Windows has no Authenticode.
+> Penglai 0.5.10 is an immutable public release built from
+> `c5c0bcb022c5ae47cca242deb27fe1d30444c41d`. It consumes official DSH `0.1.2-rc.1` npm packages,
+> reconciled to tag `dsh-v0.1.2-rc.1` at
+> `a66e4702047846cdaa10c66c9d3df3951f5ea70d`. All 254 package archives,
+> registry signatures and pinned source manifests were verified.
+> The release includes three native installers and all seven integrity and license files.
+> macOS is ad-hoc signed and not notarized; Windows has no Authenticode.
+> [Release notes](docs/RELEASE_NOTES_0.5.10.md) · [Verified publication](docs/PUBLICATION_MANIFEST_0.5.10.md)
 
 <p align="center">
   <img src=".github/assets/0.5.5/plugin-center.png" width="49%" alt="Penglai 0.5.5 Plugin Center in the installed DSH settings">
   <img src=".github/assets/0.5.5/memory.png" width="49%" alt="Penglai Memory in the installed DSH settings">
 </p>
-<p align="center"><sub>Installed 0.5.5 screenshots are retained only as UI references. The 0.5.9 native-install evidence is recorded in its successful native run; these older images are not presented as 0.5.9 screenshots.</sub></p>
+<p align="center"><sub>Installed 0.5.5 screenshots are retained only as UI references. The 0.5.10 native-install evidence is recorded in its successful native run; these older images are not presented as 0.5.10 screenshots.</sub></p>
 
 <a id="english"></a>
 
@@ -57,19 +59,19 @@ actually usable: packaging, process supervision, onboarding, local paths,
 upgrades, uninstall, product identity, and plugin distribution. There is no
 second Penglai agent hiding beside DSH and no replacement chat page.
 
-Version 0.5.9 moves the distribution to the fixed official DSH
-`0.1.2-alpha.2` source and completes the related plugin, remote-error, session,
-settings-generation, installed-runtime, and Windows compatibility work. The
-installed product is checked on all three native targets, including the first
-official message, upgrade from 0.5.8, and default uninstall.
+Version 0.5.10 adapts message recovery, budget reconciliation and Companion
+replay to the official Session snapshot API. Upgrades from 0.5.8 and 0.5.9 use
+an isolated rc.1 DSH Home and preserve the previous generation for rollback.
+All three native installers pass credential-free onboarding and plugin checks,
+both upgrade paths, and default uninstall with user data preserved.
 
-## What ships in 0.5.9
+## What ships in 0.5.10
 
 | Product surface | Fresh install | What it does |
 | --- | --- | --- |
 | Penglai Office | On | Inspect, create, edit, preview, and save DOCX, XLSX, PPTX, and PDF |
 | Penglai Memory | On | Automatic current-Workspace memory, explicit personal memory, authorised sources, provenance, and a knowledge graph |
-| Mobile Messaging | Off | Eight platform connectors under one IM control plane; WhatsApp is not exposed or supported in 0.5.9 |
+| Mobile Messaging | Off | Eight platform connectors under one IM control plane; WhatsApp is not exposed or supported in 0.5.10 |
 | Speech Recognition | Off | Local SenseVoice transcription; enabling it adds the conversation microphone entry |
 | Voice Generation | Off | Local MOSS-TTS-Nano preview, desktop playback, and supported channel audio |
 | Companion | Off | Opt-in scheduled contact with quiet hours, daily limits, and a bound IM route |
@@ -159,7 +161,7 @@ image store. Office files and audio use scoped opaque `artifact:<uuid>`
 references. A mocked webhook is never live evidence.
 
 Slack, Telegram, and Discord use official token or manifest flows and do not
-fake QR. QQ is official Bot QR, not personal QQ login. WhatsApp is not a 0.5.9
+fake QR. QQ is official Bot QR, not personal QQ login. WhatsApp is not a 0.5.10
 product surface: it is not displayed, supported, planned, or bundled. Historical
 0.5.7 release bytes and documentation remain immutable.
 
@@ -178,8 +180,8 @@ It verifies the catalog signature, archive identity, SHA-256, DSH compatibility,
 platform, and declared permissions before staging a package. Activation is a
 separate step and failed activation rolls back.
 
-This is the reason a good DSH `0.1.2-alpha.2`-compatible plugin can be reviewed and added later
-without publishing Penglai 0.5.9 merely to change a list. The catalog is still
+This is the reason a good DSH `0.1.2-rc.1`-compatible plugin can be reviewed and added later
+without publishing Penglai 0.5.10 merely to change a list. The catalog is still
 fail-closed: arbitrary npm names, Git repositories, and download URLs are not
 accepted. A DSH plugin shares the local DSH process permissions; the permission
 list explains review and consent, but it is not an operating-system sandbox.
@@ -196,16 +198,17 @@ go Back, retry a failed credential, resume after restart, and reject the app's
 own data or installation directory as a Workspace. Finishing the wizard means a
 real model reply was received, not merely that a health endpoint answered.
 
-The immutable [0.5.9 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.9)
-contains exactly three native installers. All were built from the same source SHA
-and passed [native installed-product gates](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33470301766)
+The immutable [0.5.10 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.10)
+contains exactly ten files: three native installers and seven integrity and license
+files. All installers were built from the same source SHA
+and passed [native installed-product gates](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33775824578)
 and public download readback:
 
 | Platform | Release asset | Bytes | SHA-256 |
 | --- | --- | ---: | --- |
-| Apple Silicon, macOS 13+ | [`Penglai_0.5.9_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.9/Penglai_0.5.9_macos_aarch64.dmg) | 466,289,082 | `f592fc85292ae3a7e238be5cb2ff6a41ebd5c0337406ac34e69c963d64ec319b` |
-| Intel Mac | [`Penglai_0.5.9_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.9/Penglai_0.5.9_macos_x64.dmg) | 408,295,625 | `959d7546495d11fd3f938a7fa9854518a0f6cbcf92951238bbf0589a4d469907` |
-| Windows x64 | [`Penglai_0.5.9_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.9/Penglai_0.5.9_windows_x64_setup.exe) | 357,561,673 | `a26e31b3d27c8ed55e76264ea516779313895f080079f5d64ff4134ef5e48679` |
+| Apple Silicon, macOS 13+ | [`Penglai_0.5.10_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_aarch64.dmg) | 471,410,669 | `0fdca1a2d64c536088b53ddd4910851e9876abed4ee114aecd7a1437ff9417e5` |
+| Intel Mac | [`Penglai_0.5.10_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_x64.dmg) | 407,030,741 | `6771901b5bf3b7e9e0c192125a866bf2e6c1c605655a8d07339ea37dc64ee9ea` |
+| Windows x64 | [`Penglai_0.5.10_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_windows_x64_setup.exe) | 357,546,167 | `46b45bbb6a18859c7be03413b7983ad90dacc7710233130b2c81cb5a537bd484` |
 
 Use the same-platform installer as a manual overlay when upgrading. There is no
 silent update. External Workspaces and the `Penglai/0.5` data generation are
@@ -228,9 +231,9 @@ preserved.
   catalog entries and read their permissions.
 - Source tests, packaged tests, native installed tests, and live external-account
   tests are reported separately. One never substitutes for another.
-- Owner-account connector journeys and a two-hour installed soak remain
-  supplemental `LIVE_NOT_RUN` evidence. They are not claimed by this release
-  and do not replace the completed source, native-install, or public-byte gates.
+- External model calls and Owner-account messaging journeys are recorded only
+  when actually run. Credential-free installed checks do not establish a real
+  provider reply or message delivery.
 
 See [Security](SECURITY.md), [Product and data contract](docs/PRODUCT.md),
 [Architecture](docs/ARCHITECTURE.md), and [Plugin Center](docs/PLUGIN_CENTER.md)
@@ -327,17 +330,18 @@ Turn 和会话界面都归 DSH。蓬莱负责那些不太耀眼、却决定桌�
 事情：打包、进程监管、安装引导、本地目录、升级、卸载、产品身份和插件分发。这里
 没有藏着第二套蓬莱 Agent，也没有另做一张聊天页替代 DSH。
 
-0.5.9 把发行版升级到固定的官方 DSH `0.1.2-alpha.2` 源码，并完成相关插件、
-远端错误、会话、设置生成、安装后运行环境与 Windows 兼容工作。三端安装版均已验证
-首条官方消息、从 0.5.8 升级和默认卸载。
+0.5.10 使用未经修改的官方 DSH `0.1.2-rc.1` npm 包，并让消息恢复、预算结算和
+主动陪伴回放适配官方 Session 快照接口。从 0.5.8 和 0.5.9 升级时使用独立的
+rc.1 数据目录，保留旧代际用于回退。三端安装包均通过无需真实账号的引导和插件
+检查、两条升级路径，以及默认保留用户数据的卸载验证。
 
-## 0.5.9 带来了什么
+## 0.5.10 带来了什么
 
 | 产品功能 | 全新安装 | 能做什么 |
 | --- | --- | --- |
 | 蓬莱办公 | 默认启用 | 检查、创建、编辑、预览和保存 DOCX、XLSX、PPTX、PDF |
 | 蓬莱记忆 | 默认启用 | 当前 Workspace 自动记忆、明确个人记忆、授权资料、来源追溯和知识图谱 |
-| 消息连接 | 默认关闭 | 八个平台共用一个 IM 控制平面；0.5.9 不展示或支持 WhatsApp |
+| 消息连接 | 默认关闭 | 八个平台共用一个 IM 控制平面；0.5.10 不展示或支持 WhatsApp |
 | 蓬莱语音识别 | 默认关闭 | 本地 SenseVoice 转写；启用后为电脑会话提供麦克风入口 |
 | 蓬莱语音生成 | 默认关闭 | 本地 MOSS-TTS-Nano 试听、电脑播放和支持渠道的语音输出 |
 | 蓬莱主动陪伴 | 默认关闭 | 安静时段、每日上限、指定 IM 路由下的主动联系 |
@@ -414,7 +418,7 @@ QQ、Slack、Telegram、Discord。文字和受支持的图片、文件、语音�
 图片走 official 图片存储；文件和音频走 `artifact:<uuid>`。
 
 Slack、Telegram、Discord 走官方 Token/Manifest，禁止伪装扫码。QQ 只做官方
-Bot 扫码，不模拟个人号。WhatsApp 不是 0.5.9 的产品能力：不展示、不支持、不列为
+Bot 扫码，不模拟个人号。WhatsApp 不是 0.5.10 的产品能力：不展示、不支持、不列为
 规划，也不捆绑运行时。0.5.7 的历史发布字节与文档保持不可变。
 
 SenseVoice 和 MOSS-TTS 默认关闭，是因为模型文件较大。语音识别启用并下载模型后，
@@ -428,8 +432,8 @@ SenseVoice 和 MOSS-TTS 默认关闭，是因为模型文件较大。语音识�
 读取带版本、不可变的 GitHub Release。安装前会校验目录签名、包身份、SHA-256、DSH
 兼容版本、平台和声明权限。下载与启用是两个阶段，启用失败会回滚。
 
-因此以后审核出一个优秀的 DSH `0.1.2-alpha.2` 兼容插件，可以只发布新一代签名目录，不必为了列表变化
-再打一个 0.5.9 客户端。它仍然是 fail-closed：任意 npm 包名、Git 仓库或下载地址都
+因此以后审核出一个优秀的 DSH `0.1.2-rc.1` 兼容插件，可以只发布新一代签名目录，不必为了列表变化
+再打一个 0.5.10 客户端。它仍然是 fail-closed：任意 npm 包名、Git 仓库或下载地址都
 不会被接受。DSH 插件与本地 DSH 进程共享权限，权限列表用于审核和确认，不是操作
 系统沙箱。
 
@@ -442,16 +446,17 @@ SenseVoice 和 MOSS-TTS 默认关闭，是因为模型文件较大。语音识�
 真实 DSH Turn。它支持返回、密钥失败后重试、重启后续接，也会拒绝把应用数据目录
 或安装目录选作 Workspace。只有模型真的回复了，才算完成，不会拿健康接口冒充。
 
-不可变的 [0.5.9 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.9)
-固定三个原生安装包。它们来自同一源码提交，并已通过
-[三端原生安装门禁](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33470301766)
+不可变的 [0.5.10 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.10)
+固定十项附件：三个原生安装包和七项完整性、签名与许可证材料。
+三个安装包来自同一源码提交，并已通过
+[三端原生安装门禁](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33775824578)
 和公网下载回读：
 
 | 平台 | 正式文件 | 字节数 | SHA-256 |
 | --- | --- | ---: | --- |
-| Apple Silicon，macOS 13+ | [`Penglai_0.5.9_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.9/Penglai_0.5.9_macos_aarch64.dmg) | 466,289,082 | `f592fc85292ae3a7e238be5cb2ff6a41ebd5c0337406ac34e69c963d64ec319b` |
-| Intel Mac | [`Penglai_0.5.9_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.9/Penglai_0.5.9_macos_x64.dmg) | 408,295,625 | `959d7546495d11fd3f938a7fa9854518a0f6cbcf92951238bbf0589a4d469907` |
-| Windows x64 | [`Penglai_0.5.9_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.9/Penglai_0.5.9_windows_x64_setup.exe) | 357,561,673 | `a26e31b3d27c8ed55e76264ea516779313895f080079f5d64ff4134ef5e48679` |
+| Apple Silicon，macOS 13+ | [`Penglai_0.5.10_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_aarch64.dmg) | 471,410,669 | `0fdca1a2d64c536088b53ddd4910851e9876abed4ee114aecd7a1437ff9417e5` |
+| Intel Mac | [`Penglai_0.5.10_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_x64.dmg) | 407,030,741 | `6771901b5bf3b7e9e0c192125a866bf2e6c1c605655a8d07339ea37dc64ee9ea` |
+| Windows x64 | [`Penglai_0.5.10_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_windows_x64_setup.exe) | 357,546,167 | `46b45bbb6a18859c7be03413b7983ad90dacc7710233130b2c81cb5a537bd484` |
 
 升级时使用同平台安装包手动覆盖即可。它不会静默升级；外部 Workspace 与
 `Penglai/0.5` 数据代际会保留。
@@ -469,8 +474,8 @@ SenseVoice 和 MOSS-TTS 默认关闭，是因为模型文件较大。语音识�
 - 蓬莱 Ed25519 签名保护升级和插件字节，但不能代替 Apple 或 Microsoft 发布者身份。
 - 插件和 DSH 在同一本地进程中运行，只应安装经过审核的目录条目并阅读权限。
 - 源码测试、打包测试、原生安装测试、真实外部账号测试分别记录，不能互相冒充。
-- Owner 真实账号连接旅程和两小时安装版稳定运行仍是补充性的 `LIVE_NOT_RUN`
-  证据，本次发布不宣称完成，也不拿它们替代已经通过的源码、原生安装和公开字节门禁。
+- 真实模型调用与 Owner 账号消息旅程仅记录实际执行结果；无凭据安装检查不能证明
+  真实模型回复或消息送达。
 
 完整边界见 [安全说明](SECURITY.md)、[产品与数据契约](docs/PRODUCT.md)、
 [架构](docs/ARCHITECTURE.md) 和 [插件中心](docs/PLUGIN_CENTER.md)。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,15 +1,22 @@
 # Security Policy
 
-Penglai 0.5.8 is a **community-verified** desktop distribution of official DeepSeek Harness (DSH). This file is the public security entry. The full product contract lives in [`docs/SECURITY.md`](docs/SECURITY.md).
+Penglai 0.5.10 is a **community-verified** desktop distribution of official DeepSeek Harness (DSH). This file is the public security entry. The full product contract lives in [`docs/SECURITY.md`](docs/SECURITY.md).
 
 ## Supported versions
 
 | Version | Status |
 | --- | --- |
-| 0.5.8 | Current immutable public release |
-| 0.5.7 | Previous immutable public release; supported for upgrade to 0.5.8 |
-| 0.5.0–0.5.6 | Supported only for upgrading to the current 0.5 generation; 0.5.0 requires a manual overlay |
+| 0.5.10 | Current immutable public release |
+| 0.5.8 and 0.5.9 | Historical releases; native upgrades to 0.5.10 verified on all three targets |
+| Earlier 0.5.x | Historical releases; use the documented migration path |
 | 0.4.1 and earlier | Unsupported; 0.5 does not silently import or delete old secrets or databases |
+
+The 0.5.10 release contains all ten files in its release contract, including
+signed update metadata, SHA256SUMS, the three-target SBOM and third-party notices.
+The immutable 0.5.9 release contains only its three installers; its missing
+metadata is a historical publication defect. Do not infer signed updater
+coverage for that release from its installer availability. The published 0.5.9
+assets have not been changed.
 
 ## Trust tier
 
@@ -27,7 +34,7 @@ On macOS the credentials directory/file use 0700/0600. On Windows they use a cur
 
 0.4.1 credentials and databases are not read, imported, or deleted.
 
-Official DSH 0.1.2-alpha.1 source bundles a session-telemetry adapter and a configured DeepSeek
+Official DSH 0.1.2-rc.1 bundles a session-telemetry adapter and a configured DeepSeek
 OTLP endpoint. Penglai does not operate that backend and does not rely only on
 the adapter's default mode: the owned DSH child receives
 `DSH_TELEMETRY_DISABLED=1` from a closed environment allowlist. DSH applies that
@@ -37,12 +44,14 @@ pipeline.
 ## Instant messaging risk
 
 `@penglai/im` is the only IM plugin. Eight platforms have connection entries.
-Adapters cannot call a parallel Agent. Live support is evidence-gated in
-`docs/0.5.7/LIVE_IM_MATRIX.md`. Slack, Telegram, and Discord do not fake QR.
-WhatsApp is not displayed, supported, planned, or bundled in 0.5.8.
+Adapters cannot call a parallel Agent. `docs/0.5.7/LIVE_IM_MATRIX.md` preserves
+historical account-test requirements; it does not establish current-version live
+results. Current account journeys are claimed only with current evidence. Slack,
+Telegram, and Discord do not fake QR.
+WhatsApp is not displayed, supported, planned, or bundled in 0.5.10.
 
 - Weixin: real QR login. The scanner is the only allowed identity unless the user expands the allowlist.
-- Feishu: the user must create and publish their own enterprise self-built app. There is no Penglai-hosted Feishu QR and no fake “scan to finish”.
+- Feishu: the official application-registration QR flow is used where available, with manual App ID/Secret setup as a fallback. Penglai does not host the application or invent a login QR.
 - Both channels accept private text, supported images, files, and audio. Images use the official DSH image path; non-image bytes use Workspace/Session-scoped opaque artifacts. Group chat, video, and unsupported rich content are rejected before they reach the model.
 - Route binding is explicit Workspace/Session. Focus, recency, or “any agent” guesses are not used.
 
@@ -67,3 +76,25 @@ If a real credential may have leaked, rotate it immediately and say so in the re
 ## What this project will not claim
 
 Penglai will not claim notarization, Authenticode, App Store trust, silent auto-update, zero-config Feishu, or “absolute security”.
+
+## 中文
+
+当前正式版本为 0.5.10，使用固定的官方 DSH `0.1.2-rc.1` npm 包。
+Apple Silicon、Intel Mac 和 Windows x64 均验证从 0.5.8、0.5.9 升级并在默认
+卸载后保留用户数据。旧版 DSH Home 保留，rc.1 在独立目录通过健康检查后启用。
+
+0.5.10 的正式发布包含十项完整附件，包括签名更新清单、校验和、三端 SBOM 与
+第三方声明。0.5.9 历史发布只有三个安装包，缺少元数据属于当时的发布缺陷；
+不能据此声称该版签名更新链路完整。原有不可变附件未被修改。
+
+macOS 为社区 ad-hoc 签名、未公证；Windows 无 Authenticode。蓬莱 Ed25519
+签名保护字节完整性，不等于 Apple 或 Microsoft 发布者认证。更新必须由用户确认。
+
+密钥由官方 DSH 保存在应用私有 YAML 中，受文件权限或当前用户 ACL 保护；
+这不是 Keychain 或硬件隔离，同一操作系统用户下的进程仍可能读取。蓬莱启动的
+DSH 强制禁用官方遥测管线；模型调用仍会把任务需要的上下文发送给用户选择的
+供应商。插件与 DSH 共享进程权限，签名目录不是操作系统沙箱。
+
+外部模型与消息账号只报告实际执行的验证，无凭据自动检查不代表真实回复或消息
+送达。WhatsApp 不展示、不支持、不捆绑。发现漏洞请使用上面的私密报告入口，
+不要把密钥、扫码内容、私人消息或本地资料放进公开 issue。

--- a/docs/PUBLICATION_0.5.10.md
+++ b/docs/PUBLICATION_0.5.10.md
@@ -1,0 +1,19 @@
+# Penglai 0.5.10 publication
+
+Recorded after immutable public readback: 2026-09-03T16:52:18.350923+00:00.
+
+Penglai 0.5.10 publishes three native installers and all seven required metadata files. [The complete public byte manifest](PUBLICATION_MANIFEST_0.5.10.md) records their sizes and SHA-256 values. [Release notes](RELEASE_NOTES_0.5.10.md) describe the rc.1 adaptation, upgrade behavior and known boundaries.
+
+The build source is `c5c0bcb022c5ae47cca242deb27fe1d30444c41d`. [Native build and installed checks](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33775824578) and [main Source CI](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33775804473) passed on that source. [Publication](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33780754033) verified the signed mutable draft, sealed its asset identities, published it once, and downloaded all ten immutable public assets.
+
+The later README, security entry, bilingual website and publication documents are documentation changes. Their commit is not the installer's build source. Website deployment independently verifies publication-only changes and exact download facts; its final readback checks every deployed file at both [Cloudflare Pages](https://penglai.pages.dev/) and [GitHub Pages](https://kevinchennewbee.github.io/PenglaiAgent/). Deployment completion is established by that workflow's actual result.
+
+The older 0.5.9 release's missing metadata remains recorded as a historical defect; no published old asset or tag was replaced. This release supplies the complete signed update set with sequence 6. macOS remains not notarized and Windows has no Authenticode. No private account journey is inferred from automated tests.
+
+## 中文
+
+0.5.10 已公开三个原生安装器和七项配套文件，精确公开字节见上方清单。三端安装与升级检查、源码 CI、完整草稿验证和不可变公网回读均绑定安装包源码 `c5c0bcb022c5ae47cca242deb27fe1d30444c41d`。
+
+README、安全入口、双语官网和发布记录属于随后独立提交的公开文档，不能把文档提交写成安装包来源。官网部署另行核对仅有允许的文档差异、真实下载信息，并逐文件回读两个公网站点；以该部署任务的实际结果确认上线。
+
+0.5.9 缺元数据的历史问题没有通过改写旧发布掩盖。0.5.10 提供完整签名更新组，序号为 6。macOS 未公证、Windows 无 Authenticode；无凭据自动检查不代表私人账号或真实模型回复已验证。

--- a/docs/PUBLICATION_MANIFEST_0.5.10.md
+++ b/docs/PUBLICATION_MANIFEST_0.5.10.md
@@ -1,0 +1,40 @@
+# PUBLICATION_MANIFEST 0.5.10
+
+Status: `PUBLIC_READBACK_PASS`
+
+All ten immutable assets were downloaded after publication. Their exact sizes, SHA-256 digests, update signature and installer signatures passed verification. The table records observed public bytes; source templates remain `UNFROZEN` and are not substituted for generated release identities.
+
+| Field | Value |
+| --- | --- |
+| Product | `0.5.10` |
+| DSH | official unmodified npm `0.1.2-rc.1`; tag `dsh-v0.1.2-rc.1`; commit `a66e4702047846cdaa10c66c9d3df3951f5ea70d` |
+| Upstream cohort | 254 packages with registry archive, signature and fixed-source manifest verification |
+| Build source SHA | `c5c0bcb022c5ae47cca242deb27fe1d30444c41d` |
+| Public export tree | `d42ba98df8cf57a08232c806d8b7a353b38c7fe8c7946a5adb91328d166339c5` |
+| Release | [`v0.5.10`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.10), immutable |
+| Source CI | [PASS](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33775804473) |
+| Three native targets | [PASS](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33775824578) |
+| Complete publication and public readback | [PASS](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33780754033) |
+| Signed catalog | [PASS](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33775829021) |
+| SBOM | 1253 components; three-target release aggregate |
+| Update sequence | `6` |
+| Trust | community-verified; macOS ad-hoc, not notarized; Windows no Authenticode |
+
+| Asset | Bytes | SHA-256 |
+| --- | ---: | --- |
+| [`Penglai_0.5.10_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_aarch64.dmg) | 471,410,669 | `0fdca1a2d64c536088b53ddd4910851e9876abed4ee114aecd7a1437ff9417e5` |
+| [`Penglai_0.5.10_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_x64.dmg) | 407,030,741 | `6771901b5bf3b7e9e0c192125a866bf2e6c1c605655a8d07339ea37dc64ee9ea` |
+| [`Penglai_0.5.10_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_windows_x64_setup.exe) | 357,546,167 | `46b45bbb6a18859c7be03413b7983ad90dacc7710233130b2c81cb5a537bd484` |
+| [`SBOM.cdx.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/SBOM.cdx.json) | 1,175,804 | `948b6217da5e9ec7e1156869eff46a36c16aa090417c74675d9c7e0ceea0bb74` |
+| [`SHA256SUMS`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/SHA256SUMS) | 833 | `02fbb7bfdb82b739a067f59105b7785f2a1a763683079517601a8e1b830b1050` |
+| [`THIRD_PARTY_NOTICES.txt`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/THIRD_PARTY_NOTICES.txt) | 182,477 | `e596c1fbfa13779c99059e300ba9fc248f5fcdab5a86551d7852b037614f07ea` |
+| [`public-export-manifest.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/public-export-manifest.json) | 277,131 | `d2d6599bef4dc3c6621f79466071c2c2edff39367a9ae8f9c6a1b79f6db4846d` |
+| [`release-manifest.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/release-manifest.json) | 758 | `3182053c5fd154318e4bcf3b6802c20fee688fab3c24e89617b8ef9488daeed1` |
+| [`update-manifest-v1.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/update-manifest-v1.json) | 2,023 | `c251b903994cf472a8eadfe61ba92a4c2f7249d9449e653aa34354700e8c3d22` |
+| [`update-manifest-v1.json.sig`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/update-manifest-v1.json.sig) | 64 | `28286f651df71555d07940a762063f55d2092505f9d79f22edee12d182037b7e` |
+
+Native lifecycle verification covers both 0.5.8 and 0.5.9 upgrades on each target, with fresh old/new process readiness and fixture user data retained after default uninstall. Installed resource UI tests and native executable checks retain their separate evidence classes. Private account delivery and real provider responses are not inferred from credential-free tests.
+
+## 中文
+
+以上十项附件均已从不可变公开发布下载回读，文件大小、摘要、更新签名及安装器签名通过验证。三端来自同一源码，均验证两条旧版升级路径与默认卸载数据保留。无凭据测试不代表真实模型回复或私人账号消息送达；系统公证与发布者信誉限制见上表。

--- a/docs/RELEASE_NOTES_0.5.10.md
+++ b/docs/RELEASE_NOTES_0.5.10.md
@@ -1,0 +1,43 @@
+# Penglai 0.5.10
+
+Penglai 0.5.10 uses the unmodified official DeepSeek Harness `0.1.2-rc.1` npm packages, fixed to tag `dsh-v0.1.2-rc.1` and commit `a66e4702047846cdaa10c66c9d3df3951f5ea70d`. DSH remains the only agent core. Penglai supplies the desktop application, onboarding, local data lifecycle and bundled plugins.
+
+## Changes
+
+- Message recovery, budget reconciliation and Companion replay now read the official Session snapshot API. A missing API produces an explicit compatibility error.
+- The complete 254-package upstream cohort is pinned and verified against official registry archives, registry signatures and fixed-source manifests, including optional peer dependencies.
+- Upgrades from both 0.5.8 and 0.5.9 prepare a separate rc.1 DSH Home, switch only after required runtime/plugin health checks, and preserve the previous generation for rollback.
+- Speech verification now disposes native workers and model resources before returning an error.
+- Publication requires the complete ten-file signed release set. All draft assets are downloaded and verified before publication, and their identities are checked again immediately before the draft becomes public. The signed update sequence is 6.
+
+## Downloads and verification
+
+Apple Silicon, Intel Mac and Windows x64 installers were built on matching native hosts from the same clean main commit: `c5c0bcb022c5ae47cca242deb27fe1d30444c41d`.
+
+[Native build and installed checks](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33775824578) cover installed startup, credential-free onboarding/recovery, bundled plugin modes, both upgrade paths and default uninstall with user data preserved. Source CI covers the upstream cohort, type and contract checks, integration, desktop regression, security, actual Office/Memory/ASR/TTS operations and clean-clone installation/build.
+
+The assets below include three installers, `SHA256SUMS`, a signed update manifest and its detached signature, a release manifest, the three-target CycloneDX SBOM, third-party notices and the public source export manifest. Check the downloaded installer against `SHA256SUMS` before running it.
+
+Office and Memory start enabled. Messaging, speech recognition, voice generation and Companion start disabled. Voice model weights download only after an explicit user action. The signed Plugin Center retains its reviewed catalog and does not accept arbitrary packages.
+
+## Known boundaries
+
+macOS is ad-hoc signed and **not notarized**. Windows has **no Authenticode**. Penglai's Ed25519 signatures establish content integrity, not Apple or Microsoft publisher trust. Updates require user confirmation.
+
+Credential-free automated checks do not prove an external model response or private messaging delivery. Account-based journeys are reported only when actually run. WhatsApp is not displayed, supported or bundled. The immutable 0.5.9 release's missing metadata has not been retroactively replaced; 0.5.10 supplies a complete release set.
+
+## 中文
+
+蓬莱 0.5.10 使用未经修改的官方 DSH `0.1.2-rc.1` npm 包，固定上游标签与提交见上方。DSH 是唯一 Agent 核心，蓬莱负责桌面发行、安装引导、本地数据生命周期和内置插件。
+
+- 消息恢复、预算结算、主动陪伴回放适配官方 Session 快照接口；缺少接口时明确报错。
+- 完整固定并验证 254 个上游包，包括归档字节、registry 签名、固定源码 manifest 和可选间接依赖。
+- 0.5.8、0.5.9 均可升级：独立准备 rc.1 数据目录，必需运行时与插件健康检查通过后才切换，保留旧代际用于回退。
+- 语音验证在失败退出前正确释放原生 worker 和模型资源。
+- 正式发布要求十项完整附件，先下载并校验草稿全部字节与签名，公开前再次核对附件身份。签名更新序号为 6。
+
+Apple Silicon、Intel Mac、Windows x64 均在对应原生环境从同一个干净 main 提交 `c5c0bcb022c5ae47cca242deb27fe1d30444c41d` 构建。安装版检查覆盖启动、无凭据引导与恢复、内置插件组合、两条升级路径，以及默认保留用户数据的卸载。源码 CI 另行验证上游包组、类型与契约、集成、桌面回归、安全、真实办公/记忆/语音操作和干净克隆构建。
+
+办公与记忆默认开启；消息、语音识别、语音生成、主动陪伴默认关闭，模型权重由用户主动下载。请核对 `SHA256SUMS` 后运行安装器。macOS 未公证，Windows 无 Authenticode；蓬莱签名不代表 Apple 或 Microsoft 发布者认证，更新必须由用户确认。
+
+无凭据自动检查不代表真实模型回复或私密消息送达，账号旅程仅按实际执行结果报告。WhatsApp 不展示、不支持、不捆绑。0.5.9 历史不可变发布缺少元数据的问题未通过改写旧附件掩盖；0.5.10 提供完整发布附件。

--- a/website/en/index.html
+++ b/website/en/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Penglai 0.5.8 | DeepSeek Harness, ready for a personal computer</title>
-  <meta name="description" content="Penglai 0.5.8 uses fixed official DeepSeek Harness 0.1.2-alpha.1 source, with plugin reconciliation, desktop lifecycle fixes, and three native releases.">
-  <meta property="og:title" content="Penglai 0.5.8">
+  <title>Penglai 0.5.10 | DeepSeek Harness, ready for a personal computer</title>
+  <meta name="description" content="Penglai 0.5.10 uses official DeepSeek Harness 0.1.2-rc.1 packages, adapted plugins, safe upgrades from 0.5.8 and 0.5.9, and three native installers.">
+  <meta property="og:title" content="Penglai 0.5.10">
   <meta property="og:description" content="DeepSeek Harness, ready to install. Office, Memory, mobile messaging, and local voice in one desktop distribution.">
   <meta property="og:image" content="https://kevinchennewbee.github.io/PenglaiAgent/shots/0.5.5/plugin-center.png">
   <link rel="icon" href="../favicon.svg" type="image/svg+xml">
@@ -16,7 +16,7 @@
   <header class="topbar">
     <a class="brand" href="#top"><span class="seal">蓬</span><span>Penglai <small>蓬莱</small></span></a>
     <nav aria-label="Main navigation">
-      <a href="#new">0.5.8</a>
+      <a href="#new">0.5.10</a>
       <a href="#inside">What ships</a>
       <a href="#story">Story</a>
       <a href="#download">Download</a>
@@ -30,11 +30,11 @@
       <img class="hero-art" src="../shots/banner-v1.png" alt="The island of Penglai rising above a sea of clouds">
       <div class="hero-shade"></div>
       <div class="hero-copy">
-        <p class="eyebrow">Penglai 0.5.8 · DeepSeek Harness 0.1.2-alpha.1</p>
+        <p class="eyebrow">Penglai 0.5.10 · DeepSeek Harness 0.1.2-rc.1</p>
         <h1>Not another agent.<br>The good open-source one, made installable.</h1>
         <p class="lead">Penglai puts official DeepSeek Harness, Node, Electron, first-run setup, updates, uninstall, and a practical set of DSH plugins into one desktop app. You do not need to learn a terminal first, or move your daily work into another cloud account.</p>
         <div class="actions">
-          <a class="button primary" href="#download">Download 0.5.8</a>
+          <a class="button primary" href="#download">Download 0.5.10</a>
           <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent">Read the source</a>
         </div>
         <p class="quiet">MIT licensed · Local first · Apple Silicon / Intel Mac / Windows x64</p>
@@ -46,12 +46,12 @@
         <p class="eyebrow">What actually changed</p>
         <h2>DSH is still the only core. Penglai makes it a complete desktop product.</h2>
       </div>
-      <p>Official DSH owns models, tools, Workspace, Session, Turn, and the conversation interface. Version 0.5.8 fixes official source tag <code>dsh-v0.1.2-alpha.1</code> without waiting for or publishing an unofficial npm package. Penglai reconciles every first-party plugin, process exit and restart, Windows child authentication forwarding, product title, and first-run ownership. All three installed-product gates explicitly check that the DSH internal-test notice and a second credentials onboarding flow do not appear.</p>
+      <p>Official DSH owns models, tools, Workspace, Session, Turn, and the conversation interface. Version 0.5.10 consumes the exact official <code>0.1.2-rc.1</code> npm packages. Message recovery, budget reconciliation and Companion replay use its Session snapshot API. Upgrades from 0.5.8 and 0.5.9 prepare a separate data generation and preserve the previous one for rollback. Three native installers verify startup, credential-free onboarding, bundled plugins, upgrade and uninstall.</p>
     </section>
 
     <figure class="feature-shot wide-shot">
       <img src="../shots/0.5.5/plugin-center.png" alt="The real Penglai 0.5.5 Plugin Center running in installed DSH">
-      <figcaption>An installed 0.5.5 screen retained as a UI reference. Native installation and public-byte evidence for 0.5.8 is recorded in its publication manifest.</figcaption>
+      <figcaption>An installed 0.5.5 screen retained as a UI reference. Native installation and public-byte evidence for 0.5.10 is recorded in its publication manifest.</figcaption>
     </figure>
 
     <section class="section" id="inside">
@@ -60,10 +60,10 @@
       <div class="cards">
         <article><span class="state on">On by default</span><h3>Penglai Office</h3><p>Inspect, create, edit, preview, and save DOCX, XLSX, PPTX, and PDF. Writes have a plan and confirmation. PDF output includes a Chinese font. LibreOffice is not a user dependency.</p></article>
         <article><span class="state on">On by default</span><h3>Penglai Memory</h3><p>Safe project facts can be organized automatically inside the current Workspace. Candidate curation calls your selected model provider; storage and recall stay local. Personal facts still require an explicit save, and recall never crosses Workspaces.</p></article>
-        <article><span class="state">Opt in</span><h3>Messaging</h3><p>Weixin, Feishu, DingTalk, WeCom, QQ, Slack, Telegram, and Discord enter one <code>@penglai/im</code> control plane, using each platform's QR, device-registration, or official-token flow. WhatsApp is not displayed, supported, or bundled in 0.5.8.</p></article>
+        <article><span class="state">Opt in</span><h3>Messaging</h3><p>Weixin, Feishu, DingTalk, WeCom, QQ, Slack, Telegram, and Discord enter one <code>@penglai/im</code> control plane, using each platform's QR, device-registration, or official-token flow. WhatsApp is not displayed, supported, or bundled in 0.5.10.</p></article>
         <article><span class="state">Opt in</span><h3>Local voice</h3><p>SenseVoice handles speech recognition; MOSS-TTS handles voice generation. Conversation Read speaks the original reply rather than translating it; both preview and Read stop on a second click. Plugin code ships in the app. The large model weights explain themselves before downloading.</p></article>
         <article><span class="state">Opt in</span><h3>Companion</h3><p>It contacts you only after you turn it on, and stays within quiet hours, a daily cap, and one chosen messaging route. Fresh installations keep it off.</p></article>
-        <article><span class="state">Independent updates</span><h3>Signed Plugin Center</h3><p>The catalog comes from immutable GitHub Releases. A reviewed DSH 0.1.2-alpha.1-compatible plugin can join later without shipping a new desktop version merely to change a list.</p></article>
+        <article><span class="state">Independent updates</span><h3>Signed Plugin Center</h3><p>The catalog comes from immutable GitHub Releases. A reviewed DSH 0.1.2-rc.1-compatible plugin can join later without shipping a new desktop version merely to change a list.</p></article>
       </div>
     </section>
 
@@ -98,21 +98,21 @@
         <p><strong>No Penglai account or Penglai-operated telemetry backend.</strong> Official DSH bundles a session-telemetry adapter and a dormant DeepSeek OTLP endpoint. Penglai hard-disables that row after profile patches, so the owned DSH process constructs no SDK provider or upload pipeline. There is no cloud memory sync. Model calls still send the context needed for that task to the provider you selected.</p>
         <p><strong>macOS is not notarized.</strong> The DMGs are ad-hoc signed; Windows has no Authenticode. Gatekeeper or SmartScreen may warn.</p>
         <p><strong>Plugins are not a sandbox.</strong> Signatures, hashes, permissions, and rollback protect distribution, but DSH plugins still share the local DSH process.</p>
-        <p><strong>Evidence stays separated.</strong> Source, packaged, native-installed, and public-byte gates are verified independently. Owner-account connector journeys and a two-hour installed soak remain supplemental <code>LIVE_NOT_RUN</code> evidence and are not claimed by this release.</p>
+        <p><strong>Evidence stays separated.</strong> Source, packaged, native-installed, and public-byte gates are verified independently. Credential-free checks do not prove an external model reply or account message delivery. Those journeys are reported only when actually run. </p>
       </div>
     </section>
 
     <section class="download section" id="download">
-      <p class="eyebrow">Penglai 0.5.8</p>
+      <p class="eyebrow">Penglai 0.5.10</p>
       <h2>Choose your computer.</h2>
       <div class="download-grid">
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.8/Penglai_0.5.8_macos_aarch64.dmg"><strong>macOS · Apple Silicon</strong><span>GitHub · 448.3 MiB · M1 / M2 / M3 / M4 / M5</span><code>cc08a1820f92be4fe5a851a4cfd33f02ab48035c8e98f72feacb2fd074a9b992</code></a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.8/Penglai_0.5.8_macos_x64.dmg"><strong>macOS · Intel</strong><span>GitHub · 393.6 MiB · x86_64 Mac</span><code>14d0c4edf572c134d9d71e6dea69a4bcf53b46cf31ed267fe8472c2f1a4c1b00</code></a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.8/Penglai_0.5.8_windows_x64_setup.exe"><strong>Windows · x64</strong><span>GitHub · 343.2 MiB · 64-bit installer</span><code>0a238bec35ea5117619a5112566ba6985f2194873eb60ef7110d1ca21bc1bec5</code></a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_aarch64.dmg"><strong>macOS · Apple Silicon</strong><span>GitHub · 449.6 MiB · M1 / M2 / M3 / M4 / M5</span><code>0fdca1a2d64c536088b53ddd4910851e9876abed4ee114aecd7a1437ff9417e5</code></a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_x64.dmg"><strong>macOS · Intel</strong><span>GitHub · 388.2 MiB · x86_64 Mac</span><code>6771901b5bf3b7e9e0c192125a866bf2e6c1c605655a8d07339ea37dc64ee9ea</code></a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_windows_x64_setup.exe"><strong>Windows · x64</strong><span>GitHub · 341.0 MiB · 64-bit installer</span><code>46b45bbb6a18859c7be03413b7983ad90dacc7710233130b2c81cb5a537bd484</code></a>
       </div>
-      <p class="quiet">The immutable GitHub Release is the sole authoritative public download source for 0.5.8; the Beijing mirror has not published 0.5.8. All three installers come from source <code>80c8ee81de7a683a1d366bdba0f354826df0a914</code>. Full SHA256SUMS, the 778-component SBOM, third-party notices, and signed update metadata are available on the same page. Updates are never silent.</p>
+      <p class="quiet">The immutable GitHub Release is the sole authoritative public download source for 0.5.10; the Beijing mirror has not published 0.5.10. All three installers come from source <code>c5c0bcb022c5ae47cca242deb27fe1d30444c41d</code>. Full SHA256SUMS, the 1253-component SBOM, third-party notices, and signed update metadata are available on the same page. Updates are never silent.</p>
       <div class="actions centered">
-        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.8">Bilingual release notes</a>
+        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.10">Bilingual release notes</a>
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">Security notes</a>
       </div>
     </section>

--- a/website/index.html
+++ b/website/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>蓬莱 0.5.8 | 把 DeepSeek Harness 装进你的电脑</title>
-  <meta name="description" content="蓬莱 0.5.8 基于固定的 DeepSeek Harness 0.1.2-alpha.1 官方源码，完成插件适配、桌面生命周期修复与三端原生发行。">
-  <meta property="og:title" content="蓬莱 0.5.8">
+  <title>蓬莱 0.5.10 | 把 DeepSeek Harness 装进你的电脑</title>
+  <meta name="description" content="蓬莱 0.5.10 基于固定的 DeepSeek Harness 0.1.2-rc.1 官方源码，完成插件适配、桌面生命周期修复与三端原生发行。">
+  <meta property="og:title" content="蓬莱 0.5.10">
   <meta property="og:description" content="DeepSeek Harness，装好就能用。办公、记忆、手机消息和本地语音都在一个桌面发行版里。">
   <meta property="og:image" content="https://kevinchennewbee.github.io/PenglaiAgent/shots/0.5.5/plugin-center.png">
   <link rel="icon" href="./favicon.svg" type="image/svg+xml">
@@ -16,7 +16,7 @@
   <header class="topbar">
     <a class="brand" href="#top"><span class="seal">蓬</span><span>蓬莱 <small>PENGLAI</small></span></a>
     <nav aria-label="主导航">
-      <a href="#new">0.5.8</a>
+      <a href="#new">0.5.10</a>
       <a href="#inside">内置能力</a>
       <a href="#story">缘起</a>
       <a href="#download">下载</a>
@@ -30,11 +30,11 @@
       <img class="hero-art" src="./shots/banner-v1.png" alt="云海中的蓬莱仙山">
       <div class="hero-shade"></div>
       <div class="hero-copy">
-        <p class="eyebrow">Penglai 0.5.8 · DeepSeek Harness 0.1.2-alpha.1</p>
+        <p class="eyebrow">Penglai 0.5.10 · DeepSeek Harness 0.1.2-rc.1</p>
         <h1>不是另一个 Agent。<br>是把好用的开源 Agent，真正装进电脑。</h1>
         <p class="lead">蓬莱把官方 DeepSeek Harness、Node、Electron、首次引导、更新、卸载和一组实用 DSH 插件放进一个桌面客户端。你不用先学终端，也不用把日常交给一个新的云账号。</p>
         <div class="actions">
-          <a class="button primary" href="#download">下载 0.5.8</a>
+          <a class="button primary" href="#download">下载 0.5.10</a>
           <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent">查看源代码</a>
         </div>
         <p class="quiet">MIT 开源 · 本地优先 · Apple Silicon / Intel Mac / Windows x64</p>
@@ -46,12 +46,12 @@
         <p class="eyebrow">这次真正变了什么</p>
         <h2>DSH 还是唯一核心，蓬莱把它变成了一个完整产品。</h2>
       </div>
-      <p>模型、工具、Workspace、Session、Turn 和会话界面都归官方 DSH。0.5.8 固定到官方源码标签 <code>dsh-v0.1.2-alpha.1</code>，无需等待或发布非官方 npm 包。蓬莱完成全部第一方插件适配，修复进程退出与重启、Windows 子进程认证转发、产品标题和首次引导归属；三端安装验证还明确检查不显示 DSH 内测通知，也不出现第二套密钥引导。</p>
+      <p>模型、工具、Workspace、Session、Turn 和会话界面都归官方 DSH。0.5.10 使用精确固定的官方 <code>0.1.2-rc.1</code> npm 包；消息恢复、预算结算和主动陪伴回放适配官方 Session 快照接口。从 0.5.8 和 0.5.9 升级时准备独立数据代际，保留旧版用于回退。三端原生安装包验证启动、无凭据引导、内置插件、升级和卸载。</p>
     </section>
 
     <figure class="feature-shot wide-shot">
       <img src="./shots/0.5.5/plugin-center.png" alt="真实安装的蓬莱 0.5.5 插件中心">
-      <figcaption>0.5.5 安装版截图作为界面参考；0.5.8 的原生安装与公开字节证据记录在发布清单中。</figcaption>
+      <figcaption>0.5.5 安装版截图作为界面参考；0.5.10 的原生安装与公开字节证据记录在发布清单中。</figcaption>
     </figure>
 
     <section class="section" id="inside">
@@ -60,7 +60,7 @@
       <div class="cards">
         <article><span class="state on">默认启用</span><h3>蓬莱办公</h3><p>读取、创建、修改、预览和保存 DOCX、XLSX、PPTX 与 PDF。写入前有计划和确认，PDF 自带中文字体，不要求用户安装 LibreOffice。</p></article>
         <article><span class="state on">默认启用</span><h3>蓬莱记忆</h3><p>安全的项目事实会自动整理到当前 Workspace；整理候选会调用你选择的模型供应商，记录与召回留在本机。个人事实仍需明确保存，记忆绝不会跨 Workspace 召回。</p></article>
-        <article><span class="state">按需启用</span><h3>蓬莱消息连接</h3><p>微信、飞书、钉钉、企业微信、QQ、Slack、Telegram 与 Discord 统一进入 <code>@penglai/im</code>，按平台使用扫码、设备注册或官方 Token。WhatsApp 在 0.5.8 中不展示、不支持，也不捆绑运行时。</p></article>
+        <article><span class="state">按需启用</span><h3>蓬莱消息连接</h3><p>微信、飞书、钉钉、企业微信、QQ、Slack、Telegram 与 Discord 统一进入 <code>@penglai/im</code>，按平台使用扫码、设备注册或官方 Token。WhatsApp 在 0.5.10 中不展示、不支持，也不捆绑运行时。</p></article>
         <article><span class="state">按需启用</span><h3>本地语音</h3><p>SenseVoice 负责语音识别，MOSS-TTS 负责语音生成。会话 Read 朗读原文，不负责翻译；试听与 Read 都可再次点击停止。插件代码随包，较大的模型权重会在启用时说明后再下载。</p></article>
         <article><span class="state">按需启用</span><h3>主动陪伴</h3><p>只有你主动开启后才会定时联系，并受安静时间、每日次数和指定消息渠道约束。默认不会擅自运行。</p></article>
         <article><span class="state">持续更新</span><h3>签名插件中心</h3><p>插件列表来自不可变 GitHub Release。兼容的新插件可以通过签名目录加入，不必只为更新一张列表重发桌面版本。</p></article>
@@ -98,21 +98,21 @@
         <p><strong>没有蓬莱账号或蓬莱运营的遥测后端。</strong>official DSH 自带 session-telemetry adapter 和一个休眠的 DeepSeek OTLP 地址。蓬莱会在所有 profile patch 之后硬性禁用该行，因此 owned DSH 不会创建 SDK provider 或上传管线。没有云端记忆同步；模型调用仍会把本次任务需要的内容发给你选择的模型供应商。</p>
         <p><strong>macOS 未公证。</strong>安装包是 ad-hoc 签名；Windows 没有 Authenticode。Gatekeeper 或 SmartScreen 可能提醒。</p>
         <p><strong>插件不是沙箱。</strong>签名、哈希、权限清单和回滚保护的是分发链路，但 DSH 插件仍与本地 DSH 共享进程权限。</p>
-        <p><strong>证据分层。</strong>源码、打包、原生安装和公开字节分别验证。真实 Owner 外部账号连接与两小时安装版稳定运行仍标记为补充性的 <code>LIVE_NOT_RUN</code>，本次发布不把它们说成已经完成。</p>
+        <p><strong>证据分层。</strong>源码、打包、原生安装和公开字节分别验证。无凭据检查不能证明真实模型回复或账号消息送达；这些旅程仅记录实际执行的结果。</p>
       </div>
     </section>
 
     <section class="download section" id="download">
-      <p class="eyebrow">Penglai 0.5.8</p>
+      <p class="eyebrow">Penglai 0.5.10</p>
       <h2>选择你的电脑。</h2>
       <div class="download-grid">
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.8/Penglai_0.5.8_macos_aarch64.dmg"><strong>macOS · Apple 芯片</strong><span>GitHub · 448.3 MiB · M1 / M2 / M3 / M4 / M5</span><code>cc08a1820f92be4fe5a851a4cfd33f02ab48035c8e98f72feacb2fd074a9b992</code></a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.8/Penglai_0.5.8_macos_x64.dmg"><strong>macOS · Intel</strong><span>GitHub · 393.6 MiB · x86_64 Mac</span><code>14d0c4edf572c134d9d71e6dea69a4bcf53b46cf31ed267fe8472c2f1a4c1b00</code></a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.8/Penglai_0.5.8_windows_x64_setup.exe"><strong>Windows · x64</strong><span>GitHub · 343.2 MiB · 64 位安装器</span><code>0a238bec35ea5117619a5112566ba6985f2194873eb60ef7110d1ca21bc1bec5</code></a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_aarch64.dmg"><strong>macOS · Apple 芯片</strong><span>GitHub · 449.6 MiB · M1 / M2 / M3 / M4 / M5</span><code>0fdca1a2d64c536088b53ddd4910851e9876abed4ee114aecd7a1437ff9417e5</code></a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_x64.dmg"><strong>macOS · Intel</strong><span>GitHub · 388.2 MiB · x86_64 Mac</span><code>6771901b5bf3b7e9e0c192125a866bf2e6c1c605655a8d07339ea37dc64ee9ea</code></a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_windows_x64_setup.exe"><strong>Windows · x64</strong><span>GitHub · 341.0 MiB · 64 位安装器</span><code>46b45bbb6a18859c7be03413b7983ad90dacc7710233130b2c81cb5a537bd484</code></a>
       </div>
-      <p class="quiet">0.5.8 当前只以不可变 GitHub Release 为权威公开下载源；北京镜像尚未发布 0.5.8。三个安装包来自源码 <code>80c8ee81de7a683a1d366bdba0f354826df0a914</code>。完整 SHA256SUMS、778 组件 SBOM、第三方声明与签名元数据同页提供；更新不会静默执行。</p>
+      <p class="quiet">0.5.10 当前只以不可变 GitHub Release 为权威公开下载源；北京镜像尚未发布 0.5.10。三个安装包来自源码 <code>c5c0bcb022c5ae47cca242deb27fe1d30444c41d</code>。完整 SHA256SUMS、1253 组件 SBOM、第三方声明与签名元数据同页提供；更新不会静默执行。</p>
       <div class="actions centered">
-        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.8">中英文发布说明</a>
+        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.10">中英文发布说明</a>
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">安全说明</a>
       </div>
     </section>


### PR DESCRIPTION
README and the bilingual website still pointed to older releases, and the public security entry was on 0.5.8. Update them to the immutable 0.5.10 release with the observed installer sizes and SHA-256 digests, official DSH rc.1 provenance, both supported upgrade paths, and honest signing/account-test boundaries. Add the bilingual release notes and publication records for all ten verified assets.

The installers remain built from c5c0bcb022c5ae47cca242deb27fe1d30444c41d. This PR changes only the permitted publication documents and website pages; it does not alter the frozen build or any published asset.

Validation: 14 publication-document and website tests passed; formatting and whitespace checks passed. Three native targets and the complete 21-gate release aggregate passed in run 33775824578. Guarded publication and immutable ten-asset byte/signature readback passed in run 33780754033. Website deployment and both-origin byte readback follow this PR.
