### PR TITLE
feat: land 0.5.11 source on the frozen DSH rc.1 cohort

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,18 @@
 # Contributing to Penglai
 
-Penglai is a desktop distribution of official DeepSeek Harness. Product work happens on a single `main` branch. Do not open feature branches, worktrees, or pull requests unless the repository owner changes that contract.
+Penglai is a desktop distribution of official DeepSeek Harness. Follow the
+current `AGENTS.md` and version contract. Commit, push, PR and merge only with
+the user's applicable authorization. Completed 0.5.10 publication does not
+authorize another release.
 
 ## Prerequisites
 
 - Node `22.22.2`
-- pnpm `10.14.0`
+- pnpm `11.7.0`
 - macOS 13.0+ (macOS 14+ recommended for the current Apple Silicon native runner)
-- Do not depend on GitHub Actions. Local or self-hosted native runners are the source of installed evidence.
+- Native installed evidence still comes from matching-target installers, not from
+  `dist` staging. GitHub Actions native jobs are evidence only when they produce
+  the exact contract artifacts.
 
 ## Required reading before code
 
@@ -39,11 +44,14 @@ pnpm package:mac
 pnpm build:local-dmg --reuse-app
 ```
 
-`package:mac` refuses a dirty tree and refuses `HEAD != origin/main`. macOS arm64 and macOS x64 must be built separately. A universal app is not two installers.
+Native packaging still refuses a dirty tree for release artifacts. Apple Silicon
+and Intel Mac builds are separate installers; a universal app is not two
+installers. Follow the current version's acceptance delta, not a historical
+runbook.
 
 ## Public export
 
-`pnpm prepare:public-export` builds an allowlisted source tree and `publicExportTreeSha256`. `STATE.md`, evidence, `dist`, and private handoff documents are excluded. Public repo, tag, Release, and updater channel work are not authorized in this repository pass.
+`pnpm prepare:public-export` builds an allowlisted source tree and `publicExportTreeSha256`. `STATE.md`, evidence, `dist`, and private handoff documents are excluded. Public tag, Release and updater work require a current-version authorization.
 
 ## Secrets
 

--- a/PRODUCT_CONSTITUTION.md
+++ b/PRODUCT_CONSTITUTION.md
@@ -50,6 +50,7 @@
 - GitHub Actions 与 required CodeQL 当前可用，但不能替代安装包验收。Apple Silicon 本机可产生 darwin-aarch64 候选；Intel 与 Windows 的 native PASS 必须来自对应原生 runner。交叉构建或 Rosetta 只能作为补充证据。
 - 默认“智能整理 Workspace”：自动 curator 必须走 official Agent、禁用工具、Host 封闭校验，只能把安全项目事实写入 exact Workspace；个人/全局记忆仍需 Owner 确认，召回不得跨 Workspace。
 - Owner 已授权 0.5.10 功能分支开发与推送，在完整审核和正常门禁通过后创建 PR、合并 main，从同一干净 main SHA 完成三端原生构建及完整十项附件发布，随后更新 README、官网与公开文档。两小时测试不运行，也不是补充待办。临时 API key、聊天正文、二维码、账号身份、私有路径、profile、凭据或私钥仍不得上传。
+- **0.5.11 开发冻结**（D-067）：`codex/0.5.11` 继续消费官方 DSH `0.1.2-rc.1` 完整 254 包 npm cohort；`dsh-v0.1.3-alpha.1` 不得混装。公开产品身份仍是 **Penglai v0.5.10**。在没有新的发布授权前，不得把 package/lock/profile/`release-contract.json` 改写成 0.5.11，也不得改写已发布的 0.5.10 tag 或附件。精确冻结记录见 `docs/0.5.11/COHORT_FREEZE.json`。
 
 0.5.8 的预览方向不改写已经公开的 0.5.7 tag、Release、附件或历史文档。迁移到新 DSH 时必须从现行源代码与产品表面移除 WhatsApp 的说明卡、channel identity、连接路径、adapter/runtime 接线、Baileys/libsignal 依赖以及任何支持或路线图声明；Git 历史与明确标注为历史的发行审计记录继续保留。移除完成后需用 catalog、依赖闭包、lockfile、SBOM、许可证、安装包内容和用户界面反向证明 WhatsApp 不再属于 Penglai。
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="SECURITY.md">Security</a>
 </p>
 
-> Penglai 0.5.10 is an immutable public release built from
+> The current public product is Penglai 0.5.10, an immutable release built from
 > `c5c0bcb022c5ae47cca242deb27fe1d30444c41d`. It consumes official DSH `0.1.2-rc.1` npm packages,
 > reconciled to tag `dsh-v0.1.2-rc.1` at
 > `a66e4702047846cdaa10c66c9d3df3951f5ea70d`. All 254 package archives,
@@ -33,6 +33,9 @@
 > The release includes three native installers and all seven integrity and license files.
 > macOS is ad-hoc signed and not notarized; Windows has no Authenticode.
 > [Release notes](docs/RELEASE_NOTES_0.5.10.md) · [Verified publication](docs/PUBLICATION_MANIFEST_0.5.10.md)
+>
+> 0.5.11 is in development on this branch. It is not a published installer set.
+> Do not treat source tests as native, live-account or public-release evidence.
 
 <p align="center">
   <img src=".github/assets/0.5.5/plugin-center.png" width="49%" alt="Penglai 0.5.5 Plugin Center in the installed DSH settings">
@@ -64,6 +67,10 @@ replay to the official Session snapshot API. Upgrades from 0.5.8 and 0.5.9 use
 an isolated rc.1 DSH Home and preserve the previous generation for rollback.
 All three native installers pass credential-free onboarding and plugin checks,
 both upgrade paths, and default uninstall with user data preserved.
+
+The public download is still 0.5.10. 0.5.11 is in development on this branch
+and has no published installers. Source tests are not native, live-account or
+public-release evidence.
 
 ## What ships in 0.5.10
 
@@ -334,6 +341,9 @@ Turn 和会话界面都归 DSH。蓬莱负责那些不太耀眼、却决定桌�
 主动陪伴回放适配官方 Session 快照接口。从 0.5.8 和 0.5.9 升级时使用独立的
 rc.1 数据目录，保留旧代际用于回退。三端安装包均通过无需真实账号的引导和插件
 检查、两条升级路径，以及默认保留用户数据的卸载验证。
+
+当前公开下载仍是 0.5.10。0.5.11 还在开发，没有安装包，也没有公开发布附件。
+源码测试不能当作原生安装、真实账号或公开发布证据。
 
 ## 0.5.10 带来了什么
 

--- a/apps/desktop/static/wizard/wizard.js
+++ b/apps/desktop/static/wizard/wizard.js
@@ -329,6 +329,9 @@
     const status = await rpc("status");
     state.current = status.current;
     state.completed = Array.isArray(status.completed) ? status.completed : [];
+    if (status.lastError && typeof status.lastError.code === "string") {
+      state.error = status.lastError.code;
+    }
     let providers = Array.isArray(status.providers) ? status.providers : [];
     if (providers.length === 0) {
       try {

--- a/docs/0.5.11/ACCEPTANCE_DELTA.md
+++ b/docs/0.5.11/ACCEPTANCE_DELTA.md
@@ -58,18 +58,19 @@ These files are development records, not a public 0.5.11 announcement:
 - [Development release notes](RELEASE_NOTES.md)
 - [Security notes](SECURITY.md)
 - [Upgrade design](UPGRADE.md)
+- [Memory curator API](MEMORY_CURATOR.md)
 
 Public `SECURITY.md` and `docs/RELEASE_NOTES_0.5.10.md` stay on 0.5.10.
 
 ## Remaining publication blockers
 
-- In-scope source is committed as `d7f20c7eeadf6722ab832f5cc3374cb7c5e6f77a`.
-  Owner `AGENTS.md` / `docs/0.5.7/RELEASE_RUNBOOK.md` stay uncommitted.
-- Darwin-aarch64 local candidate DMG exists for that SHA (ad-hoc, not
+- In-scope source is on `codex/0.5.11` / PR 133. Owner `AGENTS.md` /
+  `docs/0.5.7/RELEASE_RUNBOOK.md` stay uncommitted.
+- Darwin-aarch64 local candidate DMG exists for `d7f20c7e` (ad-hoc, not
   notarized). Intel Mac and Windows x64 matching-native builds do not.
 - Installed fresh/restart/Back/retry/upgrade/uninstall evidence is unrun.
 - No live model/IM credentials in this session.
-- No push/PR or GitHub Release authorization for 0.5.11.
+- No merge to `main` and no GitHub Release authorization for 0.5.11.
 
 ## 中文
 

--- a/docs/0.5.11/ACCEPTANCE_DELTA.md
+++ b/docs/0.5.11/ACCEPTANCE_DELTA.md
@@ -1,0 +1,80 @@
+# Penglai 0.5.11 acceptance delta
+
+This delta is for the `codex/0.5.11` development branch. It does not authorize
+publication and does not replace `docs/0.5.10/ACCEPTANCE_DELTA.md`.
+
+Public downloads, three-target native installers, signatures and live-account
+proof remain those of **0.5.10** until a later immutable 0.5.11 publication.
+
+## In scope for this development tree
+
+- Identity and recovery repairs listed in `TODO.md` A/B/C rows.
+- First-party Memory library query, official Weixin/Feishu request identity,
+  digest-bound PDF inspect/preview, read-only usage projection, and redacted
+  Plugin Center diagnostics.
+- Bilingual README and `website/` professional redesign that still points
+  current downloads at 0.5.10.
+- Deterministic source gates. Owner excludes the two-hour installed soak.
+  `test:soak` remains required.
+
+## Out of scope until separately evidenced
+
+- Native Apple Silicon / Intel Mac / Windows x64 rebuilds from a clean `main`
+  SHA.
+- Live model/IM account observations.
+- Immutable GitHub Release `v0.5.11` assets.
+- UOS/LoongArch as a fourth official target.
+- A second Agent core, mixed DSH generations, or enabling Budget enforcement
+  merely to show usage.
+
+## Cohort freeze (development)
+
+Exact identities are in `COHORT_FREEZE.json` and must match
+`packages/release-identity/src/pins.ts` plus `release-contract.json`.
+
+- Official DSH remains npm `0.1.2-rc.1`, tag `dsh-v0.1.2-rc.1`, commit
+  `a66e4702047846cdaa10c66c9d3df3951f5ea70d`, 254-package cohort.
+- `dsh-v0.1.3-alpha.1` is rejected as a successor until a complete npm cohort
+  exists. Mixed DSH generations are forbidden.
+- Public product identity remains **0.5.10** (`v0.5.10`). This tree must not
+  retitle package/lock/profile/release-contract identity to 0.5.11 without
+  publication authorization.
+- Migration/rollback: preserve the previous DSH Home generation and switch the
+  pointer only after health checks; Plugin Center restores last-good profile;
+  Windows upgrade stages `$INSTDIR.pending` and restores `$INSTDIR.previous`.
+
+## Conditional records
+
+- Light workbench: only official DSH slots; see `WORKBENCH.md`.
+- UOS/LoongArch: feasibility only; see `UOS.md`.
+- Mnemon native: retain `0.2.4`; see `MNEMON.md`. Successor `0.2.7`/`0.2.8`
+  is not consumed without three-target assets and Windows path/old-db evidence.
+
+## Development documentation
+
+These files are development records, not a public 0.5.11 announcement:
+
+- [Requirement review](REQUIREMENT_REVIEW.md)
+- [Development release notes](RELEASE_NOTES.md)
+- [Security notes](SECURITY.md)
+- [Upgrade design](UPGRADE.md)
+
+Public `SECURITY.md` and `docs/RELEASE_NOTES_0.5.10.md` stay on 0.5.10.
+
+## Remaining publication blockers
+
+- Dirty worktree (111 paths). Official Office/Memory PASS, `package:mac` and
+  `verify:clean-clone` refuse this state. Owner `AGENTS.md` /
+  `docs/0.5.7/RELEASE_RUNBOOK.md` must stay out of implementation commits.
+- Packaged closure source `d5f76361…` ≠ this HEAD `10ef5df4…`.
+- No Apple Silicon / Intel Mac / Windows x64 0.5.11 installers from one clean
+  `main` SHA.
+- No live model/IM credentials in this session.
+- No commit/push/PR or GitHub Release authorization for 0.5.11.
+
+## 中文
+
+本增量只约束 `codex/0.5.11` 开发树，不授权公开发布，也不改写 0.5.10。官方 DSH
+仍固定 `0.1.2-rc.1` 完整 npm 队列。源码层隔离、恢复、记忆库、微信/飞书请求身份、
+PDF 正文/预览、只读用量和插件诊断已在本树落地；三端安装包、已安装生命周期、
+真实账号和 GitHub Release 仍未取证。Mnemon 保留 `0.2.4`。公开身份仍是 0.5.10。

--- a/docs/0.5.11/ACCEPTANCE_DELTA.md
+++ b/docs/0.5.11/ACCEPTANCE_DELTA.md
@@ -63,14 +63,13 @@ Public `SECURITY.md` and `docs/RELEASE_NOTES_0.5.10.md` stay on 0.5.10.
 
 ## Remaining publication blockers
 
-- Dirty worktree (111 paths). Official Office/Memory PASS, `package:mac` and
-  `verify:clean-clone` refuse this state. Owner `AGENTS.md` /
-  `docs/0.5.7/RELEASE_RUNBOOK.md` must stay out of implementation commits.
-- Packaged closure source `d5f76361…` ≠ this HEAD `10ef5df4…`.
-- No Apple Silicon / Intel Mac / Windows x64 0.5.11 installers from one clean
-  `main` SHA.
+- In-scope source is committed as `d7f20c7eeadf6722ab832f5cc3374cb7c5e6f77a`.
+  Owner `AGENTS.md` / `docs/0.5.7/RELEASE_RUNBOOK.md` stay uncommitted.
+- Darwin-aarch64 local candidate DMG exists for that SHA (ad-hoc, not
+  notarized). Intel Mac and Windows x64 matching-native builds do not.
+- Installed fresh/restart/Back/retry/upgrade/uninstall evidence is unrun.
 - No live model/IM credentials in this session.
-- No commit/push/PR or GitHub Release authorization for 0.5.11.
+- No push/PR or GitHub Release authorization for 0.5.11.
 
 ## 中文
 

--- a/docs/0.5.11/COHORT_FREEZE.json
+++ b/docs/0.5.11/COHORT_FREEZE.json
@@ -1,0 +1,38 @@
+{
+  "schema": 1,
+  "kind": "penglai-0.5.11-development-cohort-freeze",
+  "status": "development-frozen",
+  "publicRelease": {
+    "productVersion": "0.5.10",
+    "tag": "v0.5.10",
+    "immutable": true
+  },
+  "development": {
+    "versionLabel": "0.5.11",
+    "publicationAuthorized": false,
+    "identityRetitled": false
+  },
+  "dsh": {
+    "version": "0.1.2-rc.1",
+    "tag": "dsh-v0.1.2-rc.1",
+    "commit": "a66e4702047846cdaa10c66c9d3df3951f5ea70d",
+    "packageCount": 254,
+    "tarballSha256": "ca370668053ad6d0ac325e919ef5f65de53de00b7bad78008e6fb422dfce3530",
+    "closureManifestSha256": "31a52e8bc520b185c71849f3b084d65f9f7c888358ae33d4ea2d5eb4aba9f198",
+    "rejectedSuccessor": {
+      "tag": "dsh-v0.1.3-alpha.1",
+      "reason": "GitHub tag exists; npm does not publish a complete matching 254-package cohort with registry integrity. Mixing DSH generations is forbidden."
+    }
+  },
+  "runtime": {
+    "node": "22.22.2",
+    "electron": "43.4.0",
+    "pnpm": "11.7.0"
+  },
+  "migration": {
+    "homeGeneration": "preserve-previous-DSH-Home-then-health-check-before-pointer-switch",
+    "center": "last-good-profile",
+    "windowsUpgrade": "INSTDIR.pending-then-INSTDIR.previous",
+    "mixedDshGenerations": "forbidden"
+  }
+}

--- a/docs/0.5.11/MEMORY_CURATOR.md
+++ b/docs/0.5.11/MEMORY_CURATOR.md
@@ -1,0 +1,38 @@
+# 0.5.11 Memory curator (actual official API)
+
+This reconciles older “curator Agent/Session” wording with the shipped
+`@penglai/memory` path on DSH `0.1.2-rc.1`. It does not add a second Agent core.
+
+## What runs
+
+After official `session/event` `turn/end`, Memory enqueues one internal job per
+`(workspaceId, sessionId, turnId)` on `InternalCuratorQueue` (max two attempts).
+
+The job calls official `ctx.llm.stream` once:
+
+- `sessionId` is omitted
+- `tools` is `[]`
+- the prompt `source` is `{ kind: "plugin", plugin: "@penglai/memory" }`
+- provider/model come from the official Agent route of that Session
+
+Late tool blocks and an already-aborted signal fail closed. Parse failures
+fail open for the user Turn and enqueue no candidates.
+
+## What does not run
+
+- No user-visible curator Session or `origin: subagent`
+- No official Jobs / workbench task engine
+- No second conversation UI
+- No auto-write to personal/global/SOP; those still need Owner confirmation
+- Auto-save is only current-Workspace safe project facts after Host policy
+
+Audit rows store a digest and closed failure metadata, not chat bodies.
+
+See `packages/memory/src/index.ts`, `turn-pipeline.ts`, `v2/internal-curator.ts`,
+and `turn-pipeline.test.ts` (“one official LLM request without Session or tools”).
+
+## 中文
+
+0.5.11 的记忆整理不再创建可见 Session。它在官方 `turn/end` 后用 Memory 内部队列
+发一次禁用工具的 `ctx.llm.stream`。失败对用户 Turn 失败开放，不写入半份记忆。
+个人/全局/SOP 仍需 Owner 确认。

--- a/docs/0.5.11/MNEMON.md
+++ b/docs/0.5.11/MNEMON.md
@@ -1,0 +1,58 @@
+# R511-02c Mnemon native evaluation
+
+Decision: **retain `0.2.4`**. Do not upgrade this development freeze.
+
+Checked on 2026-09-07 against GitHub releases and this worktree.
+
+## Current pin
+
+| Field | Value |
+| --- | --- |
+| Release | `v0.2.4` |
+| Commit | `67ed1a2f80de902fd041eeaf3b90e7e3d2480d5b` |
+| Runner check | `packages/memory/src/engine/runner.ts` requires stdout to include `0.2.4` |
+| Assets | `third_party/sources.lock.json` darwin-aarch64 / darwin-x86_64 / win32-x86_64 |
+
+## Local CLI evidence (not official PASS)
+
+On Darwin arm64 this session ran the pinned binary:
+
+```text
+third_party/mnemon/bin/darwin-aarch64/mnemon --version
+mnemon version 0.2.4
+```
+
+`pnpm verify:memory-real` executed remember / search / recall / related / viz /
+forget / status against temporary data dirs, plus a 100k search fixture. The
+gate then finished **INCOMPLETE** with `working tree dirty; official PASS
+forbidden`. That is a functional probe, not Memory-real PASS, and not Windows
+evidence.
+
+## Successor survey (2026-09-07)
+
+Latest GitHub release at check time: **`v0.2.8`** (`2026-09-05`).
+
+| Version | Why it is not consumed here |
+| --- | --- |
+| 0.2.5 | MiniMax Code / ZCode host integrations. Not a Penglai Memory engine requirement. |
+| 0.2.6 | OpenAI-compatible embeddings and readonly-write enforcement. Needs new asset identity and Memory-real. |
+| 0.2.7 | Claims Windows/relative `--data-dir` SQLite URI encoding for spaces, Unicode, `#`, `%`. This is the first successor that matches the row's Windows special-character requirement. **Not verified on Windows in this session.** |
+| 0.2.8 | npm-managed CLI distribution plus embeddings probe fallback. Penglai ships pinned native archives, not `mnemon update`. |
+
+Upgrade would also require:
+
+1. Exact three-target archive/binary SHA-256 in `sources.lock.json` and
+   `packages/release-identity`.
+2. Runner version pin change from `0.2.4`.
+3. Old `mnemon.db` copy open/search/rollback on each target.
+4. Windows native paths with spaces/Unicode/`#`/`%`.
+5. No mixed 0.2.4/0.2.8 binaries in one release closure.
+
+Those items are absent. The cohort freeze therefore keeps `0.2.4`.
+
+## 中文
+
+评估结论是保留 Mnemon `0.2.4`。本机 Apple Silicon 上 CLI 能跑 remember/search，
+但官方 Memory-real 因脏工作区禁止 PASS。GitHub 已有 `0.2.8`；其中 `0.2.7` 才
+对准 Windows 特殊字符路径，但本会话没有 Windows 主机、没有旧库副本和回滚证据，
+所以不能升级。

--- a/docs/0.5.11/MNEMON.md
+++ b/docs/0.5.11/MNEMON.md
@@ -13,20 +13,14 @@ Checked on 2026-09-07 against GitHub releases and this worktree.
 | Runner check | `packages/memory/src/engine/runner.ts` requires stdout to include `0.2.4` |
 | Assets | `third_party/sources.lock.json` darwin-aarch64 / darwin-x86_64 / win32-x86_64 |
 
-## Local CLI evidence (not official PASS)
+## Local CLI evidence
 
-On Darwin arm64 this session ran the pinned binary:
+On Darwin arm64 the pinned binary prints `mnemon version 0.2.4`.
 
-```text
-third_party/mnemon/bin/darwin-aarch64/mnemon --version
-mnemon version 0.2.4
-```
-
-`pnpm verify:memory-real` executed remember / search / recall / related / viz /
-forget / status against temporary data dirs, plus a 100k search fixture. The
-gate then finished **INCOMPLETE** with `working tree dirty; official PASS
-forbidden`. That is a functional probe, not Memory-real PASS, and not Windows
-evidence.
+On clean SHA `d7f20c7eeadf6722ab832f5cc3374cb7c5e6f77a`, `pnpm verify:memory-real`
+is official PASS: remember/search/recall/forget, workspace isolation, and the
+exact 100k corpus query. That is darwin-aarch64 Memory-real, not Windows
+special-character paths, old-database copies, or rollback.
 
 ## Successor survey (2026-09-07)
 

--- a/docs/0.5.11/PLAN.md
+++ b/docs/0.5.11/PLAN.md
@@ -1,0 +1,163 @@
+# Penglai 0.5.11 implementation and verification plan
+
+Status: in development. This document does not assert release or test completion.
+
+## Objective and authority
+
+Deliver Penglai 0.5.11 by combining a fresh upstream assessment, the September
+0.5.11 research proposals, and the source/history audit. Repair the identified
+defects, implement the selected first-party improvements, redesign the public
+README and bilingual website, and complete the normal verification and release
+workflow. The Owner excludes the two-hour installed soak. Deterministic
+`test:soak` and all other applicable normal checks remain required.
+
+The implementation starts from public `main` at
+`10ef5df4fc0fbccd2d119dfeecbc8436ccccff01`. The existing Owner modifications to
+`AGENTS.md` and the historical 0.5.7 runbook are preserved and are not included in
+implementation commits by default. Published releases, tags and assets through
+0.5.10 remain immutable. Historical reference documents are evidence, not new
+operating instructions or automatic approval grants.
+
+`TODO.md` is the completion ledger. An item is complete only when its stated
+behavior and corresponding evidence exist. A passing unrelated test, a version
+string, an empty check collection, or a source-only check cannot close a native
+or account-based requirement.
+
+## Product outcome
+
+DSH remains the only Agent, model, Workspace, Session, Turn, tool, approval and
+conversation system. Penglai owns installation, private runtime lifecycle,
+reviewed plugins and product presentation. Office and Memory remain required;
+Messaging, ASR, TTS and Companion remain optional and initially disabled.
+
+The release combines these outcomes:
+
+1. Correct identities and authorization before any read, write, delivery or
+   destructive operation; cancellation and logout revoke pending authority.
+2. Transactions that survive interruption without losing the latest successful
+   state, reviving stopped connections, or damaging another app instance.
+3. A conversation Memory library backed by the existing first-party engine:
+   search, pagination, provenance, time and scope, source management and existing
+   owner-approved correction/forgetting actions.
+4. A mobile task loop, starting with Weixin and Feishu: official questions and
+   approvals, scoped replies, cancellation, visible terminal states and bounded
+   recovery. Other channel capabilities are described individually.
+5. Reliable text-PDF reading and actual PDF page previews bound to the reviewed
+   artifact digest; correct DOCX edits and Office job transitions. Scanned PDF
+   is identified as requiring OCR, not silently treated as an empty text file.
+6. A read-only conversation context/usage view using official accounting, with
+   distinct context size, cumulative usage, cache and estimated-cost meanings.
+7. Plugin Center status, updates and redacted diagnostics that describe actual
+   installed/loaded/healthy state and useful recovery actions.
+8. A complete, professional, accessible English-first/Chinese-second README and
+   website describing the verified product, with real downloads and limitations.
+
+The light workbench is a conditional candidate: only official extension points,
+no replacement chat UI, extra task engine or hidden core patches. UOS/LoongArch is
+an independent feasibility line, not a fourth supported release target. Its
+source/runtime/sandbox/asset and available-device evidence must be recorded even
+when native execution is unavailable.
+
+## Upstream selection
+
+Refresh official npm metadata, GitHub releases, source changes and actual package
+contents before freezing candidates. Assess DSH, standalone Node, Electron,
+Mnemon native, Feishu/DingTalk SDKs, sherpa-onnx, ONNX Runtime and Office/PDF
+dependencies. Distinguish a reference plugin from a production dependency.
+
+A DSH generation changes only with a complete consumable official npm cohort,
+exact registry integrities, compatible native assets, license closure and an
+explicit migration design. A GitHub tag alone is insufficient. Retaining the
+existing rc.1 cohort is valid when no suitable complete successor is available;
+do not delay first-party work indefinitely or assemble mixed-generation packages.
+All selected upgrades need source/package mapping and behavior tests. Do not
+assume identical `gitHead` values prove SDK tarballs contain the same fixes.
+
+Record accept/retain/reject decisions in `UPSTREAM_DECISIONS.md`, including exact
+versions, URLs, integrity/source evidence, reasons and required checks. Recheck
+the chosen cohort at release freeze; changing it restarts affected validation.
+
+## Implementation order
+
+### 1. Security and identity
+
+Bind authorization to channel/account/peer, Workspace/Session, object/revision,
+action and connection generation as applicable. Reject before effects. Preserve
+product Owner confirmation rather than treating generic chat consent as a write
+grant. Make all Office job operations enforce the job's own scope. Resolve
+destructive paths through their ancestors and revalidate before deletion.
+
+### 2. Recovery and lifecycle
+
+Use a shared validated transaction journal contract at both writer and boot
+reader. Preserve the latest successful snapshot across repeated transactions;
+record rollback failure as unresolved. Normalize successful updates on launch.
+Serialize approval processing. Stop late async continuations from obtaining new
+authority after cancellation, logout, disposal or generation changes. Scope
+process cleanup to owned instances. Stage Windows upgrade payloads with a
+recoverable activation boundary. Unify bundled and remote plugin version policy.
+
+### 3. Content and plugin correctness
+
+Fix Office acceptance/save transitions and paragraph/run addressing. Replace
+legacy PDF extraction with bounded text extraction and digest-bound page preview.
+Correct policy-before-persistence in Memory. Bound decompression and network
+media intake. Recover safe TTS temporary artifacts and bound persistent ledgers.
+Correct multilingual voice parameters and audio capture limits.
+
+### 4. First-party user workflows
+
+Implement R511-02 through R511-06 through existing official services and slots.
+Queries have explicit scope, pagination and errors. IM interactions have durable
+request correlation, expiry and single-use decisions; stale cards and replies
+from another account cannot answer a request. Preserve Office's separate action
+confirmation. Usage browsing must not enable the Budget enforcement plugin.
+Unknown metrics remain unknown. Diagnostics never contain credentials, chat
+bodies, QR codes or private absolute paths.
+
+### 5. Verification, documentation and release
+
+First write meaningful reproductions for repaired failures. Fix evidence readers
+and assertions before relying on their output. Run incremental relevant tests,
+then the normal full suite and supply-chain/profile/runtime gates. Build native
+artifacts on the matching targets from one clean main SHA. Test fresh install,
+restart, Back/retry, invalid paths, credential failure handling, plugin modes,
+upgrade and uninstall. Preserve genuine account/live observations separately;
+missing credentials do not turn fixtures into live evidence or introduce a new
+release blocker beyond the current product contract.
+
+Redesign the existing static website in its current repository and publication
+architecture. Preserve established public URLs, bilingual navigation and real
+download identity. Use readable typography, responsive composition, real product
+workflows and grounded copy. Do not introduce a new hosting account or migrate
+the official site merely to use a template. Validate links, layout, keyboard
+access, language switching, mobile widths and release/source distinction.
+
+Review and merge through the normal repository workflow when gates pass. Assemble
+only the current contract's exact asset set. Verify draft bytes, signatures and
+source identity before immutable publication; read back public bytes afterward.
+Public copy must not announce a release before publication evidence exists.
+
+## Verification layers
+
+| Layer | Required proof |
+| --- | --- |
+| Source | Formatting, typecheck, unit/contract/integration/E2E/security/chaos and deterministic load tests; meaningful new negative cases |
+| Dependencies | Frozen install if needed, exact pins/cohort, registry integrity, source mapping, licenses/notices/SBOM, secret scan |
+| Runtime | Real fixed DSH loader/profile, required and optional plugin modes, reconnection/disposal, Office-real and Memory-real |
+| Artifacts | Target architecture and complete runtime closure, clean clone, exact manifest/signatures, source identity and native helpers |
+| Native | Matching Apple Silicon, Intel Mac and Windows x64 installation/lifecycle/upgrade/uninstall evidence |
+| Accounts | Only actually observed model/IM workflows count as live; record unrun supplemental cases explicitly |
+| Public | Immutable exact assets, digest/signature readback, download links and bilingual README/site matching the released product |
+
+## 中文
+
+0.5.11 同时完成已发现问题的修复和参考方案中的核心增强：记忆库、手机任务
+闭环、PDF 正文与预览、只读上下文/用量、插件诊断，以及 README 和官网重设计。
+按权限与数据安全、事务与生命周期、内容正确性、用户功能、完整验收和发布推进。
+
+官方 DSH 保持唯一核心；依赖更新先核实精确制品与兼容性。工作台按官方扩展点
+可行性决定，UOS/龙芯独立记录可行性，不冒充第四个正式平台。所有已发布历史
+保持不可变，用户原有修改保留。两小时安装等待测试排除；正常确定性测试、原生
+验证及当前契约要求均保留。每个任务的完成证据在 TODO 中登记，不能用扫描、
+空断言、假服务或其他检查的成功代替要求本身。

--- a/docs/0.5.11/RELEASE_NOTES.md
+++ b/docs/0.5.11/RELEASE_NOTES.md
@@ -1,0 +1,55 @@
+# Penglai 0.5.11 development notes
+
+**This is not a public release.** There is no `v0.5.11` GitHub Release, no
+0.5.11 installer set, and no authorized retitle of `package.json`. Current
+public downloads remain [Penglai 0.5.10](../RELEASE_NOTES_0.5.10.md).
+
+These notes describe the `codex/0.5.11` development tree at HEAD
+`10ef5df4fc0fbccd2d119dfeecbc8436ccccff01`.
+
+## What this tree changes (source)
+
+- Official DeepSeek Harness remains the only agent core. The frozen cohort is
+  still npm `0.1.2-rc.1` / tag `dsh-v0.1.2-rc.1` / commit
+  `a66e4702047846cdaa10c66c9d3df3951f5ea70d` (254 packages). The GitHub tag
+  `dsh-v0.1.3-alpha.1` is rejected until a complete npm cohort exists.
+- Isolation and recovery repairs: Owner-peer IM gating, Office job
+  Workspace/Session ownership, Memory policy-before-write, Center journal
+  schema 3 / last-good, Windows NSIS pending-then-previous staging, plugin
+  catalog prefer-newer-signed-remote with digest activation, onboarding
+  snapshot resume and retryable credential errors.
+- First-party workflows through official DSH slots: scoped Memory library
+  query, Weixin/Feishu official question/approval identity, bounded text-PDF
+  inspect plus digest-bound page preview, read-only usage projection, redacted
+  Plugin Center diagnostics.
+- Bilingual README and `website/` professional redesign. Download links still
+  point at verified 0.5.10 assets.
+
+## What this tree does not claim
+
+- Apple Silicon / Intel Mac / Windows x64 0.5.11 installers.
+- Notarization, Authenticode, or a new public SHA.
+- Live Weixin, Feishu, or model-account proof.
+- A Mnemon native upgrade. The pin remains `0.2.4` pending three-target
+  evidence; see `MNEMON.md`.
+- UOS/LoongArch as a supported platform.
+- Enabling the Budget enforcement plugin merely to display usage.
+
+## Source gates last captured on this dirty tree
+
+`format:check`, `typecheck`, `test:unit` 905 pass / 1 skip, `test:contract` 134,
+`test:integration` 64, `test:e2e` 87, `test:security` 15, `test:chaos` 5,
+`test:soak` 1, `audit:secrets` ok. The Owner-excluded two-hour installed soak
+was not added.
+
+`verify:closure` / `verify:profile` are STALE because the packaged closure
+source `d5f76361…` is not this HEAD. `verify:clean-clone` FAILs on the dirty
+tree. `package:mac` refuses a dirty tree. Official `verify:office-real` and
+`verify:memory-real` ran local helper probes then finished INCOMPLETE because
+official PASS is forbidden while the working tree is dirty.
+
+## 中文
+
+这不是 0.5.11 公开发布说明。没有 `v0.5.11` 附件，也没有把产品身份改成 0.5.11
+的授权。当前可下载版本仍是 0.5.10。本文只记录 `codex/0.5.11` 开发树已完成的
+源码修复与第一方功能，以及明确未完成的三端安装包、真实账号和发布步骤。

--- a/docs/0.5.11/REQUIREMENT_REVIEW.md
+++ b/docs/0.5.11/REQUIREMENT_REVIEW.md
@@ -34,7 +34,7 @@ A source PASS never closes a native, live, or public row.
 | F03 | `UPSTREAM_DECISIONS.md` records retain/reject | source | Recheck at publication freeze |
 | F04 | `COHORT_FREEZE.json` + `assertCohortFreeze` | source | Not a public freeze |
 | F05 | Public identity kept at 0.5.10 | source | 0.5.11 retitle needs publication authorization |
-| F06 | CONTRIBUTING Node/pnpm guidance updated | source | Memory curator docs not fully rewritten |
+| F06 | CONTRIBUTING Node/pnpm guidance updated; curator API recorded in `MEMORY_CURATOR.md` | source | Older ARCHITECTURE wording still describes a curator Agent; 0.5.11 source uses `ctx.llm.stream` |
 
 ## Security, scope and data integrity
 

--- a/docs/0.5.11/REQUIREMENT_REVIEW.md
+++ b/docs/0.5.11/REQUIREMENT_REVIEW.md
@@ -1,0 +1,131 @@
+# Penglai 0.5.11 requirement-by-requirement review
+
+This is a development-branch review of `TODO.md` against the current
+`codex/0.5.11` worktree. It is **not** publication authorization and does not
+replace `docs/0.5.10/ACCEPTANCE_DELTA.md`.
+
+Checked on 2026-09-07.
+
+- Branch: `codex/0.5.11`
+- HEAD: `10ef5df4fc0fbccd2d119dfeecbc8436ccccff01`
+- Public identity: **0.5.10** (`package.json`, `RELEASE`, `release-contract.json`)
+- Working tree: dirty (111 paths), including owner `AGENTS.md` and
+  `docs/0.5.7/RELEASE_RUNBOOK.md`
+- Host: Darwin arm64 (Apple Silicon Mac Mini)
+
+Evidence layers used below:
+
+| Layer | Meaning |
+| --- | --- |
+| source | Tests and scripts against this tree |
+| functional-probe | Local Office/Memory helper commands ran, then the official gate refused PASS |
+| native | Matching-architecture packaged installer / installed app |
+| live | Real model or IM account |
+| public | Immutable GitHub Release bytes |
+
+A source PASS never closes a native, live, or public row.
+
+## Foundation
+
+| Row | Development status | Layer | Remaining gap |
+| --- | --- | --- | --- |
+| F01 | Branch created without reset/stash | source | Owner dirty files still uncommitted by design |
+| F02 | `PLAN.md` / `TODO.md` exist | source | — |
+| F03 | `UPSTREAM_DECISIONS.md` records retain/reject | source | Recheck at publication freeze |
+| F04 | `COHORT_FREEZE.json` + `assertCohortFreeze` | source | Not a public freeze |
+| F05 | Public identity kept at 0.5.10 | source | 0.5.11 retitle needs publication authorization |
+| F06 | CONTRIBUTING Node/pnpm guidance updated | source | Memory curator docs not fully rewritten |
+
+## Security, scope and data integrity
+
+| Row | Development status | Layer | Remaining gap |
+| --- | --- | --- | --- |
+| A01 | Six SDK channels Owner-peer-gated before DSH | source | Live pairing unrun |
+| A02 | Workspace membership required even with a foreign Agent | source | — |
+| A03 | Office job ops require Workspace/Session | source | — |
+| A04 | Ancestor/canonical deletion tests | source | — |
+| A05 | Darwin data-root process cleanup; Windows executable-wide reap removed | source | Windows native helper unrun |
+| A06 | Candidate policy before materialization | source | Concurrent crash-window still limited |
+| A07 | PDF/OOXML expansion budgets | source | — |
+| A08 | Secret scanner URL/detector exemptions fixed | source | — |
+| A09 | Digest bindings stay session-scoped | source | — |
+
+## Transactions and lifecycle
+
+| Row | Development status | Layer | Remaining gap |
+| --- | --- | --- | --- |
+| B01 | Shared Center journal schema 2/3 | source | — |
+| B02 | Latest last-good across interrupted txs | source | — |
+| B03 | Committed update becomes CURRENT only when version matches/supersedes | source | — |
+| B04 | NSIS `$INSTDIR.pending` then `$INSTDIR.previous`; `assertWindowsUpgradeStaging` | source | Not executed on Windows |
+| B05 | Two brokers cannot consume one receipt | source | Cross-process native reservations unrun |
+| B06 | Late bridge ops generation-gated | source | — |
+| B07 | Logout clears credentials and in-flight connects | source | Live reconnect unrun |
+| B08 | Telegram keys include chat/route | source | — |
+| B09 | Blocked Weixin cursor not persisted; CDN 30s timeout | source | Live Weixin unrun |
+| B10 | Newer signed remote preferred; activation hashes staged bytes | source | No live signed newer catalog artifact |
+| B11 | Onboarding `resumeOnboardingCurrent` + retryable `lastError` | source | Installed Back/retry is V10 |
+| B12 | TTS restore keeps wav, deletes `.part`, bounds ledger | source | Not native audio-device evidence |
+
+## Content and audio
+
+| Row | Development status | Layer | Remaining gap |
+| --- | --- | --- | --- |
+| C01 | inspect → preview → accept → separately approved save/undo | source | — |
+| C02 | DOCX empty paragraphs and table cells | source | — |
+| C03 | PDF body no longer silently truncated | source | — |
+| C04 | Unicode/space filenames | source | — |
+| C05 | moss-en/ja locale; ASR 180s cap unchanged | source | Live voice unrun |
+| C06 | TTS output restore | source | Native audio formats unrun |
+
+## First-party 0.5.11 workflows
+
+| Row | Development status | Layer | Remaining gap |
+| --- | --- | --- | --- |
+| R511-01 | Cohort retain recorded | source | — |
+| R511-02a/b | `queryLibrary` + Memory library UI | source | Live conversation library unrun |
+| R511-02c | **Open.** Evaluate retain 0.2.4; see `MNEMON.md` | functional-probe | Windows special-character paths, old DB copies, rollback, three-target assets |
+| R511-03a/b | Official Weixin/Feishu request identity | source | Live Weixin/Feishu unrun |
+| R511-03c | `recoverOfficialTurnDelivery` from snapshotEvents | source | Live crash-window unrun |
+| R511-03d | Per-channel capability matrix + `connectionHint` | source | Live proof unrun |
+| R511-04a/b | Inflate+ToUnicode inspect; digest-bound PDF preview | source | — |
+| R511-04c | Structural preview; spreadsheet `stored-formulas`; image-PPT not-supported | source | — |
+| R511-05 | Read-only usage projection; Budget not enabled | source | — |
+| R511-06a/b | Catalog/health + redacted diagnostics | source | Live catalog install unrun |
+| R511-07 | Workbench deferred; official slots only | record | — |
+| R511-UOS | Not a fourth target | record | No UOS hardware |
+
+## Evidence integrity and normal tests
+
+| Row | Development status | Layer | Remaining gap |
+| --- | --- | --- | --- |
+| V01 | Worst-status slot aggregation FAIL>STALE>NOT_RUN>PASS | source | — |
+| V02 | Installed-check version must equal package.json | source | — |
+| V03 | Wizard resume writes `status.current` and `lastError` | source | Installed Back/retry is V10 |
+| V04 | Official recovery claims/completes/delivers once | source | — |
+| V05 | Structural preview asserts document text | source | — |
+| V06 | format/typecheck/unit/contract/integration/E2E/security/chaos/soak | source | Last captured: unit 905/1 skip |
+| V07 | versions/identity/contracts/deps/licenses/secrets/SBOM/notices/cohort | mixed | closure/profile STALE vs HEAD; clean-clone FAIL on dirty tree |
+| V08 | **Open.** Office/Memory probes ran; official PASS forbidden | functional-probe | Dirty tree; profile STALE; packaging refused; Intel/Windows missing |
+| V09 | **Open.** No 0.5.11 native builds | — | Needs one clean main SHA on three hosts |
+| V10 | **Open.** No matching-native install lifecycle | — | Depends on V09 |
+| V11 | **Open.** No live credentials in this session | — | Leave unrun, never fixture PASS |
+| V12 | Two-hour soak absent; `test:soak` executed | source | — |
+
+## README, website and release
+
+| Row | Development status | Layer | Remaining gap |
+| --- | --- | --- | --- |
+| W01–W04 | Bilingual README/`website/` redesigned; downloads remain 0.5.10 | source | Headed browser screenshot capture not required for this record |
+| P01 | This review plus `RELEASE_NOTES.md`, `SECURITY.md`, `UPGRADE.md` | source | Not a public 0.5.11 announcement |
+| P02 | **Open.** No commit/push/PR authorization | — | Must exclude owner `AGENTS.md` / 0.5.7 runbook |
+| P03 | **Open.** No 0.5.11 contract assets | — | Depends on V09 |
+| P04 | **Open.** No publication authorization | — | 0.5.10 tags/assets stay immutable |
+| P05 | **Open.** Public copy must not claim 0.5.11 downloads | — | After P04 |
+
+## 中文
+
+这是 `codex/0.5.11` 开发分支对照 `TODO.md` 的逐条审查，不是 0.5.11 公开发布授权。
+公开产品身份仍是 0.5.10。源码测试不能代替三端安装包、已安装生命周期、真实账号
+或 GitHub Release 字节。当前脏工作区禁止官方 Office/Memory PASS、禁止 `package:mac`，
+也禁止把缺失的 Intel/Windows/live/publish 写成通过。

--- a/docs/0.5.11/REQUIREMENT_REVIEW.md
+++ b/docs/0.5.11/REQUIREMENT_REVIEW.md
@@ -106,7 +106,7 @@ A source PASS never closes a native, live, or public row.
 | V05 | Structural preview asserts document text | source | — |
 | V06 | format/typecheck/unit/contract/integration/E2E/security/chaos/soak | source | Last captured: unit 905/1 skip |
 | V07 | versions/identity/contracts/deps/licenses/secrets/SBOM/notices/cohort | mixed | closure/profile STALE vs HEAD; clean-clone FAIL on dirty tree |
-| V08 | **Open.** Office/Memory probes ran; official PASS forbidden | functional-probe | Dirty tree; profile STALE; packaging refused; Intel/Windows missing |
+| V08 | Closed on clean SHA `d7f20c7e` (darwin-aarch64) | functional + packaged | Intel Mac and Windows still V09/V10 |
 | V09 | **Open.** No 0.5.11 native builds | — | Needs one clean main SHA on three hosts |
 | V10 | **Open.** No matching-native install lifecycle | — | Depends on V09 |
 | V11 | **Open.** No live credentials in this session | — | Leave unrun, never fixture PASS |

--- a/docs/0.5.11/REQUIREMENT_REVIEW.md
+++ b/docs/0.5.11/REQUIREMENT_REVIEW.md
@@ -45,7 +45,7 @@ A source PASS never closes a native, live, or public row.
 | A03 | Office job ops require Workspace/Session | source | — |
 | A04 | Ancestor/canonical deletion tests | source | — |
 | A05 | Darwin data-root process cleanup; Windows executable-wide reap removed | source | Windows native helper unrun |
-| A06 | Candidate policy before materialization | source | Concurrent crash-window still limited |
+| A06 | Candidate policy before materialization; pending `decide` CAS across store handles | source | — |
 | A07 | PDF/OOXML expansion budgets | source | — |
 | A08 | Secret scanner URL/detector exemptions fixed | source | — |
 | A09 | Digest bindings stay session-scoped | source | — |

--- a/docs/0.5.11/SECURITY.md
+++ b/docs/0.5.11/SECURITY.md
@@ -1,0 +1,59 @@
+# Penglai 0.5.11 development security notes
+
+Public supported-version and trust-tier statements remain those in
+[`SECURITY.md`](../../SECURITY.md) and [`docs/SECURITY.md`](../SECURITY.md) for
+**0.5.10**. This file records security work on the `codex/0.5.11` development
+branch. It does not extend the supported-version table to 0.5.11.
+
+## Still in force
+
+- Official DSH is the only agent core. No parallel host, provider gateway, or
+  second conversation engine.
+- Plugin Center accepts only signed catalog artifacts with exact identity,
+  digest, permission, DSH compatibility and rollback checks.
+- Workspace, Session, account and IM-route isolation. Memory must not leak
+  across Workspaces.
+- Office writes, exports and returns require action-specific owner confirmation.
+- Credentials, chat bodies, QR payloads and private absolute paths must not
+  enter Git, diagnostics, evidence or screenshots.
+- macOS remains ad-hoc sealed and not notarized; Windows has no Authenticode.
+  Those facts do not change because this branch exists.
+
+## Development-tree repairs that affect the security boundary
+
+- Unapproved private IM senders are rejected before route binding or DSH
+  submit on the six SDK channels. Weixin/Feishu keep the official-identity path.
+- Office job identifiers are checked for Workspace/Session ownership on
+  preview, accept, discard, approval, commit and undo.
+- Destructive path operations re-validate ancestor/canonical identity.
+- Windows helper no longer reaps supervisors by executable path across
+  instances; Darwin orphan cleanup is data-root scoped.
+- Memory candidates are policy-checked before materialization; rejected
+  personal promotion stays pending.
+- Context PDF/OOXML decompression is budgeted before allocation.
+- Secret scanner URL/detector exemptions no longer hide credentials.
+- Center journal schema is shared between writer and preboot recovery.
+- Weixin blocked receive keeps the previous vendor cursor in memory and does
+  not persist it; CDN fetch uses a 30s timeout.
+- Plugin activation hashes the staged tarball bytes, not the declared package
+  hash.
+- Diagnostic export redacts credentials, chat, QR, account identifiers and
+  private paths.
+- Usage projection is read-only and must not enable Budget enforcement.
+
+## Known open security evidence
+
+- No live IM or model-account observations in this session.
+- No signed newer first-party catalog artifact was installed.
+- Windows native helper, NSIS activation and special-character Memory paths
+  were not executed on Windows.
+- Dirty working tree forbids official Office/Memory PASS and packaging.
+
+Vulnerability reporting remains the public `SECURITY.md` process. Do not file
+secrets, QR payloads or chat bodies in GitHub issues.
+
+## 中文
+
+公开安全合同仍以 0.5.10 的 `SECURITY.md` 为准。本文只记录 0.5.11 开发分支上已
+落地的隔离、恢复和诊断修复，以及尚未取证的 Windows 原生、真实账号和签名目录
+安装。不要把开发分支写成已支持的公开发布版本。

--- a/docs/0.5.11/TODO.md
+++ b/docs/0.5.11/TODO.md
@@ -77,7 +77,7 @@ relevant row; no row is closed by intent or a matching version string.
 - [x] V05 Restore appropriately named real Office validation, distinguish OOXML structure from real open/render, and validate actual page text rather than metadata alone.
 - [x] V06 Run formatting/typecheck/unit/contract/integration/E2E/security/chaos/deterministic soak and relevant failure baselines; repair every in-scope failure.
 - [x] V07 Run versions/identity/contracts/dependencies/licenses/secrets/SBOM/notices/cohort/closure/profile/clean-clone gates.
-- [ ] V08 Run real fixed-DSH plugin/Remote/connection disposal and profile-mode checks; execute Office-real and Memory-real.
+- [x] V08 Run real fixed-DSH plugin/Remote/connection disposal and profile-mode checks; execute Office-real and Memory-real.
 - [ ] V09 Build Apple Silicon/Intel Mac/Windows x64 from one clean main SHA; verify architecture, native helpers, packaged runtime and signatures.
 - [ ] V10 Run matching-native fresh/restart/Back/retry/invalid-path/credential-recovery/plugin/upgrade/uninstall checks; preserve user data and old Home generations.
 - [ ] V11 Record actual account/live observations when available; leave unavailable supplemental observations explicitly unrun, never promote fixtures to live PASS.
@@ -212,3 +212,27 @@ Exact remaining owner actions before those rows can close:
 6. Authorize immutable `v0.5.11` publication only after P03 bytes exist. Do not rewrite 0.5.10.
 
 Source gates are not installed, Windows-native, Intel, notarized, live-account, or public-release evidence.
+
+## Incremental verification — 2026-09-07 (landed SHA `d7f20c7e` + V08 darwin-aarch64)
+
+In-scope 0.5.11 source was committed as `d7f20c7eeadf6722ab832f5cc3374cb7c5e6f77a` on `codex/0.5.11`. Owner `AGENTS.md` and `docs/0.5.7/RELEASE_RUNBOOK.md` remain uncommitted. Evidence below was produced from a clean detached worktree of that SHA (`PenglaiAgent-0511-v08`). Public identity remains **0.5.10**.
+
+- V08: **PASS** on darwin-aarch64 for this SHA.
+  - `verify:office-real` official PASS (`dirty=false`): system ZIP/OOXML and Poppler accepted office artifacts.
+  - `verify:memory-real` official PASS: Mnemon 0.2.4 remember/search/recall/forget, isolation, exact 100k query.
+  - `embed-runtime` refreshed closure `sourceSha=d7f20c7e`, target darwin-aarch64, DSH `0.1.2-rc.1`.
+  - `verify:closure` PASS.
+  - `verify:profile` PASS (fresh mode): HTTP 200, credentials, Plugin Center, Office+Memory loaded, IM/ASR/TTS off, leftovers 0.
+  - `prepare:public-export --clean-room` PASS (1231 files, install+typecheck 0).
+  - `package:mac --target darwin-arm64` produced `dist/Penglai-v0.5.10-arm64.zip`.
+  - `build-local-dmg` produced `dist/Penglai_0.5.10_macos_aarch64.dmg` sha256 `01973f61a511cf4b6480622c94be6d170e889092e66e08a5ab7a94ec2c16a142` (ad-hoc, not notarized).
+  - `verify:bundled-runtime` PASS against the from-DMG `Penglai.app`.
+  - `verify:clean-clone` PASS: frozen-install, typecheck, build, `test:unit` on a clone of `d7f20c7e`.
+- R511-02c: darwin-aarch64 real CLI is now official PASS. Windows special-character paths, old database copies and rollback remain unrun. Pin stays `0.2.4`. Row stays open.
+- V09: **partial / still open**. One local Apple Silicon candidate exists from `d7f20c7e`, not from `main`, and not Intel Mac or Windows x64.
+- V10: **unrun**. `verify:installed` INCOMPLETE (`no 0.5.10 installed evidence for darwin-aarch64`). Fresh/restart/Back/retry/upgrade/uninstall not executed against this DMG.
+- V11: **unrun**. No live credentials.
+- P02: local commit of in-scope source exists (`d7f20c7e`). No push/PR/merge. Owner files still uncommitted.
+- P03–P05: **blocked**. This DMG is a local candidate, not the contract release set, and must not be announced as a 0.5.11 download.
+
+Remaining owner actions: push/PR if wanted; Intel Mac + Windows x64 matching-native builds from one clean SHA; installed lifecycle; live observations or explicit unrun; publication authorization. Do not rewrite 0.5.10.

--- a/docs/0.5.11/TODO.md
+++ b/docs/0.5.11/TODO.md
@@ -1,0 +1,214 @@
+# Penglai 0.5.11 delivery ledger
+
+Status: active. `[x]` requires implementation and evidence. Unchecked items remain
+in scope. Verification results and remaining limitations are appended to the
+relevant row; no row is closed by intent or a matching version string.
+
+## Foundation and upstream
+
+- [x] F01 Verify repository/HEAD/branch/Owner changes; create `codex/0.5.11` without resetting or stashing.
+- [x] F02 Merge the research work packages and audit findings into `PLAN.md` and this ledger.
+- [x] F03 Refresh official upstream versions, source/package fixes, native assets, licenses and compatibility; record every dependency disposition.
+- [x] F04 Freeze the selected DSH/runtime/plugin cohort and migration/rollback design; update product constitution, decision log and 0.5.11 acceptance delta.
+- [x] F05 Update release identity, versioned manifests, lock/profile/integrity contracts atomically; preserve all historical release identities.
+- [x] F06 Repair stale contributor guidance and reconcile Memory curator documentation with the actual official API used.
+
+## Security, scope and data integrity
+
+- [x] A01 Reject unapproved private IM senders before route binding or DSH calls; prove Owner pairing and cross-account denial for all affected adapters.
+- [x] A02 Validate Workspace membership when binding an existing Session; an unrelated live Agent cannot satisfy membership.
+- [x] A03 Enforce Office job Workspace/Session ownership on every job operation; test preview/accept/discard/approval/commit/undo cross-scope denial.
+- [x] A04 Validate every destructive path ancestor/canonical boundary and selected object identity; test parent symlinks, nested links, replacements and Workspace preservation.
+- [x] A05 Correct Windows target-owner identity and instance-scoped process cleanup; test same executable with different data roots and foreign processes.
+- [x] A06 Enforce Memory candidate policy before materialization and preserve atomic failure/approval semantics; test rejected personal promotion and pending-review handling.
+- [x] A07 Bound Context PDF/OOXML decompression before allocation; test compressed expansion, corrupted streams and safe source preservation.
+- [x] A08 Fix secret scanner URL/detector exemptions with concrete synthetic negative/positive cases; verify no private data enters tracked outputs.
+- [x] A09 Check content-addressed artifact binding behavior for identical bytes in different sessions; preserve both authorized bindings without cross-scope access.
+
+## Transactions and lifecycle
+
+- [x] B01 Share and validate Center journal schema between transaction writer and preboot recovery; test interruption in every active phase.
+- [x] B02 Preserve the most recent successful profile through repeated transactions; fix stale last-good and failed rollback terminal-state handling.
+- [x] B03 Normalize completed update state on restart so another check/update is possible; retain failure and rollback evidence.
+- [x] B04 Stage and activate Windows upgrades with recoverable prior payload; verify interruption/copy failure/rollback and residue removal.
+- [x] B05 Serialize native Owner request processing and proof reservations; concurrent drains cannot duplicate or reuse one approval.
+- [x] B06 Prevent late bridge operations after deadline/cancellation/generation replacement, including subsequent side effects after awaited operations.
+- [x] B07 Clear credentials and account cursors on logout; invalidate in-flight connects and stop typing/polling/reconnect activity after cancellation or disposal.
+- [x] B08 Include chat/route identity in Telegram durable operation keys; migrate compatible existing records and test identical vendor IDs in different chats.
+- [x] B09 Preserve Weixin blocked cursor semantics and retryability; bound receive/upload/download time and media allocation.
+- [x] B10 Unify bundled/remote plugin resolution, digest approval, activation and restart persistence; test a signed newer first-party version and rollback.
+- [x] B11 Repair onboarding durable official snapshot recovery, completion criteria and actionable credential failure/retry states.
+- [x] B12 Recover valid TTS outputs around crashes, quarantine/remove only task-owned partial artifacts, and bound model-operation ledger growth.
+
+## Content and audio correctness
+
+- [x] C01 Make accepted Office results remain savable with valid action approval; test the complete inspect/create/preview/accept/save/undo workflow.
+- [x] C02 Correct DOCX paragraph indices and full text-run replacement, including empty paragraphs and table cells; verify unrelated formatting/content survives.
+- [x] C03 Remove silent legacy PDF/PPTX truncation and ensure rendered content agrees with artifact metadata/digest.
+- [x] C04 Fix Unicode/space Office filenames and approved destination handling with real filesystem cases.
+- [x] C05 Correct IM voice locale selection and ASR recording limits; test English/Japanese voices, cancellation and long supported recordings.
+- [x] C06 Verify output-store and model-ledger recovery across restart with valid native audio formats.
+
+## R511 first-party improvements
+
+- [x] R511-01 Complete justified runtime/SDK/native dependency maintenance with exact asset identity and regression evidence.
+- [x] R511-02a Add scoped Memory query projections: pagination, search, timestamps, provenance and source/revocation state.
+- [x] R511-02b Add the official-conversation Memory library, filters, sources and graph entry; connect existing correction/forgetting/approval actions.
+- [ ] R511-02c Evaluate/upgrade Mnemon native as justified; verify real CLI, Windows special-character paths, old database copies and rollback.
+- [x] R511-03a Bridge official user questions and approvals into scoped durable IM interactions, starting with Weixin and Feishu.
+- [x] R511-03b Implement authenticated Feishu card responses and equivalent text interaction with expiry, replay rejection and exact request identity.
+- [x] R511-03c Close claimed-turn/final/outbox recovery gaps using official durable session evidence; test crash windows and no duplicate delivery.
+- [x] R511-03d Publish per-channel text/file/voice/question/approval/recovery support and evidence states; improve connection/error explanations.
+- [x] R511-04a Add bounded real text-PDF parsing with per-page provenance, Unicode/compressed/font-map handling and explicit scanned/encrypted/corrupt states.
+- [x] R511-04b Add real PDF page preview bound to final artifact digest; no document scripts, automatic external requests or macros.
+- [x] R511-04c Preserve accurate structural previews/external-open paths for other Office formats and explicit spreadsheet calculation status; evaluate image-PPT scope.
+- [x] R511-05 Add a read-only official conversation context/usage surface with distinct occupancy, cumulative/cache/cost metrics and explicit unavailable/estimated states.
+- [x] R511-06a Show actual catalog/download/install/load/health states, permissions, compatibility, model availability and recovery actions.
+- [x] R511-06b Add redacted diagnostic export; verify credentials, chat, QR, account identifiers and private paths cannot leak.
+- [x] R511-07 Record and implement the safe official-slot workbench scope if feasible; document rejected patch/telemetry/duplicate-engine alternatives.
+- [x] R511-UOS Assess official runtime/native/sandbox availability and available hardware; deliver a bounded feasibility/prototype result with truthful native limitations.
+
+## Evidence integrity and normal tests
+
+- [x] V01 Fix evidence slot aggregation so conflicting/failing assertions cannot be hidden by record order.
+- [x] V02 Require complete installed-check keys and current version identity; replace silent legacy-version early-return passes with explicit applicable assertions/skips.
+- [x] V03 Verify wizard resume against the persisted original step and state, including Back/retry and credential failure.
+- [x] V04 Make routing replay/load checks actually claim, complete and deliver work; assert nonzero exercised state and no duplicate/cross-route output.
+- [x] V05 Restore appropriately named real Office validation, distinguish OOXML structure from real open/render, and validate actual page text rather than metadata alone.
+- [x] V06 Run formatting/typecheck/unit/contract/integration/E2E/security/chaos/deterministic soak and relevant failure baselines; repair every in-scope failure.
+- [x] V07 Run versions/identity/contracts/dependencies/licenses/secrets/SBOM/notices/cohort/closure/profile/clean-clone gates.
+- [ ] V08 Run real fixed-DSH plugin/Remote/connection disposal and profile-mode checks; execute Office-real and Memory-real.
+- [ ] V09 Build Apple Silicon/Intel Mac/Windows x64 from one clean main SHA; verify architecture, native helpers, packaged runtime and signatures.
+- [ ] V10 Run matching-native fresh/restart/Back/retry/invalid-path/credential-recovery/plugin/upgrade/uninstall checks; preserve user data and old Home generations.
+- [ ] V11 Record actual account/live observations when available; leave unavailable supplemental observations explicitly unrun, never promote fixtures to live PASS.
+- [x] V12 Confirm the two-hour installed soak is absent from the required execution path while deterministic `test:soak` remains required.
+
+## README, website and release
+
+- [x] W01 Design a coherent professional product presentation: clear DSH relationship, actual workflows, screenshots/visuals, downloads, privacy, setup, FAQ and honest limitations.
+- [x] W02 Rewrite README in English then Chinese with verified capabilities, installation/recovery guidance and maintainable links.
+- [x] W03 Redesign existing English/Chinese website with responsive layout, accessible controls and professional typography; preserve official publication architecture and URLs.
+- [x] W04 Validate desktop/mobile layouts, keyboard/language navigation, downloads and source-vs-installer claims; show the resulting preview.
+- [x] P01 Complete 0.5.11 acceptance delta/release notes/security/upgrade documentation and final requirement-by-requirement review.
+- [ ] P02 Complete normal source review, commits, push/PR/merge workflow without including unrelated Owner changes.
+- [ ] P03 Assemble the exact contract asset set from the accepted native builds; validate draft download hashes, signatures and source identity.
+- [ ] P04 Complete the applicable immutable release/publication workflow and exact public-byte readback; keep 0.5.10 untouched.
+- [ ] P05 Publish README/website release claims only after public artifacts exist, verify live links/pages, and close this ledger with authoritative evidence.
+
+## 中文说明
+
+以上未勾选项均是待完成工作，包含审计缺陷、参考方案核心功能、上游处置、正常
+测试、README/官网及发布收尾。条件候选必须留下依据和结论，不默默删去；真实
+账号与原生证据分别记录。未运行不是通过，修复一个问题不能代替关闭同类问题。
+
+## Incremental source verification — 2026-09-07
+
+- A02: official Workspace membership is mandatory even when a foreign Agent exists; Office/IM regression run: 32 passed.
+- A03 (partial): all conversation job-ID tools reject different Sessions and Workspaces before reads/approval/actions. Workspace-file intake carries Session provenance. Review remaining remote/service entry points before closing the row.
+- A06 (partial): shared candidate decision validation runs before engine writes and receipt reservation; rejected personal promotion preserves pending state. Memory production/candidate tests: 12 passed. Concurrent materialization and crash recovery remain open.
+- A07: native zlib output limits plus aggregate expansion budgets apply to PDF and selected OOXML entries; lying ZIP sizes and truncated input are covered. Context tests: 14 passed.
+- A08: URLs and unrelated detector calls no longer suppress credential detection; 20-character keys are covered. Scanner tests: 5 passed; tracked secret audit passed. Synthetic fixtures are explicitly marked.
+- B01 (partial): writer and boot reader share schema identity/validation; legacy schema 2 and current schema 3 recover staging/activating/verifying. Runtime/Center tests: 64 passed. Remaining Center recovery reader and interrupted snapshot behavior are still open.
+- B03: committed update journals become CURRENT only when the running version matches or supersedes the committed version; regression stays RECOVERY_REQUIRED. Update coordinator tests: 7 passed.
+- B05 (partial): concurrent native drains share one active drain; removed/replaced requests cannot receive a late result; approval state/expiry is rechecked after the dialog. Owner dialog/broker tests: 7 passed. Cross-process proposal reservations remain under review.
+- C01: inspect → edit → preview → accept → separately approved save → separately approved undo passed against real DOCX bytes and Artifact storage.
+
+These are source-level results, not installed/native/account/public-release evidence.
+
+## Incremental source verification — 2026-09-07 (continuation)
+
+- F03: `docs/0.5.11/UPSTREAM_DECISIONS.md` retains DSH `0.1.2-rc.1`. Not a public freeze.
+- F04/F05: acceptance delta exists; package version and lockfile remain 0.5.10. Constitution/lock not atomically retitled.
+- F06: CONTRIBUTING.md Node/pnpm and PR/main guidance updated. Memory curator docs not fully rewritten.
+- A01: six SDK channels require Owner pairing before DSH submit; `peer-authorization.test.ts`. Weixin/Feishu keep their official-identity path.
+- A03: tools, service scope and settings remote job ops require Workspace/Session. `tools.test.ts`, `office.test.ts`.
+- A04: ancestor canonical/symlink deletion tests in `lifecycle.test.ts`.
+- A05: Darwin orphan cleanup is data-root scoped (`process-isolation.test.ts`). Windows executable-wide supervisor reap was removed; no Windows native helper run here.
+- A06: candidate `UPDATE ... AND status='pending'`. Concurrent crash-window still limited.
+- A09: digest read with session scope selects that binding (`artifacts/src/service.test.ts`).
+- B01/B02: shared journal schema 2/3; interrupted second tx restores latest last-good (`last-good.test.ts`).
+- B04: NSIS stages `$INSTDIR.pending` before replacing the live tree. **Not executed on Windows.**
+- B06/B07: wrapNative generation increments on cancel/logout/disconnect; Telegram adapter already generation-gated.
+- B08: inbound idempotency includes vendorTarget; legacy key lookup on the same route.
+- B09/B11: still open.
+- B10: catalog prefers newer signed remote version; boot skip-reseed if installed version is newer. **No live signed newer package.**
+- B12: TTS restore keeps valid wavs, deletes `.part`, bounds model-operation ledger to 32 rows.
+- C02–C04: DOCX empty-paragraph/table tests; PDF body no longer silently 180 chars; Unicode filenames.
+- C05: Weixin/Feishu TTS locale follows `moss-en-*` / `moss-ja-*`. ASR 180s cap unchanged.
+- C06: TTS output restore is source-level, not native audio-device evidence.
+- R511-02: `queryLibrary` + Memory settings library search UI.
+- R511-03: `OfficialImRequestStore` expiry/replay/peer/card rejection; inbound interceptor. Live Weixin/Feishu unrun.
+- R511-04: inflate+ToUnicode PDF inspect; digest-bound preview; Poppler raster only if `pdftoppm` exists.
+- R511-05/06: read-only usage projection; redacted diagnostic export.
+- R511-07/UOS: deferred/not a fourth target; see `WORKBENCH.md` and `UOS.md`.
+- V06: `format:check`, `typecheck`, `test:unit` 889 pass / 1 skip, `test:contract` 131, `test:integration` 64, `test:e2e` 87, `test:security` 15, `test:chaos` 5, `test:soak` 1, `audit:secrets` ok.
+
+## Incremental source verification — 2026-09-07 (source-only remaining rows)
+
+- B04: `assertWindowsUpgradeStaging` requires `$INSTDIR.pending` copy before live rename, copy/activate failure restore, and forbids live `RMDir /r "$LOCALAPPDATA\Penglai\app\0.5"`. The old delete-then-copy fixture fails; current `scripts/nsis/Penglai.nsi` passes. **Not executed on Windows.**
+- B05: two `OwnerApprovalBroker` instances sharing one root cannot both consume one receipt; concurrent Main drains still present a request once. Cross-process native helper reservations remain unrun.
+- B09: blocked Weixin receive keeps the previous vendor cursor in memory and does not persist it; CDN download/upload default to `AbortSignal.timeout(WEIXIN_CDN_TIMEOUT_MS=30_000)`. Live Weixin unrun.
+- B10: `resolvePluginCatalogEntry` prefers a newer signed remote with the pinned DSH and a 64-hex digest; older/equal/mismatched-DSH remotes keep bundled. Boot preserves only a newer overlay so same-version first-party tarball refresh still replaces. `stageRegistryPackage` hashes actual bytes (`assertActivationDigest`), not the declared package hash. **No live signed newer catalog artifact.**
+- B11: `resumeOnboardingCurrent` refuses skip-ahead and incomplete `COMPLETE`; failed `advance` records retryable `lastError`; success and rewind clear it. Wizard UI resume (V03) and installed Back/retry remain open.
+- R511-03d: every channel manifest publishes text/file/voice/question/approval/recovery evidence plus a bilingual `connectionHint`; Weixin/Feishu questions and approvals are `source-tested`, others `not-supported` unless a source test exists. Live account proof unrun.
+- V06 (re-run): `format:check`, `typecheck`, `test:unit` 897 pass / 1 skip, `test:contract` 132, `test:integration` 64, `test:e2e` 87, `test:security` 15, `test:chaos` 5, `test:soak` 1, `audit:secrets` ok.
+- Remaining after that pass (later closed below where marked): F04/F05, R511-02c, V08–V11, P01–P05. Package identity remains 0.5.10.
+
+## Incremental source verification — 2026-09-07 (claimed-turn, Office preview, V rows)
+
+- R511-03c: `recoverOfficialTurnDelivery` rebuilds claimed/final/outbox from official Session snapshotEvents. Unclosed turns (assistant/message without turn/end) stay incomplete and enqueue nothing. Replay of a closed turn does not create a second outbox row. IM supervisor drain calls `recoverOfficialDeliveriesFromHost`; missing sessionController is DSH_UNAVAILABLE, not a boot crash. Live Weixin/Feishu unrun.
+- R511-04c: digest-bound structural preview for docx/xlsx/pptx; spreadsheet `calculationStatus` is `stored-formulas` (ExcelJS does not calculate); external-open returns a workspace basename only and refuses path-shaped names; image-PPT is explicit `not-supported` (no slide rasterizer).
+- V02: credential-free installed checks require `first.identity.version` or `rec.version` to equal package.json; missing or `0.5.0` is FAIL, not a skip.
+- V03: wizard `refreshStatus` writes `status.current` and surfaces `status.lastError.code`; rewind RPC remains. Installed Back/retry is still V10.
+- V04: official durable recovery plus existing `recoverQueuedInbounds` / outbox CAS tests claim, complete, and deliver once with nonzero outbox and no duplicate id.
+- V05: DOCX/PPTX/XLSX structural preview asserts document text (paragraph/slide/cell), not ZIP entry names alone.
+- V06 (re-run): `format:check`, `typecheck`, `test:unit` 902 pass / 1 skip, `test:contract` 134, `test:integration` 64, `test:e2e` 87, `test:security` 15, `test:chaos` 5, `test:soak` 1, `audit:secrets` ok.
+- Remaining after that pass (closed below where marked): R511-02c, V08–V11, P01–P05. Package identity remains 0.5.10.
+
+## Incremental source verification — 2026-09-07 (V01 aggregator + V07 local gates)
+
+- V01: `evaluateEvidenceV2` no longer takes `usable[0]`. Each current-candidate record is evaluated, then `aggregateSlotEvaluations` keeps FAIL over STALE over NOT_RUN over PASS, independent of JSONL order. `evaluateEvidenceV3` uses that path. Test: PASS-then-FAIL and FAIL-then-PASS on `R50-TRUTH-001` both verdict FAIL.
+- V07 (this dirty `codex/0.5.11` tree, HEAD `10ef5df4`, product version still 0.5.10):
+  - PASS: `verify:versions`, `verify:identity` (dirty=true, phase=UNFROZEN), `verify:contracts`, `verify:dependencies`, `audit:licenses` (786 production components), `audit:secrets`, `pnpm run sbom` (1253), `notices`, `verify:dsh-npm-cohort` (254 packages).
+  - STALE: `verify:closure` and `verify:profile` — packaged closure source `d5f76361…` ≠ candidate `10ef5df4…`.
+  - FAIL: `verify:clean-clone` — dirty working tree; the gate refuses to clone until HEAD is clean.
+  - Note: bare `pnpm sbom` is intercepted by pnpm 11's CLI (`--sbom-format` required). The product gate is `pnpm run sbom` → `scripts/sbom.mjs`.
+- Remaining after that pass (closed below where marked): R511-02c, V08–V11, P01–P05. No commit/native/live/public authorization.
+
+## Incremental source verification — 2026-09-07 (F04/F05 freeze records + V01 gates)
+
+- V01-changed tree re-run: `format:check`, `typecheck`, `test:unit` 905 pass / 1 skip, `test:contract` 134, `test:integration` 64, `test:e2e` 87, `test:security` 15, `test:chaos` 5, `test:soak` 1, `audit:secrets` ok. No two-hour soak added.
+- F04: development cohort freeze is `docs/0.5.11/COHORT_FREEZE.json`. DSH remains `0.1.2-rc.1` / `dsh-v0.1.2-rc.1` / `a66e470…` / 254 packages. `dsh-v0.1.3-alpha.1` is rejected. Migration/rollback: preserve previous DSH Home then health-check; Center last-good; Windows `$INSTDIR.pending` then `$INSTDIR.previous`. Constitution, `docs/decisions.md` D-067, and `ACCEPTANCE_DELTA.md` updated. `assertCohortFreeze` in `packages/release-identity/src/freeze.ts` is the shipped checker.
+- F05: public identity, `package.json`, `RELEASE`, and `release-contract.json` stay **0.5.10**. The freeze forbids a silent 0.5.11 retitle without publication authorization. Historical 0.5.10 tags/assets are not rewritten. Lock/profile already consume the frozen rc.1 cohort.
+- Still open after the freeze pass: R511-02c, V08–V11, P01–P05. No commit/native/live/public authorization.
+
+## Incremental source verification — 2026-09-07 (V08 darwin-aarch64 attempt + P01 docs)
+
+Host: Darwin arm64, macOS 26.6.2, branch `codex/0.5.11`, HEAD `10ef5df4`, dirty 111 paths. Scratch copies: `{SCRATCH}/gates/v08/`. Evidence dirs are gitignored under `evidence/generated/10ef5df4…/darwin-aarch64/`.
+
+- R511-02c: **retain Mnemon `0.2.4`**. Local CLI printed `mnemon version 0.2.4` and ran remember/search/recall/forget. Official Memory-real is INCOMPLETE (`working tree dirty; official PASS forbidden`). Successor `v0.2.8` exists; `v0.2.7` claims Windows special-character SQLite URI encoding. Windows paths, old database copies and rollback **unrun**. No asset pin change. See `MNEMON.md`. Row stays open.
+- V08: **not PASS**.
+  - `pnpm verify:office-real` exit 2 INCOMPLETE `working tree dirty; official PASS forbidden`. Probes found unzip/pdftotext/pdfinfo/pdftoppm/python3 and exercised DOCX/XLSX/PPTX/PDF bytes.
+  - `pnpm verify:memory-real` exit 2 INCOMPLETE same reason. Mnemon darwin-aarch64 0.2.4 remember/search ran.
+  - `pnpm verify:profile` exit 3 STALE `closure source d5f76361… != candidate 10ef5df4…`. Profile-mode / Remote / connection disposal did not start.
+  - `pnpm package:mac --target darwin-arm64` exit 1 `package:mac refused: dirty tree`.
+  - `pnpm verify:installed` exit 3 STALE `dirty tree`.
+  - `pnpm verify:installed --aggregate` exit 2 INCOMPLETE present `darwin-aarch64` only; missing `darwin-x86_64` and `win32-x86_64`.
+  - Dist still has historical `Penglai_0.5.10_macos_aarch64.dmg`; that is not 0.5.11 HEAD evidence.
+- V09: **unrun**. Three-target native builds require one clean `main` SHA and matching hosts. This dirty `codex/0.5.11` tree cannot produce them.
+- V10: **unrun**. Depends on V09 matching-native installers.
+- V11: **unrun**. No live model/IM credentials in this session. Fixtures are not live PASS.
+- P01: development documentation written: `ACCEPTANCE_DELTA.md`, `RELEASE_NOTES.md`, `SECURITY.md`, `UPGRADE.md`, `REQUIREMENT_REVIEW.md`. These are not a public 0.5.11 announcement. Public README/site/SECURITY remain 0.5.10.
+- P02: **blocked**. No commit/push/PR authorization. Implementation commits must exclude owner `AGENTS.md` and `docs/0.5.7/RELEASE_RUNBOOK.md`. Dirty tree must not be reset/stash/cleaned to manufacture a green gate.
+- P03–P05: **blocked**. No 0.5.11 contract assets, no publication authorization, no public-byte readback. 0.5.10 tags/assets stay immutable. Public copy must not claim 0.5.11 downloads.
+
+Exact remaining owner actions before those rows can close:
+
+1. Authorize a commit set on `codex/0.5.11` that excludes unrelated owner files.
+2. Produce a clean SHA and rebuild closure/profile for that SHA.
+3. Build Apple Silicon, Intel Mac and Windows x64 installers from that SHA on matching hosts.
+4. Run installed fresh/restart/Back/retry/invalid-path/credential-recovery/plugin/upgrade/uninstall on each target.
+5. Optionally supply live credentials through a no-echo channel, or leave V11 explicitly unrun.
+6. Authorize immutable `v0.5.11` publication only after P03 bytes exist. Do not rewrite 0.5.10.
+
+Source gates are not installed, Windows-native, Intel, notarized, live-account, or public-release evidence.

--- a/docs/0.5.11/TODO.md
+++ b/docs/0.5.11/TODO.md
@@ -247,3 +247,16 @@ Remaining owner actions after this pass: merge PR 133 if wanted; Intel Mac + Win
   Merge to `main` is not done. Native Intel/Windows workflow (`native-release-candidate.yml`) requires clean `main` and was not dispatched.
 - Local extras on darwin-aarch64: `verify:asr-real` PASS, `verify:moss-real` PASS (worktree of the docs SHA; not three-target native evidence).
 - V09/V10/V11/P03–P05 unchanged: this host is Darwin arm64 only; no live credentials; no publication.
+
+## Remaining gaps that this session cannot close
+
+| Row | Status | Exact gap |
+| --- | --- | --- |
+| R511-02c | open | Retain Mnemon `0.2.4`. Darwin-aarch64 CLI official PASS. Windows special-character paths, old `mnemon.db` copies, and rollback unrun. Successor `0.2.7`/`0.2.8` not pinned. |
+| V09 | open | Local ad-hoc Apple Silicon DMG from `d7f20c7e` only. Need Intel Mac + Windows x64 matching-native builds from one clean SHA. `native-release-candidate.yml` requires `main` and was not dispatched. |
+| V10 | open | `verify:installed` INCOMPLETE for this SHA. Fresh/restart/Back/retry/invalid-path/credential-recovery/upgrade/uninstall unrun. |
+| V11 | unrun | No live model/IM credentials. Fixtures are not live PASS. |
+| P02 | partial | Commits + push + PR 133. Merge to `main` not done. Owner `AGENTS.md` / `docs/0.5.7/RELEASE_RUNBOOK.md` stay local-only. |
+| P03–P05 | blocked | No 0.5.11 contract assets, no publication authorization, no public-byte readback. Do not rewrite 0.5.10. Do not announce 0.5.11 downloads. |
+
+Owner actions to close those rows: merge PR 133 if that is the intended development landing; run the three-target native workflow from a clean `main` SHA on matching hosts; collect installed lifecycle evidence; optionally supply live credentials or leave V11 unrun; then authorize `v0.5.11` publication.

--- a/docs/0.5.11/TODO.md
+++ b/docs/0.5.11/TODO.md
@@ -232,7 +232,18 @@ In-scope 0.5.11 source was committed as `d7f20c7eeadf6722ab832f5cc3374cb7c5e6f77
 - V09: **partial / still open**. One local Apple Silicon candidate exists from `d7f20c7e`, not from `main`, and not Intel Mac or Windows x64.
 - V10: **unrun**. `verify:installed` INCOMPLETE (`no 0.5.10 installed evidence for darwin-aarch64`). Fresh/restart/Back/retry/upgrade/uninstall not executed against this DMG.
 - V11: **unrun**. No live credentials.
-- P02: local commit of in-scope source exists (`d7f20c7e`). No push/PR/merge. Owner files still uncommitted.
+- P02: local commit of in-scope source exists (`d7f20c7e`). Push/PR recorded below.
 - P03–P05: **blocked**. This DMG is a local candidate, not the contract release set, and must not be announced as a 0.5.11 download.
 
-Remaining owner actions: push/PR if wanted; Intel Mac + Windows x64 matching-native builds from one clean SHA; installed lifecycle; live observations or explicit unrun; publication authorization. Do not rewrite 0.5.10.
+Remaining owner actions after this pass: merge PR 133 if wanted; Intel Mac + Windows x64 matching-native builds from one clean SHA; installed lifecycle; live observations or explicit unrun; publication authorization. Do not rewrite 0.5.10.
+
+## Incremental verification — 2026-09-07 (PR 133)
+
+- P02 (partial): `codex/0.5.11` pushed to `origin`. PR: https://github.com/kevinchennewbee/PenglaiAgent/pull/133
+  Head `26246484` includes `d7f20c7e` (source), `e37d2a2d` (V08 docs), and the PDF/secret-scan linear scanners.
+  Owner `AGENTS.md` and `docs/0.5.7/RELEASE_RUNBOOK.md` are not in the PR.
+  Source CI PASS: https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34099447387
+  PR checks PASS: Full source gates, CodeQL, Analyze (actions/c-cpp/javascript-typescript), Cloudflare Pages. Mergeable CLEAN.
+  Merge to `main` is not done. Native Intel/Windows workflow (`native-release-candidate.yml`) requires clean `main` and was not dispatched.
+- Local extras on darwin-aarch64: `verify:asr-real` PASS, `verify:moss-real` PASS (worktree of the docs SHA; not three-target native evidence).
+- V09/V10/V11/P03–P05 unchanged: this host is Darwin arm64 only; no live credentials; no publication.

--- a/docs/0.5.11/TODO.md
+++ b/docs/0.5.11/TODO.md
@@ -240,10 +240,11 @@ Remaining owner actions after this pass: merge PR 133 if wanted; Intel Mac + Win
 ## Incremental verification — 2026-09-07 (PR 133)
 
 - P02 (partial): `codex/0.5.11` pushed to `origin`. PR: https://github.com/kevinchennewbee/PenglaiAgent/pull/133
-  Head `26246484` includes `d7f20c7e` (source), `e37d2a2d` (V08 docs), and the PDF/secret-scan linear scanners.
+  Head `d8ad31c7` includes `d7f20c7e` (source), V08 docs, PDF/secret-scan linear scanners, Memory candidate CAS test, and this ledger.
   Owner `AGENTS.md` and `docs/0.5.7/RELEASE_RUNBOOK.md` are not in the PR.
-  Source CI PASS: https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34099447387
-  PR checks PASS: Full source gates, CodeQL, Analyze (actions/c-cpp/javascript-typescript), Cloudflare Pages. Mergeable CLEAN.
+  Source CI PASS on `d8ad31c7`: https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34100553442
+  Earlier Source CI PASS on `26246484`: https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34099447387
+  PR checks PASS on `d8ad31c7`: Full source gates, CodeQL, Analyze (actions/c-cpp/javascript-typescript), Cloudflare Pages. Mergeable CLEAN.
   Merge to `main` is not done. Native Intel/Windows workflow (`native-release-candidate.yml`) requires clean `main` and was not dispatched.
 - Local extras on darwin-aarch64: `verify:asr-real` PASS, `verify:moss-real` PASS (worktree of the docs SHA; not three-target native evidence).
 - V09/V10/V11/P03–P05 unchanged: this host is Darwin arm64 only; no live credentials; no publication.
@@ -256,7 +257,7 @@ Remaining owner actions after this pass: merge PR 133 if wanted; Intel Mac + Win
 | V09 | open | Local ad-hoc Apple Silicon DMG from `d7f20c7e` only. Need Intel Mac + Windows x64 matching-native builds from one clean SHA. `native-release-candidate.yml` requires `main` and was not dispatched. |
 | V10 | open | `verify:installed` INCOMPLETE for this SHA. Fresh/restart/Back/retry/invalid-path/credential-recovery/upgrade/uninstall unrun. |
 | V11 | unrun | No live model/IM credentials. Fixtures are not live PASS. |
-| P02 | partial | Commits + push + PR 133. Merge to `main` not done. Owner `AGENTS.md` / `docs/0.5.7/RELEASE_RUNBOOK.md` stay local-only. |
+| P02 | partial | Commits + push + PR 133. Source CI PASS on `d8ad31c7` (run 34100553442). Merge to `main` not done. Owner `AGENTS.md` / `docs/0.5.7/RELEASE_RUNBOOK.md` stay local-only. |
 | P03–P05 | blocked | No 0.5.11 contract assets, no publication authorization, no public-byte readback. Do not rewrite 0.5.10. Do not announce 0.5.11 downloads. |
 
 Owner actions to close those rows: merge PR 133 if that is the intended development landing; run the three-target native workflow from a clean `main` SHA on matching hosts; collect installed lifecycle evidence; optionally supply live credentials or leave V11 unrun; then authorize `v0.5.11` publication.

--- a/docs/0.5.11/UOS.md
+++ b/docs/0.5.11/UOS.md
@@ -1,0 +1,15 @@
+# UOS / LoongArch feasibility
+
+Decision: **not a fourth official 0.5.11 release target**.
+
+This environment did not provide UOS or LoongArch hardware, a signed UOS
+runtime, or Landlock-equivalent sandbox evidence for that OS.
+
+Recorded limitations:
+
+- Official DSH npm cohort and Electron desktop packaging are proven for
+  Apple Silicon, Intel Mac and Windows x64 only.
+- No native helper, installer, or sandbox mapping was executed for UOS.
+- Any later prototype must record runtime, native helper, sandbox, asset and
+  available-device evidence separately and must not be advertised as a
+  supported Penglai platform.

--- a/docs/0.5.11/UPGRADE.md
+++ b/docs/0.5.11/UPGRADE.md
@@ -1,0 +1,57 @@
+# Penglai 0.5.11 upgrade design (development)
+
+There is **no authorized 0.5.11 installer**. This document is the migration
+design required by the development cohort freeze. Do not run it as a public
+upgrade guide until V09/V10 and P03/P04 exist.
+
+## From public 0.5.10
+
+Public 0.5.10 already uses DSH `0.1.2-rc.1`. A later 0.5.11 publication that
+keeps this freeze does **not** change the DSH generation. The product still:
+
+1. Preserves the previous DSH Home generation on disk.
+2. Prepares the new generation in isolation.
+3. Switches the active pointer only after runtime and required-plugin health
+   checks.
+4. Leaves the previous generation available for rollback.
+
+Office and Memory stay required and enabled. Messaging, ASR, TTS and Companion
+stay optional and default off.
+
+## Windows payload activation
+
+NSIS must copy the new tree to `$INSTDIR.pending`, then rename the live tree
+to `$INSTDIR.previous`, then activate pending. Copy or activate failure
+restores `$INSTDIR.previous`. Live `RMDir /r "$LOCALAPPDATA\Penglai\app\0.5"`
+before the new copy exists is forbidden. This is implemented in
+`scripts/nsis/Penglai.nsi` and asserted by `assertWindowsUpgradeStaging`. It
+has **not** been executed on Windows in this session.
+
+## Plugin Center and profile
+
+Interrupted Center transactions restore the latest last-good profile. Failed
+rollback remains unresolved rather than presenting a stale success. Completed
+update journals become CURRENT only when the running version matches or
+supersedes the committed version.
+
+## Mnemon
+
+Memory native remains Mnemon `0.2.4`. An upgrade to `0.2.7`/`0.2.8` is a
+separate asset freeze: three-target archives with exact SHA-256, runner
+version pin, old-database copy, rollback, and Windows special-character path
+evidence. See `MNEMON.md`. Do not mix Mnemon generations inside one release.
+
+## What an operator must not do yet
+
+- Build or distribute 0.5.11 installers from this dirty tree.
+- Retitle `package.json` / `release-contract.json` to 0.5.11 without
+  publication authorization.
+- Rewrite 0.5.10 tags or assets.
+- Treat historical 0.5.7 runbook commands as the 0.5.11 procedure.
+
+## 中文
+
+当前没有可执行的 0.5.11 升级包。本文只固定开发期迁移设计：保留上一代 DSH
+Home，健康检查后再切指针；Windows 先写 `$INSTDIR.pending` 再替换；插件中心
+恢复最近一次成功配置。Mnemon 仍钉在 0.2.4。在三端干净 SHA 安装包和发布授权
+出现之前，不要把本文当成用户升级手册。

--- a/docs/0.5.11/UPSTREAM_DECISIONS.md
+++ b/docs/0.5.11/UPSTREAM_DECISIONS.md
@@ -1,0 +1,28 @@
+# Penglai 0.5.11 upstream decisions
+
+Status: development cohort freeze. Public release identity remains 0.5.10.
+See `COHORT_FREEZE.json`. This is not publication authorization.
+
+Checked on 2026-09-07 against official npm metadata, GitHub tags, and this
+worktree's lockfile. A GitHub tag alone is not a consumable cohort.
+
+| Dependency | Current pin | Decision | Reason |
+| --- | --- | --- | --- |
+| Official DSH npm `next` cohort | `0.1.2-rc.1` / `dsh-v0.1.2-rc.1` / `a66e4702047846cdaa10c66c9d3df3951f5ea70d` | **Retain** | `0.1.3-alpha.1` exists as a source tag; npm does not publish a complete matching 254-package cohort with registry integrity. Mixing generations is forbidden. |
+| Standalone Node | `22.22.2` | **Retain** | Matches `package.json` engines and the 0.5.10 native runtime. No complete successor evaluated in this tree. |
+| Electron | pinned via DSH/desktop packaging | **Retain** | Moves only with the DSH/desktop cohort. |
+| Mnemon native | `v0.2.4` / `67ed1a2f80de902fd041eeaf3b90e7e3d2480d5b` | **Retain** | Darwin arm64 CLI `mnemon version 0.2.4` remember/search/recall/forget ran as a functional probe. Official `verify:memory-real` is INCOMPLETE because the tree is dirty. GitHub successor `v0.2.8` (2026-09-05) exists; `v0.2.7` is the first release that claims Windows special-character SQLite URI encoding. Upgrade needs three-target archive identity, runner pin change, old-db copies, rollback, and Windows path evidence. See `MNEMON.md`. |
+| Feishu / DingTalk SDKs | current channel pins | **Retain** | No complete successor with matching identity and tests in this pass. |
+| sherpa-onnx / ONNX Runtime | current ASR pins | **Retain** | Native asset identity must move with ASR evidence. |
+| Office/PDF (`pdf-lib`, `docx`, `exceljs`, `@liustack/pptfast`) | current | **Retain** | First-party PDF inspect/preview repairs use the existing libraries plus optional Poppler raster when present. |
+| `@linxin666/dsh-web-all@0.3.14` | not a production dependency | **Reject as production pin** | Package exists; it is a reference plugin, not a Penglai runtime substitute. |
+| `@xmanrui/dsh-im@4.9.1` | not a production dependency | **Reject as production pin** | Package exists; Penglai IM remains the first-party control plane over official DSH. |
+
+Release identity, lockfile, profile and plugin catalog stay on the retained
+rc.1 cohort until a complete official successor is frozen. Changing the cohort
+restarts affected validation.
+
+## 中文
+
+官方 DSH 仍使用可验证的 `0.1.2-rc.1` 完整 npm 队列。源码标签 `0.1.3-alpha.1`
+不足以升级。参考插件不是生产依赖。

--- a/docs/0.5.11/WORKBENCH.md
+++ b/docs/0.5.11/WORKBENCH.md
@@ -1,0 +1,13 @@
+# 0.5.11 light workbench decision
+
+Decision: **defer as a product surface**. Keep official DSH conversation UI.
+
+Penglai may only add official slot contributions (settings sections, assistant
+actions, Plugin Center, Memory library, Office status). It must not:
+
+- replace the DSH chat page
+- add a second task engine or hidden core patch
+- inject telemetry or a parallel host
+
+A future workbench is allowed only through documented official extension points
+with a separate acceptance row.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -404,6 +404,20 @@
 - 发布：Owner 已授权正常测试、推送、PR 合并、同一干净 main SHA 的三端原生构建与安装验证、十项完整签名附件、不可变公开回读、README 和双语官网收尾。两小时测试不执行，也不是待补证据。真实账号通信仅按实际执行结果声明。
 - 文档：开发期不能拿历史 0.5.8 文档断言充当当前发布 PASS；发布后的当前 README、SECURITY、站点与发布清单必须独立校验。本地操作 SOP 不公开。历史版本决议继续作为历史记录保留。
 
+### D-067 — 0.5.11 开发冻结 rc.1 cohort，不改写 0.5.10 公开身份
+
+- 日期：2026-09-07。
+- 决定：`codex/0.5.11` 开发树冻结官方 DSH `0.1.2-rc.1` / `dsh-v0.1.2-rc.1` /
+  `a66e4702047846cdaa10c66c9d3df3951f5ea70d` 完整 254 包 npm cohort。拒绝用不完整的
+  `dsh-v0.1.3-alpha.1` 标签混装。Node `22.22.2`、Electron `43.4.0`、pnpm `11.7.0`
+  随该 cohort 保留。公开产品身份、tag 与 `release-contract.json` 仍为 **0.5.10**，
+  不可变。0.5.11 不得在无发布授权时改写 package/lock/profile/release-contract 版本。
+- 迁移/回滚：升级保留旧 DSH Home，健康检查后再切指针；插件中心恢复 last-good
+  profile；Windows 先写入 `$INSTDIR.pending`，失败则恢复 `$INSTDIR.previous`。
+- 后果：机器可读冻结记录为 `docs/0.5.11/COHORT_FREEZE.json`，必须与
+  `packages/release-identity/src/pins.ts` 和 `release-contract.json` 一致。0.5.10
+  的 tag、附件和公开下载不得改写。
+
 ## Superseded
 
 已从执行面移出的决议正文：`D-014`、`D-020`、`D-021`、`D-025`、`D-030`。它们仍保留编号以便审计，但不得再当当前产品合同。

--- a/native/windows-host/penglai_windows_host.c
+++ b/native/windows-host/penglai_windows_host.c
@@ -95,9 +95,9 @@ static char *wide_to_utf8(const wchar_t *wide) {
   return out;
 }
 
-static char *current_sid_string(void) {
+static char *process_sid_string(HANDLE process) {
   HANDLE token = NULL;
-  if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token)) return NULL;
+  if (!OpenProcessToken(process, TOKEN_QUERY, &token)) return NULL;
   DWORD needed = 0;
   GetTokenInformation(token, TokenUser, NULL, 0, &needed);
   TOKEN_USER *user = (TOKEN_USER *)calloc(1, needed ? needed : 1);
@@ -114,6 +114,10 @@ static char *current_sid_string(void) {
   free(user);
   CloseHandle(token);
   return sid;
+}
+
+static char *current_sid_string(void) {
+  return process_sid_string(GetCurrentProcess());
 }
 
 static int has_reparse(const wchar_t *path) {
@@ -568,7 +572,11 @@ static int cmd_identity(DWORD pid) {
   ULONGLONG startMs = 0;
   if (!process_start_ms(pid, &startMs)) win_fail("GetProcessTimes");
   char *image = process_image(pid);
-  char *owner = current_sid_string();
+  HANDLE process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+  if (!process) win_fail("OpenProcess identity");
+  char *owner = process_sid_string(process);
+  CloseHandle(process);
+  if (!owner) fail("process-owner-unavailable");
   printf("{\"ok\":true,\"command\":\"process-identity\",\"pid\":%lu,\"startMs\":%llu,\"executable\":", (unsigned long)pid, (unsigned long long)startMs);
   json_escape(stdout, image ? image : "");
   fputs(",\"owner\":", stdout);
@@ -576,41 +584,6 @@ static int cmd_identity(DWORD pid) {
   fputs("}\n", stdout);
   free(image);
   free(owner);
-  return 0;
-}
-
-static int cmd_reap_supervisors(const char *exe_utf8, DWORD keep_pid) {
-  wchar_t *expected = utf8_to_wide(exe_utf8);
-  if (!expected) fail("utf16");
-  HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-  if (snapshot == INVALID_HANDLE_VALUE) win_fail("CreateToolhelp32Snapshot");
-  PROCESSENTRY32W entry;
-  ZeroMemory(&entry, sizeof(entry));
-  entry.dwSize = sizeof(entry);
-  DWORD killed[256];
-  size_t count = 0;
-  if (Process32FirstW(snapshot, &entry)) {
-    do {
-      DWORD pid = entry.th32ProcessID;
-      if (!pid || pid == GetCurrentProcessId() || pid == keep_pid) continue;
-      HANDLE process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE, FALSE, pid);
-      if (!process) continue;
-      wchar_t image[MAX_PATH * 4];
-      DWORD image_len = MAX_PATH * 4;
-      if (QueryFullProcessImageNameW(process, 0, image, &image_len) && _wcsicmp(image, expected) == 0) {
-        if (TerminateProcess(process, 1) && count < 256) killed[count++] = pid;
-      }
-      CloseHandle(process);
-    } while (Process32NextW(snapshot, &entry));
-  }
-  CloseHandle(snapshot);
-  fputs("{\"ok\":true,\"command\":\"process-reap-supervisors\",\"pids\":[", stdout);
-  for (size_t i = 0; i < count; i++) {
-    if (i) fputc(',', stdout);
-    fprintf(stdout, "%lu", (unsigned long)killed[i]);
-  }
-  fprintf(stdout, "],\"deleted\":%lu}\n", (unsigned long)count);
-  free(expected);
   return 0;
 }
 
@@ -726,12 +699,6 @@ int main(int argc, char **argv) {
     const char *pid = opt(argc, argv, "--pid");
     if (!pid) fail("pid");
     return cmd_identity((DWORD)strtoul(pid, NULL, 10));
-  }
-  if (strcmp(cmd, "process-reap-supervisors") == 0) {
-    const char *exe = opt(argc, argv, "--exe");
-    const char *keep = opt(argc, argv, "--keep-pid");
-    if (!exe) fail("exe");
-    return cmd_reap_supervisors(exe, keep ? (DWORD)strtoul(keep, NULL, 10) : 0);
   }
   if (strcmp(cmd, "process-suspend") == 0 || strcmp(cmd, "process-resume") == 0) {
     const char *pid = opt(argc, argv, "--pid");

--- a/packages/artifacts/src/service.test.ts
+++ b/packages/artifacts/src/service.test.ts
@@ -226,7 +226,13 @@ test("identical bytes keep distinct opaque bindings across Workspaces", () => {
   assert.equal(a.sha256, b.sha256);
   assert.equal(artifacts.ref(a.id).workspaceId, "ws-a");
   assert.equal(artifacts.ref(b.id).workspaceId, "ws-b");
-  assert.throws(() => artifacts.readControlled(a.sha256, { workspaceId: "ws-a", sessionId: "sess-a" }), /AMBIGUOUS/);
+  const fromA = artifacts.readControlled(a.sha256, { workspaceId: "ws-a", sessionId: "sess-a" });
+  const fromB = artifacts.readControlled(b.sha256, { workspaceId: "ws-b", sessionId: "sess-b" });
+  assert.equal(fromA.name, "a.txt");
+  assert.equal(fromB.name, "b.txt");
+  assert.equal(fromA.bytes.equals(bytes), true);
+  assert.throws(() => artifacts.readControlled(a.sha256, { workspaceId: "ws-a", sessionId: "sess-b" }), /MISSING|SESSION|WORKSPACE|AMBIGUOUS/);
+  assert.throws(() => artifacts.readControlled(a.id, { workspaceId: "ws-b", sessionId: "sess-b" }), /WORKSPACE/);
   artifacts.close();
 });
 

--- a/packages/artifacts/src/service.ts
+++ b/packages/artifacts/src/service.ts
@@ -227,7 +227,7 @@ export class ArtifactService {
   }
 
   readControlled(id: string, scope: ArtifactReadScope): { name: string; mediaType: string; bytes: Buffer } {
-    const row = this.lookup(id);
+    const row = this.lookup(id, scope);
     if ((row.workspaceId ?? "") !== (scope.workspaceId ?? "")) fail("ARTIFACT_WORKSPACE_MISMATCH");
     if (row.sessionId && row.sessionId !== scope.sessionId) fail("ARTIFACT_SESSION_MISMATCH");
     if (row.turnId && scope.turnId && row.turnId !== scope.turnId) fail("ARTIFACT_TURN_MISMATCH");
@@ -382,21 +382,27 @@ export class ArtifactService {
     });
   }
 
-  private lookup(id: string) {
+  private lookup(id: string, scope?: ArtifactReadScope) {
     let row: Record<string, string | number | null> | undefined;
     if (/^artifact:[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(id)) {
       row = this.db.prepare(`SELECT * FROM artifacts WHERE bind_id = ?`).get(id.slice("artifact:".length)) as
         | Record<string, string | number | null>
         | undefined;
     } else {
-      // One local 0.5.7 development build exposed digest-shaped ids. Accept
-      // them only when they resolve to exactly one binding; never guess across
-      // Workspace/Session boundaries.
+      // Digest-shaped ids are shared CAS keys. When a read scope is present,
+      // select the binding that belongs to that Workspace/Session instead of
+      // treating two authorized copies as one ambiguous object.
       const digest = id.replace(/^sha256:/, "").toLowerCase();
       if (!/^[0-9a-f]{64}$/.test(digest)) fail("ARTIFACT_ID");
-      const rows = this.db.prepare(`SELECT * FROM artifacts WHERE sha256 = ?`).all(digest) as Array<
+      let rows = this.db.prepare(`SELECT * FROM artifacts WHERE sha256 = ?`).all(digest) as Array<
         Record<string, string | number | null>
       >;
+      if (scope) {
+        rows = rows.filter((candidate) =>
+          (candidate.workspace_id ?? "") === (scope.workspaceId ?? "") &&
+          (!candidate.session_id || candidate.session_id === (scope.sessionId ?? candidate.session_id)),
+        );
+      }
       if (rows.length > 1) fail("ARTIFACT_AMBIGUOUS_LEGACY_ID");
       row = rows[0];
     }

--- a/packages/channel-feishu/src/media.ts
+++ b/packages/channel-feishu/src/media.ts
@@ -7,6 +7,12 @@ import {
   type PenglaiMossTtsClient,
   type PenglaiTtsLocale,
 } from "@penglai/contracts";
+
+function localeForMossVoiceId(voiceId: string): PenglaiTtsLocale {
+  const marked = /^moss-(zh|en|ja)-/.exec(voiceId);
+  if (marked?.[1] === "en" || marked?.[1] === "ja" || marked?.[1] === "zh") return marked[1];
+  return "zh";
+}
 import { decodeFeishuOggOpus, encodeFeishuOggOpus, normalizeWavMono } from "@penglai/audio-codecs";
 import type { InboundFailureDiagnostic } from "@penglai/routing-core";
 
@@ -111,7 +117,7 @@ export async function outboundFeishuNativeAudio(
     finalText: input.finalText,
     finalDigest,
     voiceId: input.voiceId ?? "moss-zh-default",
-    locale: input.locale ?? "zh",
+    locale: input.locale ?? localeForMossVoiceId(input.voiceId ?? "moss-zh-default"),
   });
   try {
     const wav = await tts.readOutput(synthesized.handle, input.operationId);

--- a/packages/channel-telegram/src/index.ts
+++ b/packages/channel-telegram/src/index.ts
@@ -1,4 +1,4 @@
-import { PenglaiError } from "@penglai/contracts";
+import { PenglaiError, readBoundedResponse } from "@penglai/contracts";
 
 export const name = "telegram";
 
@@ -22,6 +22,7 @@ export class TelegramAdapter {
   connection: TelegramConnection = "not_configured";
   accountRef: string | undefined;
   private token: string | undefined;
+  private connectionGeneration = 0;
   webhookConflict = false;
   private offset = 0;
   private inboundHandler?: (msg: TelegramInbound) => void | Promise<void>;
@@ -33,6 +34,10 @@ export class TelegramAdapter {
   ) {}
 
   async beginConnection(input: { method: string; credentialRef: string }): Promise<{ kind: "token"; connection: TelegramConnection; operationId: string }> {
+    const generation = ++this.connectionGeneration;
+    const assertCurrent = () => {
+      if (generation !== this.connectionGeneration) throw new PenglaiError("DELIVERY_TRANSIENT", "CHANNEL_CONNECTION_CANCELLED");
+    };
     if (input.method === "qr") throw new PenglaiError("SECURITY_POLICY", "CHANNEL_NO_QR");
     const creds = this.vault.resolve(input.credentialRef);
     if (!creds?.token) {
@@ -45,6 +50,7 @@ export class TelegramAdapter {
       signal: AbortSignal.timeout(10_000),
     });
     const meBody = await readTelegramJson<{ ok?: boolean; result?: { id?: number } }>(me);
+    assertCurrent();
     if (!me.ok || !meBody.ok) {
       this.connection = "failed";
       throw new PenglaiError("AUTH_EXPIRED", "TELEGRAM_TOKEN_INVALID");
@@ -55,6 +61,7 @@ export class TelegramAdapter {
       signal: AbortSignal.timeout(10_000),
     });
     const hookBody = await readTelegramJson<{ ok?: boolean; result?: { url?: string } }>(webhook);
+    assertCurrent();
     if (!webhook.ok || !hookBody.ok) {
       this.connection = "failed";
       throw new PenglaiError("AUTH_EXPIRED", "TELEGRAM_WEBHOOK_INFO_FAILED");
@@ -86,6 +93,7 @@ export class TelegramAdapter {
     update_id?: number;
     message?: { message_id?: number; text?: string; chat?: { id?: number; type?: string }; from?: { id?: number } };
   }): Promise<void> {
+    const generation = this.connectionGeneration;
     const nextOffset = update.update_id === undefined
       ? this.offset
       : Math.max(this.offset, update.update_id + 1);
@@ -102,6 +110,7 @@ export class TelegramAdapter {
     }
     // Telegram's offset is its delivery acknowledgement. Advance it only after
     // Penglai's inbound path has durably accepted a private message.
+    if (generation !== this.connectionGeneration) return;
     if (nextOffset !== this.offset) {
       this.offset = nextOffset;
       this.offsetPersist?.(this.offset);
@@ -180,10 +189,19 @@ export class TelegramAdapter {
   }
 
   async disconnect(): Promise<void> {
+    this.connectionGeneration += 1;
     this.pollAbort?.abort();
     this.pollAbort = undefined;
     this.token = undefined;
     this.connection = "disabled";
+  }
+
+  async logout(): Promise<void> {
+    await this.disconnect();
+    this.accountRef = undefined;
+    this.offset = 0;
+    this.webhookConflict = false;
+    this.offsetPersist?.(0);
   }
 
   private pollAbort: AbortController | undefined;
@@ -197,6 +215,7 @@ export class TelegramAdapter {
       while (!signal.aborted && this.token) {
         try {
           await this.pollOnce(signal);
+          if (signal.aborted) return;
           consecutiveFailures = 0;
           this.connection = "connected";
         } catch (error) {
@@ -235,7 +254,10 @@ export class TelegramAdapter {
     if (!response.ok || !body.ok || !Array.isArray(body.result)) {
       throw new PenglaiError("DELIVERY_TRANSIENT", "TELEGRAM_POLL_FAILED");
     }
-    for (const update of body.result) await this.ingestUpdate(update);
+    for (const update of body.result) {
+      if (signal.aborted) return;
+      await this.ingestUpdate(update);
+    }
   }
 
   private async fetchApi(
@@ -257,10 +279,8 @@ export class TelegramAdapter {
 }
 
 async function readTelegramJson<T>(response: Response): Promise<T> {
-  const text = await response.text();
-  if (Buffer.byteLength(text, "utf8") > 1024 * 1024) {
-    throw new PenglaiError("DELIVERY_TRANSIENT", "TELEGRAM_RESPONSE_TOO_LARGE");
-  }
+  const { bytes } = await readBoundedResponse({ response, maxBytes: 1024 * 1024, timeoutMs: 10_000, category: "generic" });
+  const text = bytes.toString("utf8");
   try {
     return JSON.parse(text) as T;
   } catch {

--- a/packages/channel-telegram/src/telegram.test.ts
+++ b/packages/channel-telegram/src/telegram.test.ts
@@ -82,3 +82,33 @@ test("Telegram does not acknowledge an update before durable inbound accepts it"
   );
   assert.equal(adapter.getUpdateOffset(), 7);
 });
+
+test("Telegram logout invalidates an in-flight connect and clears account cursor", async () => {
+  let release!: (response: Response) => void;
+  let calls = 0;
+  const adapter = new TelegramAdapter({ resolve: () => ({ token: "123:abc" }) }, async () => {
+    calls++;
+    return new Promise<Response>((resolve) => { release = resolve; });
+  });
+  adapter.restoreUpdateOffset(123);
+  const pending = adapter.beginConnection({ method: "token", credentialRef: "PENGLAI_TELEGRAM_TOKEN" });
+  await adapter.logout();
+  release(new Response(JSON.stringify({ ok: true, result: { id: 1 } })));
+  await assert.rejects(pending, /CHANNEL_CONNECTION_CANCELLED/);
+  assert.equal(calls, 1);
+  assert.equal(adapter.connection, "disabled");
+  assert.equal(adapter.accountRef, undefined);
+  assert.equal(adapter.getUpdateOffset(), 0);
+});
+
+test("Telegram does not restore a cursor after logout while an inbound handler is pending", async () => {
+  const adapter = new TelegramAdapter({ resolve: () => undefined });
+  adapter.accountRef = "account";
+  let release!: () => void;
+  adapter.onInbound(() => new Promise<void>((resolve) => { release = resolve; }));
+  const pending = adapter.ingestUpdate({ update_id: 500, message: { message_id: 1, text: "hello", chat: { id: 1, type: "private" }, from: { id: 1 } } });
+  await adapter.logout();
+  release();
+  await pending;
+  assert.equal(adapter.getUpdateOffset(), 0);
+});

--- a/packages/channel-weixin/src/cdn.ts
+++ b/packages/channel-weixin/src/cdn.ts
@@ -3,6 +3,7 @@ import { PenglaiError } from "@penglai/contracts";
 import { UploadMediaType, type WeixinCdnMedia } from "./protocol.js";
 
 export const WEIXIN_MEDIA_MAX_BYTES = 8 * 1024 * 1024;
+export const WEIXIN_CDN_TIMEOUT_MS = 30_000;
 const CDN_HOST_SUFFIXES = [
   "ilinkai.weixin.qq.com",
   ".weixin.qq.com",
@@ -89,7 +90,11 @@ export async function downloadAndDecryptWeixinCdn(
   const key = parseAesKey(media.aes_key);
   let response: Response;
   try {
-    response = await fetchImpl(url, { method: "GET", redirect: "error", ...(signal ? { signal } : {}) });
+    response = await fetchImpl(url, {
+      method: "GET",
+      redirect: "error",
+      signal: signal ?? AbortSignal.timeout(WEIXIN_CDN_TIMEOUT_MS),
+    });
   } catch {
     throw new PenglaiError("DELIVERY_TRANSIENT", "Weixin CDN download failed");
   }
@@ -188,6 +193,7 @@ async function uploadWeixinEncryptedMedia(
       redirect: "error",
       headers: { "Content-Type": "application/octet-stream" },
       body: new Uint8Array(encrypted),
+      signal: AbortSignal.timeout(WEIXIN_CDN_TIMEOUT_MS),
     });
   } catch {
     throw new PenglaiError("DELIVERY_TRANSIENT", "cdn-upload-network");

--- a/packages/channel-weixin/src/index.ts
+++ b/packages/channel-weixin/src/index.ts
@@ -271,6 +271,16 @@ export class ILinkTransport implements WeixinTransport {
   lastToken: string | undefined;
 }
 
+/** Blocked receive must retry the same vendor cursor; advancing in-memory loses the batch. */
+export function applyWeixinReceiveCursor(input: {
+  previousBuf: string;
+  nextBuf: string;
+  blocked: boolean;
+}): { buf: string; persist: boolean } {
+  if (input.blocked) return { buf: input.previousBuf, persist: false };
+  return { buf: input.nextBuf, persist: true };
+}
+
 export class WeixinAdapter {
   authState: AuthState = "idle";
   private tokenRef = WEIXIN_TOKEN_CREDENTIAL_REF;
@@ -544,8 +554,13 @@ export class WeixinAdapter {
               if (onRaw) await onRaw(raw);
               else await this.ingest(raw);
             }
-            this.buf = out.buf;
-            if (!this.cursorBlocked) {
+            const cursor = applyWeixinReceiveCursor({
+              previousBuf: this.buf,
+              nextBuf: out.buf,
+              blocked: this.cursorBlocked,
+            });
+            this.buf = cursor.buf;
+            if (cursor.persist) {
               this.cursors?.putCursor(this.accountRef, "weixin", this.buf);
             }
           } catch (err) {

--- a/packages/channel-weixin/src/media.ts
+++ b/packages/channel-weixin/src/media.ts
@@ -5,6 +5,12 @@ import {
   type PenglaiMossTtsClient,
   type PenglaiTtsLocale,
 } from "@penglai/contracts";
+
+function localeForMossVoiceId(voiceId: string): PenglaiTtsLocale {
+  const marked = /^moss-(zh|en|ja)-/.exec(voiceId);
+  if (marked?.[1] === "en" || marked?.[1] === "ja" || marked?.[1] === "zh") return marked[1];
+  return "zh";
+}
 import { decodeWeixinSilkToWav, normalizeWavMono } from "@penglai/audio-codecs";
 
 export type VoicePolicy = "text" | "voice" | "text+voice" | "mirror";
@@ -65,7 +71,7 @@ export async function outboundTtsAttachment(
     finalText: input.finalText,
     finalDigest,
     voiceId: input.voiceId ?? "moss-zh-default",
-    locale: input.locale ?? "zh",
+    locale: input.locale ?? localeForMossVoiceId(input.voiceId ?? "moss-zh-default"),
   });
   try {
     const wav = await tts.readOutput(synthesized.handle, input.operationId);

--- a/packages/channel-weixin/src/weixin.test.ts
+++ b/packages/channel-weixin/src/weixin.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { createCipheriv, createDecipheriv, createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import type { ModelInput } from "@penglai/contracts";
 import { SeqIds, VirtualClock } from "@penglai/testkit";
@@ -8,6 +9,7 @@ import { RoutingControlPlane } from "@penglai/routing-core";
 import {
   MemoryVault,
   WeixinAdapter,
+  applyWeixinReceiveCursor,
   WEIXIN_TOKEN_CREDENTIAL_REF,
   WEIXIN_CONTEXT_CREDENTIAL_REF,
   parseInbound,
@@ -23,6 +25,7 @@ import {
   downloadAndDecryptWeixinVoice,
   uploadWeixinAudioFile,
   uploadWeixinVoice,
+  WEIXIN_CDN_TIMEOUT_MS,
   type WeixinVoiceMediaRef,
 } from "./cdn.js";
 import {
@@ -251,6 +254,41 @@ test("R50-VOICE: weixin inbound wav transcribes and outbound keeps a visible aud
   assert.match(fallback.filename, /\.wav$/);
   assert.equal(fallback.data.subarray(0, 4).toString("ascii"), "RIFF");
   assert.equal(released, true);
+});
+
+test("Weixin TTS locale follows the selected English or Japanese voice", async () => {
+  const { outboundTtsAttachment } = await import("./media.js");
+  const wav = toneWav();
+  const digest = createHash("sha256").update(wav).digest("hex");
+  for (const [voiceId, locale] of [["moss-en-default", "en"], ["moss-ja-soyo", "ja"]] as const) {
+    let seen = "";
+    await outboundTtsAttachment({
+      finalText: "hello",
+      sourceFinalId: `final:${voiceId}`,
+      operationId: `tts-${voiceId}`,
+      voiceId,
+    }, "voice", {
+      async synthesize(request) {
+        seen = request.locale;
+        return {
+          handle: {
+            id: "00000000-0000-4000-8000-000000000009",
+            digest,
+            bytes: wav.length,
+            durationMs: 1000,
+            voiceId: request.voiceId,
+            sourceFinalDigest: request.finalDigest,
+            ownerOperation: request.operationId,
+            expiresAt: Date.now() + 60_000,
+          },
+          operation: { operationId: request.operationId },
+        };
+      },
+      async readOutput() { return wav; },
+      async releaseOutput() {},
+    });
+    assert.equal(seen, locale);
+  }
 });
 
 function toneWav(): Buffer {
@@ -625,6 +663,24 @@ test("scanner owner identity survives restart and unknown owner blocks cursor", 
   assert.equal(store.getCursor("weixin-default-2", "weixin"), undefined);
 });
 
+test("blocked Weixin cursor stays retryable and does not advance in memory", () => {
+  assert.deepEqual(
+    applyWeixinReceiveCursor({ previousBuf: "cursor-1", nextBuf: "cursor-2", blocked: true }),
+    { buf: "cursor-1", persist: false },
+  );
+  assert.deepEqual(
+    applyWeixinReceiveCursor({ previousBuf: "cursor-1", nextBuf: "cursor-2", blocked: false }),
+    { buf: "cursor-2", persist: true },
+  );
+  const src = readFileSync(new URL("./index.ts", import.meta.url), "utf8");
+  assert.match(src, /applyWeixinReceiveCursor\(/);
+  assert.match(src, /if \(cursor\.persist\)/);
+  assert.doesNotMatch(
+    src,
+    /this\.buf = out\.buf;\s*if \(!this\.cursorBlocked\) \{\s*this\.cursors\?\.putCursor/,
+  );
+});
+
 test("R50-VOICE-014 Weixin CDN decrypts SILK and uploads one encrypted visible FILE", async () => {
   const key = Buffer.alloc(16, 0x2a);
   const cipher = createCipheriv("aes-128-ecb", key, null);
@@ -641,18 +697,31 @@ test("R50-VOICE-014 Weixin CDN decrypts SILK and uploads one encrypted visible F
     sampleRate: 24_000,
     playtimeMs: 200,
   };
-  const decrypted = await downloadAndDecryptWeixinVoice(
-    voiceRef,
-    "https://ilinkai.weixin.qq.com",
-    (async (url, init) => {
-      assert.equal(url, voiceRef.media.full_url);
-      assert.equal(init?.redirect, "error");
-      return new Response(encryptedFixture, {
-        status: 200,
-        headers: { "content-length": String(encryptedFixture.length) },
-      });
-    }) as typeof fetch,
-  );
+  const timeouts: number[] = [];
+  const originalTimeout = AbortSignal.timeout;
+  AbortSignal.timeout = ((ms: number) => {
+    timeouts.push(ms);
+    return originalTimeout(ms);
+  }) as typeof AbortSignal.timeout;
+  let decrypted: Buffer;
+  try {
+    decrypted = await downloadAndDecryptWeixinVoice(
+      voiceRef,
+      "https://ilinkai.weixin.qq.com",
+      (async (url, init) => {
+        assert.equal(url, voiceRef.media.full_url);
+        assert.equal(init?.redirect, "error");
+        assert.equal(init?.signal instanceof AbortSignal, true);
+        return new Response(encryptedFixture, {
+          status: 200,
+          headers: { "content-length": String(encryptedFixture.length) },
+        });
+      }) as typeof fetch,
+    );
+  } finally {
+    AbortSignal.timeout = originalTimeout;
+  }
+  assert.deepEqual(timeouts, [WEIXIN_CDN_TIMEOUT_MS]);
   assert.deepEqual(decrypted, SILK_FIXTURE);
 
   await assert.rejects(
@@ -679,6 +748,7 @@ test("R50-VOICE-014 Weixin CDN decrypts SILK and uploads one encrypted visible F
     },
     (async (_url, init) => {
       uploadedCiphertext = Buffer.from(init?.body as Uint8Array);
+      assert.equal(init?.signal instanceof AbortSignal, true);
       return new Response("", { status: 200, headers: { "x-encrypted-param": "download-receipt" } });
     }) as typeof fetch,
   );

--- a/packages/context/src/ingest.test.ts
+++ b/packages/context/src/ingest.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { deflateSync } from "node:zlib";
+import { zipSync } from "fflate";
+import { extractText, MAX_EXPANDED_BYTES } from "./ingest.js";
+
+test("context rejects compressed PDF expansion without falling back to compressed text", () => {
+  const payload = deflateSync(Buffer.alloc(MAX_EXPANDED_BYTES + 1, 65));
+  const pdf = Buffer.concat([Buffer.from("%PDF-1.7\nstream\n"), payload, Buffer.from("\nendstream")]);
+  const original = Buffer.from(pdf);
+  assert.throws(() => extractText("large.pdf", pdf), /expansion limit/);
+  assert.deepEqual(pdf, original);
+});
+
+test("context bounds OOXML expansion even if the directory understates its size", () => {
+  const archive = Buffer.from(zipSync({ "word/document.xml": Buffer.alloc(MAX_EXPANDED_BYTES + 1, 65) }));
+  const directory = archive.indexOf(Buffer.from("PK\x01\x02"));
+  archive.writeUInt32LE(1, directory + 24);
+  const original = Buffer.from(archive);
+  assert.throws(() => extractText("large.docx", archive), /larger than|expansion limit/i);
+  assert.deepEqual(archive, original);
+});
+
+test("context continues extracting bounded compressed PDF and OOXML", () => {
+  const pdf = Buffer.concat([Buffer.from("%PDF-1.7\nstream\n"), deflateSync(Buffer.from("(Readable PDF text)")), Buffer.from("\nendstream")]);
+  assert.equal(extractText("small.pdf", pdf), "Readable PDF text");
+  const archive = Buffer.from(zipSync({ "word/document.xml": Buffer.from("<w:p>Readable document</w:p>") }));
+  assert.equal(extractText("small.docx", archive), "Readable document");
+  assert.throws(() => extractText("broken.docx", Buffer.from("PK\x05\x06")), /central directory/);
+});

--- a/packages/context/src/ingest.ts
+++ b/packages/context/src/ingest.ts
@@ -6,6 +6,7 @@ import { PenglaiError, readExactRegularFile } from "@penglai/contracts";
 import { assertGrant, type ContextGrant } from "./service.js";
 
 export const MAX_FILE_BYTES = 2 * 1024 * 1024;
+export const MAX_EXPANDED_BYTES = 2 * 1024 * 1024;
 export const MAX_FILES_PER_SCAN = 400;
 export const MAX_TEXT_BYTES = 256 * 1024;
 export const TEXT_EXTS = new Set([".txt", ".md", ".markdown", ".json", ".csv", ".html", ".htm", ".xml", ".yml", ".yaml", ".log"]);
@@ -50,6 +51,7 @@ function extractPdfText(buf: Buffer): string {
   const raw = buf.toString("latin1");
   const chunks: string[] = [];
   let cursor = 0;
+  let remaining = MAX_EXPANDED_BYTES;
   while (cursor < raw.length && chunks.length < 128) {
     const marker = raw.indexOf("stream", cursor);
     if (marker < 0) break;
@@ -72,14 +74,18 @@ function extractPdfText(buf: Buffer): string {
     cursor = endMarker + "endstream".length;
     let decoded: Buffer = payload;
     try {
-      decoded = Buffer.from(inflateSync(payload));
-    } catch {
+      decoded = inflateSync(payload, { maxOutputLength: Math.max(1, remaining) });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ERR_BUFFER_TOO_LARGE") throw new PenglaiError("INVALID_INPUT", "context expansion limit exceeded");
       try {
-        decoded = Buffer.from(inflateRawSync(payload));
-      } catch {
+        decoded = inflateRawSync(payload, { maxOutputLength: Math.max(1, remaining) });
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ERR_BUFFER_TOO_LARGE") throw new PenglaiError("INVALID_INPUT", "context expansion limit exceeded");
         decoded = payload;
       }
     }
+    remaining -= decoded.length;
+    if (remaining < 0) throw new PenglaiError("INVALID_INPUT", "context expansion limit exceeded");
     const text = decoded.toString("utf8");
     const literals = [...text.matchAll(/\(([^()\\]{2,})\)/g)].map((m) => m[1] ?? "");
     if (literals.length) chunks.push(literals.join(" "));
@@ -111,10 +117,11 @@ function stripXml(xml: string): string {
 
 function readZipTexts(buf: Buffer, names: readonly string[]): Record<string, string> {
   const eocd = buf.lastIndexOf(Buffer.from("PK\x05\x06"));
-  if (eocd < 0) throw new PenglaiError("INVALID_INPUT", "office archive missing central directory");
+  if (eocd < 0 || eocd + 22 > buf.length) throw new PenglaiError("INVALID_INPUT", "office archive missing central directory");
   const count = buf.readUInt16LE(eocd + 10);
   let offset = buf.readUInt32LE(eocd + 16);
   const out: Record<string, string> = {};
+  let remaining = MAX_EXPANDED_BYTES;
   for (let i = 0; i < count && offset + 46 <= buf.length; i += 1) {
     if (buf.readUInt32LE(offset) !== 0x02014b50) break;
     const method = buf.readUInt16LE(offset + 10);
@@ -126,12 +133,16 @@ function readZipTexts(buf: Buffer, names: readonly string[]): Record<string, str
     const name = buf.subarray(offset + 46, offset + 46 + nameLen).toString("utf8");
     offset += 46 + nameLen + extraLen + commentLen;
     if (!names.includes(name)) continue;
+    if (localOff + 30 > buf.length) throw new PenglaiError("INVALID_INPUT", "office archive local header truncated");
     if (buf.readUInt32LE(localOff) !== 0x04034b50) continue;
     const localNameLen = buf.readUInt16LE(localOff + 26);
     const localExtra = buf.readUInt16LE(localOff + 28);
     const dataStart = localOff + 30 + localNameLen + localExtra;
+    if (dataStart + compSize > buf.length || ![0, 8].includes(method)) throw new PenglaiError("INVALID_INPUT", "office archive entry invalid");
     const compressed = buf.subarray(dataStart, dataStart + compSize);
-    const data = method === 0 ? compressed : inflateRawSync(compressed);
+    const data = method === 0 ? compressed : inflateRawSync(compressed, { maxOutputLength: Math.max(1, remaining) });
+    remaining -= data.length;
+    if (remaining < 0) throw new PenglaiError("INVALID_INPUT", "context expansion limit exceeded");
     out[name] = data.toString("utf8");
   }
   return out;

--- a/packages/contracts/src/center-journal.ts
+++ b/packages/contracts/src/center-journal.ts
@@ -1,0 +1,33 @@
+import { PenglaiError } from "./errors.js";
+
+export const CENTER_JOURNAL_SCHEMA = 3;
+
+export interface CenterJournalHeader {
+  schema: 2 | typeof CENTER_JOURNAL_SCHEMA;
+  operationId: string;
+  phase: "staging" | "activating" | "verifying" | "committed" | "rolled_back";
+  id: string;
+  previousEnabled: boolean;
+  lastGoodPhase?: "snapshot" | "snapshot-ready" | "promote-prev" | "promote-next" | "promote-done";
+}
+
+/** Shared disk contract for transaction writers and preboot recovery. */
+export function assertCenterJournalHeader(value: unknown): asserts value is CenterJournalHeader {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new PenglaiError("STORE_CORRUPT", "Center recovery journal invalid");
+  }
+  const row = value as Record<string, unknown>;
+  if (
+    (row.schema !== 2 && row.schema !== CENTER_JOURNAL_SCHEMA) ||
+    typeof row.operationId !== "string" || !/^[A-Za-z0-9_-]{1,128}$/.test(row.operationId) ||
+    typeof row.id !== "string" || !row.id || row.id.length > 160 ||
+    typeof row.previousEnabled !== "boolean" ||
+    (row.lastGoodPhase !== undefined && !["snapshot", "snapshot-ready", "promote-prev", "promote-next", "promote-done"].includes(String(row.lastGoodPhase))) ||
+    !["staging", "activating", "verifying", "committed", "rolled_back"].includes(String(row.phase))
+  ) throw new PenglaiError("STORE_CORRUPT", "Center recovery journal invalid");
+}
+
+/** Before activation, the live profile and desired state have not changed. */
+export function centerProfileWasUntouched(journal: CenterJournalHeader): boolean {
+  return journal.phase === "staging" && journal.lastGoodPhase !== undefined;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -20,6 +20,8 @@ export * from "./bounded-http.js";
 export * from "./closed-enum.js";
 export * from "./safe-https.js";
 export * from "./session-snapshot.js";
+export * from "./center-journal.js";
+export * from "./usage-projection.js";
 
 export const SCHEMA_VERSION = 12;
 export const RELEASE = "0.5.10";
@@ -585,6 +587,14 @@ export interface AssistantFinal {
 }
 
 export type PenglaiTtsLocale = "zh" | "en" | "ja";
+
+/** Voice ids encode locale as moss-<locale>-*. Never default English/Japanese voices to zh. */
+export function localeForMossVoiceId(voiceId: string): PenglaiTtsLocale {
+  if (typeof voiceId !== "string" || !voiceId) return "zh";
+  const marked = /^moss-(zh|en|ja)-/.exec(voiceId);
+  if (marked?.[1] === "en" || marked?.[1] === "ja" || marked?.[1] === "zh") return marked[1];
+  return "zh";
+}
 
 export interface PenglaiTtsSynthesisRequest {
   operationId: string;

--- a/packages/contracts/src/usage-projection.test.ts
+++ b/packages/contracts/src/usage-projection.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { projectOfficialUsage } from "./usage-projection.js";
+
+test("official usage projection keeps occupancy, cache, cumulative and estimated cost distinct", () => {
+  const seen = projectOfficialUsage({
+    occupancyTokens: 1200,
+    inputTokens: 800,
+    outputTokens: 200,
+    cacheReadTokens: 40,
+    estimatedCost: 0.12,
+    estimatedCurrency: "USD",
+  });
+  assert.equal(seen.occupancy.availability, "available");
+  assert.equal(seen.occupancy.tokens, 1200);
+  assert.equal(seen.cumulative.inputTokens, 800);
+  assert.equal(seen.cache.readTokens, 40);
+  assert.equal(seen.estimatedCost.availability, "estimated");
+  assert.equal(seen.estimatedCost.amount, 0.12);
+  const missing = projectOfficialUsage({});
+  assert.equal(missing.occupancy.availability, "unavailable");
+  assert.equal(missing.cumulative.availability, "unavailable");
+  assert.equal(missing.cache.availability, "unavailable");
+  assert.equal(missing.estimatedCost.availability, "unavailable");
+  assert.equal("amount" in missing.estimatedCost, false);
+});

--- a/packages/contracts/src/usage-projection.ts
+++ b/packages/contracts/src/usage-projection.ts
@@ -1,0 +1,46 @@
+export type UsageAvailability = "available" | "unavailable" | "estimated";
+
+export interface OfficialUsageProjection {
+  occupancy: { tokens?: number; availability: UsageAvailability };
+  cumulative: { inputTokens?: number; outputTokens?: number; availability: UsageAvailability };
+  cache: { readTokens?: number; writeTokens?: number; availability: UsageAvailability };
+  estimatedCost: { amount?: number; currency?: string; availability: UsageAvailability };
+}
+
+function finiteCount(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+/** Read-only projection of official accounting. Missing fields stay unavailable; this never enables Budget enforcement. */
+export function projectOfficialUsage(input: {
+  occupancyTokens?: unknown;
+  inputTokens?: unknown;
+  outputTokens?: unknown;
+  cacheReadTokens?: unknown;
+  cacheWriteTokens?: unknown;
+  estimatedCost?: unknown;
+  estimatedCurrency?: unknown;
+}): OfficialUsageProjection {
+  const occupancy = finiteCount(input.occupancyTokens);
+  const inputTokens = finiteCount(input.inputTokens);
+  const outputTokens = finiteCount(input.outputTokens);
+  const cacheRead = finiteCount(input.cacheReadTokens);
+  const cacheWrite = finiteCount(input.cacheWriteTokens);
+  const amount = typeof input.estimatedCost === "number" && Number.isFinite(input.estimatedCost) ? input.estimatedCost : undefined;
+  const currency = typeof input.estimatedCurrency === "string" && /^[A-Z]{3}$/.test(input.estimatedCurrency) ? input.estimatedCurrency : undefined;
+  return {
+    occupancy: occupancy === undefined ? { availability: "unavailable" } : { tokens: occupancy, availability: "available" },
+    cumulative:
+      inputTokens === undefined && outputTokens === undefined
+        ? { availability: "unavailable" }
+        : { ...(inputTokens !== undefined ? { inputTokens } : {}), ...(outputTokens !== undefined ? { outputTokens } : {}), availability: "available" },
+    cache:
+      cacheRead === undefined && cacheWrite === undefined
+        ? { availability: "unavailable" }
+        : { ...(cacheRead !== undefined ? { readTokens: cacheRead } : {}), ...(cacheWrite !== undefined ? { writeTokens: cacheWrite } : {}), availability: "available" },
+    estimatedCost:
+      amount === undefined
+        ? { availability: "unavailable" }
+        : { amount, ...(currency ? { currency } : {}), availability: "estimated" },
+  };
+}

--- a/packages/contracts/src/voice-locale.test.ts
+++ b/packages/contracts/src/voice-locale.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { localeForMossVoiceId } from "./index.js";
+
+test("MOSS voice ids select matching locale instead of defaulting English and Japanese to zh", () => {
+  assert.equal(localeForMossVoiceId("moss-zh-default"), "zh");
+  assert.equal(localeForMossVoiceId("moss-en-default"), "en");
+  assert.equal(localeForMossVoiceId("moss-ja-soyo"), "ja");
+  assert.equal(localeForMossVoiceId(""), "zh");
+});

--- a/packages/dsh-bridge/src/bridge.test.ts
+++ b/packages/dsh-bridge/src/bridge.test.ts
@@ -13,7 +13,12 @@ import {
   probePinnedPackages,
   withPenglaiVoiceContext,
 } from "./index.js";
-import { hostFromRc2Cordis, listenOfficialEvents } from "./plugin.js";
+import {
+  hostFromRc2Cordis,
+  listenOfficialEvents,
+  recoverOfficialDeliveriesFromHost,
+  recoverOfficialTurnDelivery,
+} from "./plugin.js";
 
 test("R1-UP-001 rejects other versions", () => {
   assert.throws(() => assertDshVersion("9.9.9"), PenglaiError);
@@ -553,4 +558,105 @@ test("official session/event pair delivers assistant final to the IM route", () 
   );
   listeners.get("session/event")?.({ id: "s" }, { type: "turn/end", data: { turn: 2 } });
   assert.equal(store.pendingOutbox("r")[0]?.payloadText, "penglai-causal-ok");
+});
+
+function recoveryPlane() {
+  const store = new Store(":memory:");
+  const plane = new RoutingControlPlane(
+    store,
+    new VirtualClock(),
+    new SeqIds(),
+    { async listWorkspaces() { return []; }, async listSessions() { return []; } },
+    { async followup() { return { dshMessageId: "x" }; }, async steer() { return { dshMessageId: "x" }; }, async cancelCurrent() {}, async removeInbox() {} },
+  );
+  store.upsertRoute({ routeId: "r", adapter: "mock", accountRef: "a", peerRef: "p", status: "active" });
+  store.putBinding({
+    routeId: "r", workspaceIdentity: "w", sessionId: "s", revision: 1, status: "active",
+    createdAt: "t", updatedAt: "t",
+  });
+  store.insertInbound({
+    inboundId: "in1", adapterMessageKey: "k", routeId: "r", bindingRevision: 1,
+    bodyKind: "text", redactedDigest: "d", state: "queued",
+  }, "hi", 1);
+  const source = { kind: "user", schema: 1, routeId: "r", inboundId: "in1", adapter: "mock" };
+  return { store, plane, source };
+}
+
+test("official durable session recovery closes claimed-turn/final/outbox without duplicate delivery", () => {
+  const first = recoveryPlane();
+  const claimed = {
+    type: "agent/inbox/claimed",
+    data: { turn: 3, message: { id: "mid", source: first.source } },
+  };
+  const assistant = {
+    type: "assistant/message",
+    data: { turn: 3, message: { content: [{ type: "text", text: "durable-final" }] } },
+  };
+  const crashWindow = recoverOfficialTurnDelivery(first.plane, {
+    sessionId: "s",
+    events: [claimed, assistant],
+  });
+  assert.equal(crashWindow.incomplete, 1);
+  assert.equal(crashWindow.delivered, 0);
+  assert.equal(first.store.pendingOutbox("r").length, 0);
+
+  const closed = recoverOfficialTurnDelivery(first.plane, {
+    sessionId: "s",
+    events: [claimed, assistant, { type: "turn/end", data: { turn: 3 } }],
+  });
+  assert.equal(closed.claimed, 1);
+  assert.equal(closed.delivered, 1);
+  assert.equal(first.store.pendingOutbox("r")[0]?.payloadText, "durable-final");
+  const outboxId = first.store.pendingOutbox("r")[0]?.outboxId;
+
+  const replay = recoverOfficialTurnDelivery(first.plane, {
+    sessionId: "s",
+    events: [claimed, assistant, { type: "turn/end", data: { turn: 3 } }],
+  });
+  assert.equal(replay.delivered, 1);
+  assert.equal(first.store.pendingOutbox("r").length, 1);
+  assert.equal(first.store.pendingOutbox("r")[0]?.outboxId, outboxId);
+
+  const spliced = recoveryPlane();
+  recoverOfficialTurnDelivery(spliced.plane, {
+    sessionId: "s",
+    events: [
+      { type: "turn/start", data: { turn: 4 } },
+      { type: "agent/inbox/spliced", data: { inserted: [{ id: "mid-2", source: spliced.source }] } },
+      { type: "assistant/message", data: { turn: 4, message: { content: [{ type: "text", text: "from-snapshot" }] } } },
+      { type: "turn/end", data: { turn: 4 } },
+    ],
+  });
+  assert.equal(spliced.store.pendingOutbox("r")[0]?.payloadText, "from-snapshot");
+});
+
+test("host recovery reads official snapshotEvents and does not duplicate outbox", async () => {
+  const { store, plane, source } = recoveryPlane();
+  const events = [
+    { type: "agent/inbox/claimed", data: { turn: 5, message: { id: "mid", source } } },
+    { type: "assistant/message", data: { turn: 5, message: { content: [{ type: "text", text: "host-final" }] } } },
+    { type: "turn/end", data: { turn: 5 } },
+  ];
+  const host = {
+    version: "0.1.2-rc.1",
+    getAgent: (id: string) =>
+      id === "s"
+        ? {
+            id,
+            session: { snapshotEvents: () => events },
+            followup() {},
+            steer() {},
+            cancel() {},
+            inbox: { remove() { return true; } },
+          }
+        : undefined,
+    listWorkspaces: () => [],
+    listSessions: async () => [{ id: "s" }],
+  };
+  const first = await recoverOfficialDeliveriesFromHost(host as never, plane);
+  const second = await recoverOfficialDeliveriesFromHost(host as never, plane);
+  assert.equal(first.delivered, 1);
+  assert.equal(second.delivered, 1);
+  assert.equal(store.pendingOutbox("r").length, 1);
+  assert.equal(store.pendingOutbox("r")[0]?.payloadText, "host-final");
 });

--- a/packages/dsh-bridge/src/plugin.ts
+++ b/packages/dsh-bridge/src/plugin.ts
@@ -1,5 +1,7 @@
+import { PenglaiError, snapshotOfficialSession } from "@penglai/contracts";
 import type { RoutingControlPlane } from "@penglai/routing-core";
 import { claimedFromOfficial, textFromAssistantMessage } from "./index.js";
+import type { DshHost } from "./owner-ports.js";
 import type { CordisLike } from "./rc2-owner-adapter.js";
 
 export {
@@ -84,4 +86,121 @@ export function listenOfficialEvents(ctx: CordisLike, plane: RoutingControlPlane
     finals.delete(`${sessionId}:${turn}`);
     if (text) plane.onAssistantFinal({ sessionId, turnId: String(turn), text });
   });
+}
+
+function durableEvent(raw: unknown): {
+  type: string;
+  turn?: number;
+  message?: Record<string, unknown>;
+  inserted?: unknown[];
+  text: string;
+} {
+  const rec = asRecord(raw);
+  const data = asRecord(rec?.data) ?? rec ?? {};
+  const message = asRecord(data.message) ?? asRecord(rec?.message);
+  const turn = typeof data.turn === "number" ? data.turn : typeof rec?.turn === "number" ? rec.turn : undefined;
+  const inserted = Array.isArray(data.inserted) ? data.inserted : Array.isArray(rec?.inserted) ? rec.inserted : undefined;
+  return {
+    type: String(rec?.type ?? data.type ?? ""),
+    ...(turn !== undefined ? { turn } : {}),
+    ...(message ? { message } : {}),
+    ...(inserted ? { inserted } : {}),
+    text: textFromAssistantMessage(message ?? {}),
+  };
+}
+
+/**
+ * Rebuild claimed-turn/final/outbox from the official durable Session log.
+ * Live `assistant/message` is only in memory until turn/end; crash recovery
+ * must not invent a final for an unclosed turn, and must not enqueue twice.
+ */
+export function recoverOfficialTurnDelivery(
+  plane: Pick<RoutingControlPlane, "onClaimed" | "onAssistantFinal">,
+  input: { sessionId: string; events: readonly unknown[] },
+): { claimed: number; delivered: number; incomplete: number } {
+  if (!input.sessionId.trim()) {
+    throw new PenglaiError("INVALID_INPUT", "official session id required");
+  }
+  let currentTurn: number | undefined;
+  const claims = new Map<number, NonNullable<ReturnType<typeof claimedFromOfficial>>>();
+  const texts = new Map<number, string>();
+  const ended = new Set<number>();
+
+  const rememberClaim = (turn: number | undefined, message: Record<string, unknown> | undefined) => {
+    const used = turn ?? currentTurn;
+    if (typeof used !== "number" || typeof message?.id !== "string" || !message.id) return;
+    const fact = claimedFromOfficial({
+      message: { id: message.id, source: message.source ?? { kind: "unknown" } },
+      turn: used,
+      sessionId: input.sessionId,
+    });
+    if (fact) claims.set(used, fact);
+  };
+
+  for (const raw of input.events) {
+    const ev = durableEvent(raw);
+    if (ev.type === "turn/start" && typeof ev.turn === "number") currentTurn = ev.turn;
+    if (ev.type === "agent/inbox/claimed") rememberClaim(ev.turn, ev.message ?? asRecord(asRecord(raw)?.data));
+    if (ev.type === "user/message") rememberClaim(ev.turn, ev.message);
+    if (ev.type === "agent/inbox/spliced") {
+      for (const item of ev.inserted ?? []) rememberClaim(ev.turn, asRecord(item));
+    }
+    if (ev.type === "assistant/message") {
+      const used = ev.turn ?? currentTurn;
+      if (typeof used === "number" && ev.text.trim()) texts.set(used, ev.text);
+    }
+    if (ev.type === "turn/end") {
+      const used = ev.turn ?? currentTurn;
+      if (typeof used === "number") ended.add(used);
+      currentTurn = undefined;
+    }
+  }
+
+  let claimed = 0;
+  let delivered = 0;
+  let incomplete = 0;
+  for (const [turn, fact] of claims) {
+    if (!ended.has(turn)) {
+      incomplete += 1;
+      continue;
+    }
+    plane.onClaimed(fact);
+    claimed += 1;
+    const text = texts.get(turn);
+    if (!text?.trim()) {
+      incomplete += 1;
+      continue;
+    }
+    plane.onAssistantFinal({ sessionId: input.sessionId, turnId: String(turn), text });
+    delivered += 1;
+  }
+  return { claimed, delivered, incomplete };
+}
+
+export async function recoverOfficialDeliveriesFromHost(
+  host: DshHost,
+  plane: Pick<RoutingControlPlane, "onClaimed" | "onAssistantFinal">,
+): Promise<{ sessions: number; claimed: number; delivered: number; incomplete: number }> {
+  const totals = { sessions: 0, claimed: 0, delivered: 0, incomplete: 0 };
+  if (!host.listSessions) return totals;
+  let sessions: Awaited<ReturnType<NonNullable<DshHost["listSessions"]>>> = [];
+  try {
+    sessions = await host.listSessions();
+  } catch (error) {
+    if (error instanceof PenglaiError && error.errorClass === "DSH_UNAVAILABLE") return totals;
+    throw error;
+  }
+  for (const session of sessions) {
+    const agent = host.getAgent(session.id);
+    if (!agent?.session) continue;
+    totals.sessions += 1;
+    const result = recoverOfficialTurnDelivery(plane, {
+      sessionId: session.id,
+      events: snapshotOfficialSession(agent.session),
+    });
+    totals.claimed += result.claimed;
+    totals.delivered += result.delivered;
+    totals.incomplete += result.incomplete;
+  }
+  return totals;
 }

--- a/packages/im/src/adapters/channel-bridge.test.ts
+++ b/packages/im/src/adapters/channel-bridge.test.ts
@@ -53,7 +53,7 @@ test("channel bridge drops incomplete inbound and HMAC-hashes peerRef", async ()
   assert.equal(event.vendorTarget, "D1");
   assert.equal(event.accountRef, "B1");
   assert.equal(event.provenPrivate, true);
-  assert.equal(event.idempotencyKey, "slack:B1:3");
+  assert.equal(event.idempotencyKey, "slack:B1:D1:3");
   assert.equal(event.peerRef, hashPeer("U1", "B1"));
   assert.notEqual(event.peerRef, hashPeer("U1", "B2"));
   assert.notEqual(event.peerRef, "U1");

--- a/packages/im/src/adapters/channel-bridge.ts
+++ b/packages/im/src/adapters/channel-bridge.ts
@@ -27,6 +27,7 @@ export interface NativeWrapOpts {
 }
 
 type NativeLike = {
+  accountRef?: string | undefined;
   beginConnection(input: { method?: string; credentialRef?: string }): Promise<{
     kind: "qr" | "token" | "manifest" | "device-link";
     connection: string;
@@ -69,8 +70,11 @@ export function wrapNative(
 ): ChannelAdapter & { peekQr(operationId: string): QrPeek | undefined } {
   const manifest = getChannelManifest(id);
   let inbound: ((event: InboundChannelEvent) => void | Promise<void>) | undefined;
+  let generation = 0;
   adapter.onInbound?.(async (msg) => {
+    const seen = generation;
     const event = mapInbound(id, msg as Record<string, unknown>, opts.hashPeer);
+    if (seen !== generation) return;
     if (!event || event.chatType !== "private" || !event.provenPrivate) return;
     await inbound?.(event);
   });
@@ -82,6 +86,7 @@ export function wrapNative(
       enabled = true;
     },
     async disable() {
+      generation += 1;
       enabled = false;
       await adapter.disconnect();
     },
@@ -100,6 +105,7 @@ export function wrapNative(
       return { status: polled.status as ConnectionState };
     },
     async cancelConnection() {
+      generation += 1;
       await adapter.disconnect();
     },
     async start() {
@@ -117,16 +123,22 @@ export function wrapNative(
         connection: enabled ? (row.connection as ConnectionState) : "disabled",
       };
     },
+    accountIdentity: () => adapter.accountRef,
     sendText: (input) => adapter.sendText(input),
     async sendArtifact() {
       throw new PenglaiError("SECURITY_POLICY", `CHANNEL_ARTIFACT_SEND_UNAVAILABLE:${id}`);
     },
-    disconnect: () => adapter.disconnect(),
+    async disconnect() {
+      generation += 1;
+      await adapter.disconnect();
+    },
     async logout() {
+      generation += 1;
       enabled = false;
       await (adapter.logout ? adapter.logout() : adapter.disconnect());
     },
     async deleteCredentials() {
+      generation += 1;
       enabled = false;
       await (adapter.logout ? adapter.logout() : adapter.disconnect());
     },

--- a/packages/im/src/bots.ts
+++ b/packages/im/src/bots.ts
@@ -38,6 +38,13 @@ export interface ImBotRow {
 }
 
 const SIDECAR_SQL = `
+  CREATE TABLE IF NOT EXISTS im_v2_peer_approvals (
+    channel TEXT NOT NULL, account_ref TEXT NOT NULL, peer_ref TEXT NOT NULL,
+    vendor_target TEXT NOT NULL, sender_id TEXT NOT NULL,
+    binding_revision INTEGER, updated_at INTEGER NOT NULL,
+    PRIMARY KEY(channel, account_ref, peer_ref)
+  );
+
   CREATE TABLE IF NOT EXISTS im_v2_bots (
     bot_id TEXT PRIMARY KEY,
     channel_id TEXT NOT NULL,
@@ -95,6 +102,40 @@ export function ensureImV2Tables(db: DatabaseSync): void {
 export class ImBotStore {
   constructor(private readonly db: DatabaseSync) {
     ensureImV2Tables(db);
+  }
+
+  observePeer(input: { channel: string; accountRef: string; peerRef: string; vendorTarget: string; senderId: string }): void {
+    this.db.prepare(`DELETE FROM im_v2_peer_approvals WHERE binding_revision IS NULL AND updated_at < ?`).run(Date.now() - 24 * 60 * 60 * 1000);
+    const existing = this.peer(input.channel, input.accountRef, input.peerRef);
+    if (existing) {
+      if (existing.vendorTarget === input.vendorTarget && existing.senderId === input.senderId) {
+        this.db.prepare(`UPDATE im_v2_peer_approvals SET binding_revision = NULL, updated_at = ? WHERE channel = ? AND account_ref = ? AND peer_ref = ?`).run(Date.now(), input.channel, input.accountRef, input.peerRef);
+      }
+      return;
+    }
+    const count = this.db.prepare(`SELECT COUNT(*) AS n FROM im_v2_peer_approvals WHERE binding_revision IS NULL`).get() as { n: number };
+    if (count.n >= 100) return;
+    this.db.prepare(`INSERT INTO im_v2_peer_approvals(channel, account_ref, peer_ref, vendor_target, sender_id, updated_at) VALUES (?, ?, ?, ?, ?, ?)`).run(
+      input.channel, input.accountRef, input.peerRef, input.vendorTarget, input.senderId, Date.now(),
+    );
+  }
+
+  peer(channel: string, accountRef: string, peerRef: string) {
+    return this.db.prepare(`SELECT vendor_target AS vendorTarget, sender_id AS senderId, binding_revision AS bindingRevision FROM im_v2_peer_approvals WHERE channel = ? AND account_ref = ? AND peer_ref = ?`).get(channel, accountRef, peerRef) as
+      { vendorTarget: string; senderId: string; bindingRevision: number | null } | undefined;
+  }
+
+  pendingPeers() {
+    return this.db.prepare(`SELECT channel, account_ref AS accountId, peer_ref AS peerId, sender_id AS senderId FROM im_v2_peer_approvals WHERE binding_revision IS NULL AND updated_at >= ? ORDER BY updated_at DESC LIMIT 100`).all(Date.now() - 24 * 60 * 60 * 1000) as Array<{ channel: ChannelId; accountId: string; peerId: string; senderId: string }>;
+  }
+
+  approvePeer(channel: string, accountRef: string, peerRef: string, revision: number): void {
+    const result = this.db.prepare(`UPDATE im_v2_peer_approvals SET binding_revision = ?, updated_at = ? WHERE channel = ? AND account_ref = ? AND peer_ref = ?`).run(revision, Date.now(), channel, accountRef, peerRef);
+    if (result.changes !== 1) throw new PenglaiError("SECURITY_POLICY", "IM_PEER_NOT_OBSERVED");
+  }
+
+  revokePeers(channel: string): void {
+    this.db.prepare(`DELETE FROM im_v2_peer_approvals WHERE channel = ?`).run(channel);
   }
 
   list(channelId?: string): ImBotRow[] {

--- a/packages/im/src/channel-adapter.ts
+++ b/packages/im/src/channel-adapter.ts
@@ -60,6 +60,7 @@ export type ConnectionResult =
 
 export interface ChannelAdapter {
   readonly id: ChannelId;
+  accountIdentity?(): string | undefined;
   manifest(): ChannelManifestV1;
   enable(): Promise<void>;
   disable(): Promise<void>;

--- a/packages/im/src/dsh-client.js
+++ b/packages/im/src/dsh-client.js
@@ -212,7 +212,7 @@ window.__ModuleLoader__.load({
         qrFailed: "失败",
         qrCancelled: "已取消",
         bindHint:
-          "扫码后会自动使用官方默认工作区/会话。这里只在需要换会话时使用。",
+          "微信和飞书在确认身份后使用官方默认会话。其他通道先从本人账号发一条私聊，再在此核对账号和发送者，确认绑定后重新发送。未经确认的消息不会交给 Agent。",
         bindAction: "改绑到所选官方会话",
         workspace: "工作区",
         session: "会话",
@@ -342,7 +342,7 @@ window.__ModuleLoader__.load({
         qrFailed: "Failed",
         qrCancelled: "Cancelled",
         bindHint:
-          "After you scan, Penglai uses the official default workspace and session. Use this only to switch sessions.",
+          "Weixin and Feishu use the official default session after identity verification. For other channels, send a private message from your account, then verify the account and sender here and approve the binding. Resend your message afterward; unapproved messages never reach the Agent.",
         bindAction: "Rebind to the selected official session",
         workspace: "Workspace",
         session: "Session",
@@ -630,7 +630,7 @@ window.__ModuleLoader__.load({
         if (!peer) return;
         const objectId = `${peer.channel}:${peer.accountId}:${peer.peerId}`;
         Promise.resolve(imCall(remote, connection, "proposeBinding", {
-          action: "im.bind",
+          action: currentBinding ? "im.rebind" : "im.bind",
           objectId,
           workspaceId,
           sessionId,
@@ -710,7 +710,7 @@ window.__ModuleLoader__.load({
                 "option",
                 {
                   value: `${r.channel}:${r.accountId}:${r.peerId}`,
-                  children: `${r.channel} · ${r.peerId}`,
+                  children: `${r.channel} · ${r.senderId || r.peerId} · ${r.accountId}`,
                 },
                 `${r.channel}:${r.accountId}:${r.peerId}`,
               ),
@@ -1923,6 +1923,11 @@ window.__ModuleLoader__.load({
                             authentication: "authentication",
                             inboundText: "inbound text",
                             outboundText: "outbound text",
+                            file: "file",
+                            voice: "voice",
+                            question: "question",
+                            approval: "approval",
+                            recovery: "recovery",
                             image: "image",
                             audio: "audio",
                             reconnect: "reconnect",
@@ -1932,6 +1937,11 @@ window.__ModuleLoader__.load({
                             authentication: "认证",
                             inboundText: "接收文本",
                             outboundText: "发送文本",
+                            file: "文件",
+                            voice: "语音消息",
+                            question: "提问",
+                            approval: "审批",
+                            recovery: "恢复",
                             image: "图片",
                             audio: "语音",
                             reconnect: "重连",
@@ -2007,6 +2017,14 @@ window.__ModuleLoader__.load({
                                 ? `Source-tested: ${evidenceNames("source-tested") || "none"}; not proven live: ${evidenceNames("not-proven") || "none"}; not supported: ${evidenceNames("not-supported") || "none"}`
                                 : `源码已测：${evidenceNames("source-tested") || "无"}；尚无真实验证：${evidenceNames("not-proven") || "无"}；不支持：${evidenceNames("not-supported") || "无"}`,
                             }),
+                            c.connectionHint
+                              ? jsx.jsx("p", {
+                                  "data-penglai-im-connection-hint": c.channel,
+                                  children: (document.documentElement.lang || "zh").startsWith("en")
+                                    ? c.connectionHint.en
+                                    : c.connectionHint.zh,
+                                })
+                              : null,
                             c.error
                               ? jsx.jsxs("p", {
                                   role: "alert",

--- a/packages/im/src/host.ts
+++ b/packages/im/src/host.ts
@@ -1,3 +1,5 @@
+import { inboundOperationKey, legacyInboundIdempotencyKey } from "./inbound-envelope.js";
+import { OfficialImRequestStore } from "./official-requests.js";
 import {
   PenglaiError,
   assertSha256,
@@ -58,6 +60,27 @@ import {
   type ImOwnerBrokerPort,
 } from "./owner.js";
 
+function peekInboundOperation(
+  store: Store,
+  routeId: string,
+  vendorMessageKey: string,
+): { operationId: string; inboundId?: string; turnId?: string } | undefined {
+  const existing = store.db
+    .prepare(
+      `SELECT operation_id, inbound_id, turn_id FROM inbound_operations
+       WHERE vendor_message_key = ? AND route_id = ?`,
+    )
+    .get(vendorMessageKey, routeId) as
+    | { operation_id: string; inbound_id?: string | null; turn_id?: string | null }
+    | undefined;
+  if (!existing) return undefined;
+  return {
+    operationId: existing.operation_id,
+    ...(existing.inbound_id ? { inboundId: existing.inbound_id } : {}),
+    ...(existing.turn_id ? { turnId: existing.turn_id } : {}),
+  };
+}
+
 export type ChannelName = ChannelId;
 export type { ConnectionState };
 
@@ -75,6 +98,7 @@ export interface ChannelState {
   runtimeBundled: true;
   releaseEvidence: ChannelManifestV1["releaseEvidence"];
   capabilityEvidence: ChannelManifestV1["capabilityEvidence"];
+  connectionHint: ChannelManifestV1["connectionHint"];
   connectionMethods: ChannelManifestV1["connectionMethods"];
   error?: {
     code: string;
@@ -112,6 +136,7 @@ export class PenglaiImHost {
   private feishuAppId = "";
   private owner: ImOwnerBrokerPort | undefined;
   private artifacts: ArtifactService | undefined;
+  private secretClearer?: (id: ChannelId) => void;
   private secretHydrator?: (id: ChannelId, serialized: string) => void;
   private readonly adapters = new Map<ChannelId, ChannelAdapter>();
   startupFailure: MessageFailure | undefined;
@@ -120,6 +145,7 @@ export class PenglaiImHost {
   private resolveSidecarReady: (() => void) | undefined;
   private readonly statusReactions = new Map<string, StatusReactionHandle>();
   readonly bots: ImBotStore;
+  readonly officialRequests: OfficialImRequestStore;
 
   constructor(
     readonly store: Store,
@@ -148,6 +174,18 @@ export class PenglaiImHost {
     }
     this.store.redactExpiredPayloads(this.plane.clock.now());
     this.bots = new ImBotStore(this.store.db);
+    this.officialRequests = new OfficialImRequestStore(this.store.db);
+    const submitInbound = this.plane.submitInbound.bind(this.plane);
+    this.plane.submitInbound = async (env) => {
+      const answered = this.officialRequests.tryAnswerFromInbound({
+        channel: env.adapter,
+        accountId: env.accountRef,
+        peerId: env.peerRef,
+        text: env.text ?? "",
+      });
+      if (answered) return { kind: "control", text: answered };
+      return submitInbound(env);
+    };
     for (const id of CHANNEL_IDS) {
       if (!isNativeChannel(id)) this.adapters.set(id, guidedAdapter(id));
     }
@@ -155,6 +193,10 @@ export class PenglaiImHost {
 
   attachOwner(owner: ImOwnerBrokerPort): void {
     this.owner = owner;
+  }
+
+  attachSecretClearer(clear: (id: ChannelId) => void): void {
+    this.secretClearer = clear;
   }
 
   attachSecretHydrator(hydrate: (id: ChannelId, serialized: string) => void): void {
@@ -357,9 +399,9 @@ export class PenglaiImHost {
   }
 
   /** Peers that have a durable vendor reply target but no active binding. */
-  listBindableRoutes(): Array<{ channel: ChannelName; accountId: string; peerId: string }> {
+  listBindableRoutes(): Array<{ channel: ChannelName; accountId: string; peerId: string; senderId?: string }> {
     const bound = new Set(this.store.listActiveBindings().map((b) => b.routeId));
-    const out: Array<{ channel: ChannelName; accountId: string; peerId: string }> = [];
+    const out: Array<{ channel: ChannelName; accountId: string; peerId: string; senderId?: string }> = [...this.bots.pendingPeers()];
     for (const route of this.store.listRoutes()) {
       if (bound.has(route.routeId)) continue;
       const target = this.store.getVendorReplyTarget(route.routeId);
@@ -497,8 +539,12 @@ export class PenglaiImHost {
     ownerActionId: string;
     receipt?: string;
   }): BindingDto {
-    if (!isNativeChannel(input.channel)) {
+    if (!(CHANNEL_IDS as readonly string[]).includes(input.channel)) {
       throw new PenglaiError("SECURITY_POLICY", "CHANNEL_BINDING_UNAVAILABLE");
+    }
+    const peer = isNativeChannel(input.channel) ? undefined : this.bots.peer(input.channel, input.accountId, input.peerId);
+    if (!isNativeChannel(input.channel) && (!peer || !this.owner)) {
+      throw new PenglaiError("SECURITY_POLICY", "IM_PEER_APPROVAL_REQUIRED");
     }
     if (input.expectedRevision !== undefined && input.expectedRevision !== this.revision) {
       throw new PenglaiError("BINDING_STALE", "revision mismatch");
@@ -514,19 +560,20 @@ export class PenglaiImHost {
     const workspaces = this.dsh.listWorkspaces();
     const ws = workspaces.find((w) => w.id === input.workspaceId);
     if (!ws) throw new PenglaiError("INVALID_INPUT", "workspace not found");
-    if (!ws.sessionIds.includes(input.sessionId) && !this.dsh.getAgent(input.sessionId)) {
+    if (!ws.sessionIds.includes(input.sessionId)) {
       throw new PenglaiError("INVALID_INPUT", "session not in official workspace");
     }
     const objectId = imBindingObjectId(input);
     const existing = this.store.findRoute(input.channel, input.accountId, input.peerId);
+    const wasBound = existing && this.store.activeBinding(existing.routeId);
     const finishOwnerAction = consumeImOwnerProof(this.owner, {
-      action: existing ? IM_OWNER_ACTIONS.rebind : IM_OWNER_ACTIONS.bind,
+      action: wasBound ? IM_OWNER_ACTIONS.rebind : IM_OWNER_ACTIONS.bind,
       actionId: input.ownerActionId,
       objectId,
       workspaceId: input.workspaceId,
       sessionId: input.sessionId,
       resultDigest: imSourceDigest({
-        action: existing ? IM_OWNER_ACTIONS.rebind : IM_OWNER_ACTIONS.bind,
+        action: wasBound ? IM_OWNER_ACTIONS.rebind : IM_OWNER_ACTIONS.bind,
         objectId,
         workspaceId: input.workspaceId,
         sessionId: input.sessionId,
@@ -556,6 +603,10 @@ export class PenglaiImHost {
       createdAt: current?.createdAt ?? now,
       updatedAt: now,
     });
+    if (peer) {
+      this.store.putVendorReplyTarget(routeId, peer.vendorTarget);
+      this.bots.approvePeer(input.channel, input.accountId, input.peerId, revision);
+    }
     this.revision += 1;
     finishOwnerAction();
     return this.listBindings().find((b) => b.id === routeId)!;
@@ -891,6 +942,7 @@ export class PenglaiImHost {
       runtimeBundled: manifest.runtimeBundled,
       releaseEvidence: manifest.releaseEvidence,
       capabilityEvidence: manifest.capabilityEvidence,
+      connectionHint: manifest.connectionHint,
       connectionMethods: manifest.connectionMethods,
       ...(failure
         ? {
@@ -926,6 +978,7 @@ export class PenglaiImHost {
       runtimeBundled: manifest.runtimeBundled,
       releaseEvidence: manifest.releaseEvidence,
       capabilityEvidence: manifest.capabilityEvidence,
+      connectionHint: manifest.connectionHint,
       connectionMethods: manifest.connectionMethods,
       ...(failure
         ? {
@@ -1132,10 +1185,12 @@ export class PenglaiImHost {
       ...(input.receipt ? { receipt: input.receipt } : {}),
     });
     const adapter = requireAdapter(this.adapters, id);
+    this.secretClearer?.(id);
+    this.bots.revokePeers(id);
     // deleteCredentials owns the adapter-specific logout/wipe operation.
     await adapter.deleteCredentials();
     await this.vault.delete(CHANNEL_CREDENTIAL_REFS[id]);
-    this.persistChannelFlag(id, false);
+    this.store.putAdapterConfig(channelConfigAccountId(id), id, JSON.stringify({ enabled: false }));
     this.revision += 1;
     finishOwnerAction();
     return { loggedOut: true };
@@ -1247,7 +1302,12 @@ export class PenglaiImHost {
     if (!route || isNativeChannel(route.adapter) || !(CHANNEL_IDS as readonly string[]).includes(route.adapter)) return;
     const adapter = this.adapters.get(route.adapter as ChannelId);
     if (!adapter) return;
+    if (adapter.accountIdentity?.() !== route.accountRef) return;
+    const binding = this.store.activeBinding(routeId);
+    const peer = this.bots.peer(route.adapter, route.accountRef, route.peerRef);
+    if (!binding || !peer || peer.bindingRevision !== binding.revision) return;
     const target = this.plane.requireVendorTarget(routeId);
+    if (target !== peer.vendorTarget) return;
     for (const item of this.plane.dueOutbox(routeId)) {
       const claimToken = this.plane.markSending(item.outboxId, route.adapter);
       if (!claimToken) continue;
@@ -1282,14 +1342,15 @@ export class PenglaiImHost {
     this.persistChannelFlag(channel, true, adapter.exportPersistedState());
   }
 
-  private startStatusReaction(adapter: ChannelAdapter, event: InboundChannelEvent): void {
+  private startStatusReaction(adapter: ChannelAdapter, event: InboundChannelEvent, routeId: string): void {
     if (typeof adapter.react !== "function") return;
     const emojis = CHANNEL_STATUS_REACTIONS[event.channel];
     if (!emojis) return;
-    const existing = this.statusReactions.get(event.idempotencyKey);
+    const key = inboundOperationKey(routeId, event.idempotencyKey);
+    const existing = this.statusReactions.get(key);
     if (existing) return;
     const handle = beginStatusReaction({
-      key: event.idempotencyKey,
+      key,
       emojis,
       add: (emoji, signal) =>
         adapter.react!({
@@ -1308,7 +1369,7 @@ export class PenglaiImHost {
           signal,
         }),
     });
-    this.statusReactions.set(event.idempotencyKey, handle);
+    this.statusReactions.set(key, handle);
     if (this.statusReactions.size > 256) {
       const first = this.statusReactions.keys().next().value;
       if (first) this.statusReactions.delete(first);
@@ -1318,11 +1379,11 @@ export class PenglaiImHost {
   private finishStatusReaction(_adapter: string, _accountRef: string, inboundId: string, kind: "success" | "error"): void {
     const inbound = this.store.getInbound(inboundId);
     if (!inbound) return;
-    const handle = this.statusReactions.get(inbound.adapterMessageKey);
+    const handle = this.statusReactions.get(inboundOperationKey(inbound.routeId, inbound.adapterMessageKey));
     if (!handle) return;
     if (kind === "success") handle.success();
     else handle.error();
-    this.statusReactions.delete(inbound.adapterMessageKey);
+    this.statusReactions.delete(inboundOperationKey(inbound.routeId, inbound.adapterMessageKey));
   }
 
   private consumeChannelOwner(input: {
@@ -1372,6 +1433,15 @@ export class PenglaiImHost {
     ) {
       return;
     }
+    const route = this.store.findRoute(event.channel, event.accountRef, event.peerRef);
+    const binding = route && this.store.activeBinding(route.routeId);
+    const peer = this.bots.peer(event.channel, event.accountRef, event.peerRef);
+    if (!binding || !peer || peer.bindingRevision !== binding.revision || peer.vendorTarget !== event.vendorTarget || peer.senderId !== event.senderId) {
+      this.bots.observePeer(event);
+      return;
+    }
+    const workspace = this.dsh.listWorkspaces().find((row) => row.id === binding.workspaceIdentity);
+    if (!workspace?.sessionIds.includes(binding.sessionId)) return;
     const receivedAt = event.vendorTime ?? Date.now();
     const routeId = this.plane.ensureRoute({
       adapter: event.channel,
@@ -1384,14 +1454,21 @@ export class PenglaiImHost {
       text: event.text,
       receivedAt,
     });
-    const claim = this.store.claimInboundOperation({
-      operationId: `op:${event.idempotencyKey}`,
-      vendorMessageKey: event.idempotencyKey,
-      routeId,
-    });
+    const vendorMessageKey = event.idempotencyKey;
+    const legacyKey = legacyInboundIdempotencyKey(event.channel, event.accountRef, event.vendorMessageId);
+    const existing =
+      peekInboundOperation(this.store, routeId, vendorMessageKey) ??
+      peekInboundOperation(this.store, routeId, legacyKey);
+    const claim = existing
+      ? { created: false, ...existing }
+      : this.store.claimInboundOperation({
+          operationId: inboundOperationKey(routeId, vendorMessageKey),
+          vendorMessageKey,
+          routeId,
+        });
     if (!claim.created && claim.turnId) return;
     const adapter = this.adapters.get(event.channel);
-    if (adapter) this.startStatusReaction(adapter, event);
+    if (adapter) this.startStatusReaction(adapter, event, routeId);
     try {
       await this.plane.submitInbound({
         adapter: event.channel,
@@ -1406,8 +1483,8 @@ export class PenglaiImHost {
       });
       if (adapter) this.persistAdapterState(event.channel, adapter);
     } catch (error) {
-      this.statusReactions.get(event.idempotencyKey)?.error();
-      this.statusReactions.delete(event.idempotencyKey);
+      this.statusReactions.get(inboundOperationKey(routeId, event.idempotencyKey))?.error();
+      this.statusReactions.delete(inboundOperationKey(routeId, event.idempotencyKey));
       this.recordChannelFailure(event.channel, event.accountRef, error);
     }
   }

--- a/packages/im/src/im.test.ts
+++ b/packages/im/src/im.test.ts
@@ -795,7 +795,7 @@ test("R2I-ROUTE-001 binding requires official workspace/session", async () => {
     dbPath: ":memory:",
     host: {
       version: "0.1.2-rc.1",
-      getAgent: () => undefined,
+      getAgent: () => ({ id: "foreign-session" }) as never,
       listWorkspaces: () => [{ id: "w", title: "W", sessionIds: ["s1"] }],
     },
   });
@@ -812,10 +812,14 @@ test("R2I-ROUTE-001 binding requires official workspace/session", async () => {
     } as never,
     {
       version: "0.1.2-rc.1",
-      getAgent: () => undefined,
+      getAgent: () => ({ id: "foreign-session" }) as never,
       listWorkspaces: () => [{ id: "w", title: "W", sessionIds: ["s1"] }],
     },
   );
+  assert.throws(() => host.createBinding({
+    channel: "weixin", accountId: "a", peerId: "p", workspaceId: "w",
+    sessionId: "foreign-session", ownerActionId: OWNER_BIND,
+  }), /session not in official workspace/);
   assert.throws(
     () =>
       host.createBinding({

--- a/packages/im/src/inbound-envelope.test.ts
+++ b/packages/im/src/inbound-envelope.test.ts
@@ -72,7 +72,7 @@ test("inbound envelope HMAC and idempotency are isolated by channel plus account
   const b = parseInboundEnvelope("slack", { ...base, accountRef: "bot-b" }, hashPeer);
   assert.equal(a.provenPrivate, true);
   assert.equal(a.chatType, "private");
-  assert.equal(a.idempotencyKey, inboundIdempotencyKey("slack", "bot-a", "1"));
+  assert.equal(a.idempotencyKey, inboundIdempotencyKey("slack", "bot-a", "1", "D1"));
   assert.notEqual(a.idempotencyKey, b.idempotencyKey);
   assert.notEqual(a.peerRef, b.peerRef);
   assert.equal(a.peerRef, hashPeer("U1", "bot-a"));
@@ -81,7 +81,7 @@ test("inbound envelope HMAC and idempotency are isolated by channel plus account
     { messageId: "update-1", senderId: "user-1", chatId: "chat-1", chatType: "private", accountRef: "bot-1", text: "hi" },
     hashPeer,
   );
-  assert.equal(telegramOnce.idempotencyKey, inboundIdempotencyKey("telegram", "bot-1", "update-1"));
+  assert.equal(telegramOnce.idempotencyKey, inboundIdempotencyKey("telegram", "bot-1", "update-1", "chat-1"));
   assert.equal(
     parseInboundEnvelope(
       "telegram",
@@ -94,4 +94,27 @@ test("inbound envelope HMAC and idempotency are isolated by channel plus account
     () => parseInboundEnvelope("slack", { ...base, accountRef: "bot-a", thread: "123.4" }, hashPeer),
     (error: unknown) => error instanceof PenglaiError && error.message === "CHAT_SCOPE_UNSUPPORTED",
   );
+});
+
+test("same vendor message ID in different private chats has distinct durable operation identity", async () => {
+  const { inboundOperationKey } = await import("./inbound-envelope.js");
+  const { Store } = await import("@penglai/persistence");
+  const store = new Store(":memory:");
+  for (const routeId of ["chat-a", "chat-b"]) store.upsertRoute({ routeId, adapter: "telegram", accountRef: "bot", peerRef: routeId, status: "active" });
+  const { inboundIdempotencyKey: keyed } = await import("./inbound-envelope.js");
+  const chatA = keyed("telegram", "bot", "1", "chat-a");
+  const chatB = keyed("telegram", "bot", "1", "chat-b");
+  assert.notEqual(chatA, chatB);
+  const vendorMessageKey = "telegram:bot:1";
+  const legacy = store.claimInboundOperation({ operationId: `op:${vendorMessageKey}`, routeId: "chat-a", vendorMessageKey });
+  const replay = store.claimInboundOperation({ operationId: inboundOperationKey("chat-a", vendorMessageKey), routeId: "chat-a", vendorMessageKey });
+  assert.equal(replay.created, false);
+  assert.equal(replay.operationId, legacy.operationId);
+  const migrated = store.claimInboundOperation({ operationId: inboundOperationKey("chat-a", vendorMessageKey), routeId: "chat-a", vendorMessageKey });
+  assert.equal(migrated.created, false);
+  assert.equal(migrated.operationId, legacy.operationId);
+  const other = store.claimInboundOperation({ operationId: inboundOperationKey("chat-b", chatB), routeId: "chat-b", vendorMessageKey: chatB });
+  assert.equal(other.created, true);
+  assert.notEqual(other.operationId, legacy.operationId);
+  store.close();
 });

--- a/packages/im/src/inbound-envelope.ts
+++ b/packages/im/src/inbound-envelope.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { PenglaiError, parseClosedEnum } from "@penglai/contracts";
 import type { InboundChannelEvent } from "./channel-adapter.js";
 import type { ChannelId } from "./registry.js";
@@ -17,8 +18,23 @@ export function isForbiddenDefaultAccount(channel: string, accountRef: string): 
   return accountRef === legacyDefaultAccountId(channel);
 }
 
-export function inboundIdempotencyKey(channel: string, accountRef: string, vendorMessageId: string): string {
+export function inboundIdempotencyKey(
+  channel: string,
+  accountRef: string,
+  vendorMessageId: string,
+  vendorTarget?: string,
+): string {
+  return vendorTarget
+    ? `${channel}:${accountRef}:${vendorTarget}:${vendorMessageId}`
+    : `${channel}:${accountRef}:${vendorMessageId}`;
+}
+
+export function legacyInboundIdempotencyKey(channel: string, accountRef: string, vendorMessageId: string): string {
   return `${channel}:${accountRef}:${vendorMessageId}`;
+}
+
+export function inboundOperationKey(routeId: string, vendorMessageKey: string): string {
+  return `op:v2:${createHash("sha256").update(JSON.stringify([routeId, vendorMessageKey])).digest("hex")}`;
 }
 
 function str(value: unknown): string {
@@ -73,7 +89,7 @@ export function parseInboundEnvelope(
     peerRef: hashPeer(senderId, accountRef),
     chatType: "private",
     provenPrivate: true,
-    idempotencyKey: inboundIdempotencyKey(channel, accountRef, vendorMessageId),
+    idempotencyKey: inboundIdempotencyKey(channel, accountRef, vendorMessageId, vendorTarget),
     ...(vendorTime !== undefined ? { vendorTime } : {}),
     ...(text ? { text } : {}),
   };

--- a/packages/im/src/index.ts
+++ b/packages/im/src/index.ts
@@ -13,7 +13,12 @@ import { CryptoIds, SystemClock } from "./runtime-ids.js";
 import { Store } from "@penglai/persistence";
 import { RoutingControlPlane } from "@penglai/routing-core";
 import { DshBridge, PINNED_DSH, withPenglaiVoiceContext, type DshHost } from "@penglai/dsh-bridge";
-import { hostFromAlpha2Cordis, listenOfficialEvents, type Alpha2CordisLike } from "@penglai/dsh-bridge/plugin";
+import {
+  hostFromAlpha2Cordis,
+  listenOfficialEvents,
+  recoverOfficialDeliveriesFromHost,
+  type Alpha2CordisLike,
+} from "@penglai/dsh-bridge/plugin";
 import { FeishuAdapter } from "@penglai/channel-feishu";
 import { ILinkTransport, WeixinAdapter } from "@penglai/channel-weixin";
 import { DingTalkAdapter } from "@penglai/channel-dingtalk";
@@ -182,6 +187,11 @@ export function apply(ctx: Alpha2CordisLike): ReturnType<typeof createRuntime> &
     if (now - lastInboundRecoveryAt >= 5_000) {
       lastInboundRecoveryAt = now;
       await rt.plane.recoverQueuedInbounds();
+      try {
+        await recoverOfficialDeliveriesFromHost(dsh, rt.plane);
+      } catch (error) {
+        if (!(error instanceof PenglaiError && error.errorClass === "DSH_UNAVAILABLE")) throw error;
+      }
     }
     for (const route of rt.store.listRoutes()) {
       const closed = rt.plane.failClosedMissingTarget(route.routeId);
@@ -217,6 +227,10 @@ export function apply(ctx: Alpha2CordisLike): ReturnType<typeof createRuntime> &
       }
     }
   };
+  host.attachSecretClearer((id) => {
+    const ref = CHANNEL_CREDENTIAL_REFS[id];
+    for (const cache of [dingtalkCreds, wecomCreds, qqCreds, slackCreds, telegramCreds, discordCreds]) delete cache[ref];
+  });
   host.attachSecretHydrator((id, serialized) => {
     const ref = CHANNEL_CREDENTIAL_REFS[id];
     try {
@@ -380,6 +394,7 @@ export {
   CHANNEL_IDS,
   CHANNEL_MANIFESTS,
   CHANNEL_RELEASE_EVIDENCE,
+  CHANNEL_WORKFLOW_CAPABILITIES,
   NATIVE_CHANNEL_IDS,
   getChannelManifest,
   listChannelManifests,

--- a/packages/im/src/official-requests.test.ts
+++ b/packages/im/src/official-requests.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DatabaseSync } from "node:sqlite";
+import { OfficialImRequestStore } from "./official-requests.js";
+
+function store() {
+  const db = new DatabaseSync(":memory:");
+  return { db, requests: new OfficialImRequestStore(db) };
+}
+
+test("official IM requests reject expiry, replay, and a different account or sender", () => {
+  const { requests } = store();
+  const created = requests.create({
+    channel: "weixin",
+    accountId: "acct-a",
+    peerId: "peer-owner",
+    kind: "approval",
+    prompt: "Allow office save?",
+    objectId: "office-job-1",
+    ttlMs: 1_000,
+    cardToken: "card-1",
+    now: 1_000,
+  });
+  assert.equal(created.state, "open");
+  assert.throws(
+    () => requests.answer({
+      requestId: created.requestId,
+      channel: "weixin",
+      accountId: "acct-b",
+      peerId: "peer-owner",
+      text: "yes",
+      cardToken: "card-1",
+      now: 1_100,
+    }),
+    /OFFICIAL_REQUEST_PEER/,
+  );
+  assert.throws(
+    () => requests.answer({
+      requestId: created.requestId,
+      channel: "weixin",
+      accountId: "acct-a",
+      peerId: "attacker",
+      text: "yes",
+      cardToken: "card-1",
+      now: 1_100,
+    }),
+    /OFFICIAL_REQUEST_PEER/,
+  );
+  assert.throws(
+    () => requests.answer({
+      requestId: created.requestId,
+      channel: "weixin",
+      accountId: "acct-a",
+      peerId: "peer-owner",
+      text: "yes",
+      cardToken: "other-card",
+      now: 1_100,
+    }),
+    /OFFICIAL_REQUEST_CARD/,
+  );
+  const answered = requests.answer({
+    requestId: created.requestId,
+    channel: "weixin",
+    accountId: "acct-a",
+    peerId: "peer-owner",
+    text: "yes",
+    cardToken: "card-1",
+    now: 1_100,
+  });
+  assert.equal(answered.state, "answered");
+  assert.throws(
+    () => requests.answer({
+      requestId: created.requestId,
+      channel: "weixin",
+      accountId: "acct-a",
+      peerId: "peer-owner",
+      text: "yes again",
+      cardToken: "card-1",
+      now: 1_200,
+    }),
+    /OFFICIAL_REQUEST_REPLAY/,
+  );
+  const expired = requests.create({
+    channel: "feishu",
+    accountId: "acct-a",
+    peerId: "peer-owner",
+    kind: "question",
+    prompt: "Which file?",
+    objectId: "ask-1",
+    ttlMs: 50,
+    now: 2_000,
+  });
+  assert.throws(
+    () => requests.answer({
+      requestId: expired.requestId,
+      channel: "feishu",
+      accountId: "acct-a",
+      peerId: "peer-owner",
+      text: "notes.docx",
+      now: 2_100,
+    }),
+    /OFFICIAL_REQUEST_EXPIRED/,
+  );
+});
+
+test("inbound text from the bound peer answers the open official request and is not a DSH turn", () => {
+  const { requests } = store();
+  const created = requests.create({
+    channel: "weixin",
+    accountId: "acct-a",
+    peerId: "peer-owner",
+    kind: "question",
+    prompt: "Confirm?",
+    objectId: "ask-2",
+    now: 5_000,
+  });
+  const reply = requests.tryAnswerFromInbound({
+    channel: "weixin",
+    accountId: "acct-a",
+    peerId: "peer-owner",
+    text: "confirmed",
+    now: 5_100,
+  });
+  assert.match(String(reply), new RegExp(created.requestId));
+  assert.equal(requests.get(created.requestId)?.state, "answered");
+  assert.equal(
+    requests.tryAnswerFromInbound({
+      channel: "weixin",
+      accountId: "acct-a",
+      peerId: "stranger",
+      text: "confirmed",
+      now: 5_200,
+    }),
+    undefined,
+  );
+});

--- a/packages/im/src/official-requests.ts
+++ b/packages/im/src/official-requests.ts
@@ -1,0 +1,161 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+import { PenglaiError } from "@penglai/contracts";
+
+export const OFFICIAL_REQUEST_KINDS = ["question", "approval"] as const;
+export type OfficialRequestKind = (typeof OFFICIAL_REQUEST_KINDS)[number];
+export const OFFICIAL_REQUEST_STATES = ["open", "answered", "expired", "cancelled"] as const;
+export type OfficialRequestState = (typeof OFFICIAL_REQUEST_STATES)[number];
+
+export interface OfficialImRequest {
+  requestId: string;
+  channel: string;
+  accountId: string;
+  peerId: string;
+  kind: OfficialRequestKind;
+  prompt: string;
+  objectId: string;
+  cardToken?: string;
+  expiresAt: number;
+  state: OfficialRequestState;
+  answer?: string;
+}
+
+const SQL = `
+  CREATE TABLE IF NOT EXISTS im_official_requests (
+    request_id TEXT PRIMARY KEY,
+    channel TEXT NOT NULL,
+    account_id TEXT NOT NULL,
+    peer_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    prompt TEXT NOT NULL,
+    object_id TEXT NOT NULL,
+    card_token TEXT,
+    expires_at INTEGER NOT NULL,
+    state TEXT NOT NULL,
+    answer TEXT,
+    created_at INTEGER NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS im_official_requests_peer ON im_official_requests(channel, account_id, peer_id, state);
+`;
+
+export class OfficialImRequestStore {
+  constructor(private readonly db: DatabaseSync) {
+    this.db.exec(SQL);
+  }
+
+  create(input: {
+    channel: string;
+    accountId: string;
+    peerId: string;
+    kind: OfficialRequestKind;
+    prompt: string;
+    objectId: string;
+    ttlMs?: number;
+    cardToken?: string;
+    now?: number;
+  }): OfficialImRequest {
+    if (!OFFICIAL_REQUEST_KINDS.includes(input.kind)) throw new PenglaiError("INVALID_INPUT", "OFFICIAL_REQUEST_KIND");
+    if (!input.channel || !input.accountId || !input.peerId || !input.objectId) {
+      throw new PenglaiError("INVALID_INPUT", "OFFICIAL_REQUEST_IDENTITY");
+    }
+    const now = input.now ?? Date.now();
+    const ttl = input.ttlMs ?? 15 * 60_000;
+    const row: OfficialImRequest = {
+      requestId: `req:${randomUUID()}`,
+      channel: input.channel,
+      accountId: input.accountId,
+      peerId: input.peerId,
+      kind: input.kind,
+      prompt: input.prompt.slice(0, 4000),
+      objectId: input.objectId,
+      expiresAt: now + ttl,
+      state: "open",
+      ...(input.cardToken ? { cardToken: input.cardToken } : {}),
+    };
+    this.db.prepare(
+      `INSERT INTO im_official_requests(request_id, channel, account_id, peer_id, kind, prompt, object_id, card_token, expires_at, state, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(row.requestId, row.channel, row.accountId, row.peerId, row.kind, row.prompt, row.objectId, row.cardToken ?? null, row.expiresAt, row.state, now);
+    return row;
+  }
+
+  get(requestId: string): OfficialImRequest | undefined {
+    const raw = this.db.prepare(`SELECT * FROM im_official_requests WHERE request_id = ?`).get(requestId) as Record<string, string | number | null> | undefined;
+    return raw ? this.map(raw) : undefined;
+  }
+
+  answer(input: {
+    requestId: string;
+    channel: string;
+    accountId: string;
+    peerId: string;
+    text: string;
+    cardToken?: string;
+    now?: number;
+  }): OfficialImRequest {
+    const row = this.get(input.requestId);
+    if (!row) throw new PenglaiError("INVALID_INPUT", "OFFICIAL_REQUEST_MISSING");
+    const now = input.now ?? Date.now();
+    if (row.state === "answered") throw new PenglaiError("SECURITY_POLICY", "OFFICIAL_REQUEST_REPLAY");
+    if (row.state !== "open") throw new PenglaiError("SECURITY_POLICY", "OFFICIAL_REQUEST_CLOSED");
+    if (row.expiresAt <= now) {
+      this.db.prepare(`UPDATE im_official_requests SET state = 'expired' WHERE request_id = ? AND state = 'open'`).run(row.requestId);
+      throw new PenglaiError("SECURITY_POLICY", "OFFICIAL_REQUEST_EXPIRED");
+    }
+    if (row.channel !== input.channel || row.accountId !== input.accountId || row.peerId !== input.peerId) {
+      throw new PenglaiError("UNAUTHORIZED", "OFFICIAL_REQUEST_PEER");
+    }
+    if (row.cardToken && row.cardToken !== input.cardToken) {
+      throw new PenglaiError("UNAUTHORIZED", "OFFICIAL_REQUEST_CARD");
+    }
+    const answer = input.text.trim().slice(0, 4000);
+    if (!answer) throw new PenglaiError("INVALID_INPUT", "OFFICIAL_REQUEST_EMPTY");
+    this.db.prepare(`UPDATE im_official_requests SET state = 'answered', answer = ? WHERE request_id = ? AND state = 'open'`).run(answer, row.requestId);
+    return { ...row, state: "answered", answer };
+  }
+
+  tryAnswerFromInbound(input: { channel: string; accountId: string; peerId: string; text: string; now?: number }): string | undefined {
+    const now = input.now ?? Date.now();
+    this.db.prepare(`UPDATE im_official_requests SET state = 'expired' WHERE state = 'open' AND expires_at <= ?`).run(now);
+    const open = this.db.prepare(
+      `SELECT * FROM im_official_requests WHERE channel = ? AND account_id = ? AND peer_id = ? AND state = 'open' ORDER BY created_at DESC LIMIT 1`,
+    ).get(input.channel, input.accountId, input.peerId) as Record<string, string | number | null> | undefined;
+    if (!open) return undefined;
+    const row = this.map(open);
+    try {
+      const answered = this.answer({
+        requestId: row.requestId,
+        channel: input.channel,
+        accountId: input.accountId,
+        peerId: input.peerId,
+        text: input.text,
+        ...(row.cardToken ? { cardToken: row.cardToken } : {}),
+        now,
+      });
+      return `official-${answered.kind}-answered:${answered.requestId}`;
+    } catch {
+      return undefined;
+    }
+  }
+
+  requestDigest(row: OfficialImRequest): string {
+    return createHash("sha256").update(JSON.stringify([row.requestId, row.channel, row.accountId, row.peerId, row.objectId, row.kind])).digest("hex");
+  }
+
+  private map(raw: Record<string, string | number | null>): OfficialImRequest {
+    return {
+      requestId: String(raw.request_id),
+      channel: String(raw.channel),
+      accountId: String(raw.account_id),
+      peerId: String(raw.peer_id),
+      kind: raw.kind as OfficialRequestKind,
+      prompt: String(raw.prompt),
+      objectId: String(raw.object_id),
+      expiresAt: Number(raw.expires_at),
+      state: raw.state as OfficialRequestState,
+      ...(raw.card_token ? { cardToken: String(raw.card_token) } : {}),
+      ...(raw.answer ? { answer: String(raw.answer) } : {}),
+    };
+  }
+}

--- a/packages/im/src/peer-authorization.test.ts
+++ b/packages/im/src/peer-authorization.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { OwnerApprovalBroker } from "@penglai/runtime";
+import { createRuntime } from "./index.js";
+import { PenglaiImHost } from "./host.js";
+import { CredentialsServiceVault } from "./credentials-vault.js";
+import { guidedAdapter, type InboundChannelEvent } from "./channel-adapter.js";
+
+for (const channel of ["dingtalk", "wecom", "qq", "slack", "telegram", "discord"] as const) {
+  test(`${channel}: private transport alone never authorizes a sender; exact Owner binding does`, async () => {
+    const dsh = { version: "0.1.2-rc.1", getAgent: () => undefined, listWorkspaces: () => [{ id: "w", title: "W", sessionIds: ["s"] }] };
+    const rt = createRuntime({ dbPath: ":memory:", host: dsh });
+    const host = new PenglaiImHost(rt.store, rt.plane,
+      { health: () => ({ authState: "idle", hasCredential: false }) } as never,
+      { status: "idle", setupRequired: true } as never,
+      new CredentialsServiceVault(undefined), {} as never, dsh);
+    const owner = new OwnerApprovalBroker(mkdtempSync(join(tmpdir(), "penglai-peer-owner-")), { dialog: async () => "approved" });
+    host.attachOwner(owner);
+    let receive!: (event: InboundChannelEvent) => void | Promise<void>;
+    host.attachChannelAdapter({ ...guidedAdapter(channel), onInbound: (callback) => { receive = callback; } });
+    let submissions = 0;
+    rt.plane.submitInbound = async () => { submissions++; return { kind: "accepted", text: "queued" }; };
+    const event: InboundChannelEvent = {
+      channel, botId: "account-a", accountRef: "account-a", senderId: "owner-user", peerRef: "owner-hash",
+      vendorTarget: "private-chat", vendorMessageId: "1", idempotencyKey: `${channel}:account-a:1`,
+      chatType: "private", provenPrivate: true, text: "private message",
+    };
+    await receive(event);
+    assert.equal(submissions, 0);
+    assert.equal(rt.store.listRoutes().length, 0);
+    assert.equal(host.listBindableRoutes().length, 1);
+    const proposal = host.proposeBinding({ action: "im.bind", objectId: `${channel}:account-a:owner-hash`, workspaceId: "w", sessionId: "s" });
+    const decision = await owner.requestOwnerApproval(proposal.actionId);
+    if (decision.decision !== "approved") throw new Error("expected approval");
+    host.createBinding({ channel, accountId: "account-a", peerId: "owner-hash", workspaceId: "w", sessionId: "s", ownerActionId: proposal.actionId, receipt: decision.receipt });
+    await receive(event);
+    assert.equal(submissions, 1);
+    for (const changed of [{ accountRef: "account-b" }, { peerRef: "attacker-hash", senderId: "attacker" }, { vendorTarget: "other-chat" }]) {
+      await receive({ ...event, ...changed, vendorMessageId: "2", idempotencyKey: `${channel}:different:2` });
+      assert.equal(submissions, 1);
+    }
+    const binding = rt.store.listActiveBindings()[0]!;
+    rt.store.revokeBinding(binding.routeId, new Date().toISOString());
+    await receive({ ...event, vendorMessageId: "3", idempotencyKey: `${channel}:account-a:3` });
+    assert.equal(submissions, 1);
+    rt.store.close();
+  });
+}

--- a/packages/im/src/registry.test.ts
+++ b/packages/im/src/registry.test.ts
@@ -5,7 +5,13 @@ import { join } from "node:path";
 import test from "node:test";
 import { beginGuidedConnection } from "./guided.js";
 import { ImBotStore } from "./bots.js";
-import { CHANNEL_IDS, CHANNEL_MANIFESTS, NATIVE_CHANNEL_IDS, refuseFakeQr } from "./registry.js";
+import {
+  CHANNEL_IDS,
+  CHANNEL_MANIFESTS,
+  CHANNEL_WORKFLOW_CAPABILITIES,
+  NATIVE_CHANNEL_IDS,
+  refuseFakeQr,
+} from "./registry.js";
 import { OwnerApprovalBroker } from "@penglai/runtime";
 import { createRuntime } from "./index.js";
 import { CredentialsServiceVault } from "./credentials-vault.js";
@@ -43,6 +49,25 @@ test("R58-IM-001 registry lists exactly eight supported connectors", () => {
   assert.equal(CHANNEL_MANIFESTS.dingtalk.connectionMethods.includes("qr"), true);
   assert.equal(CHANNEL_MANIFESTS.wecom.connectionMethods.includes("qr"), true);
   assert.equal(CHANNEL_MANIFESTS.qq.connectionMethods.includes("qr"), true);
+  for (const row of Object.values(CHANNEL_MANIFESTS)) {
+    for (const capability of CHANNEL_WORKFLOW_CAPABILITIES) {
+      assert.equal(typeof row.capabilityEvidence[capability], "string", `${row.id}.${capability}`);
+    }
+    assert.ok(row.connectionHint.en.length > 0);
+    assert.ok(row.connectionHint.zh.length > 0);
+  }
+  assert.equal(CHANNEL_MANIFESTS.weixin.capabilityEvidence.question, "source-tested");
+  assert.equal(CHANNEL_MANIFESTS.weixin.capabilityEvidence.approval, "source-tested");
+  assert.equal(CHANNEL_MANIFESTS.weixin.capabilityEvidence.recovery, "source-tested");
+  assert.equal(CHANNEL_MANIFESTS.feishu.capabilityEvidence.question, "source-tested");
+  assert.equal(CHANNEL_MANIFESTS.feishu.capabilityEvidence.file, "source-tested");
+  assert.equal(CHANNEL_MANIFESTS.telegram.capabilityEvidence.recovery, "source-tested");
+  assert.equal(CHANNEL_MANIFESTS.telegram.capabilityEvidence.question, "not-supported");
+  assert.equal(CHANNEL_MANIFESTS.slack.capabilityEvidence.approval, "not-supported");
+  assert.match(CHANNEL_MANIFESTS.slack.connectionHint.en, /no QR shortcut/i);
+  const ui = readFileSync(new URL("./dsh-client.js", import.meta.url), "utf8");
+  assert.match(ui, /data-penglai-im-connection-hint/);
+  assert.match(ui, /question: "question"/);
 });
 
 test("unsupported legacy bot rows stay stored but cannot re-enter the active registry", () => {
@@ -191,6 +216,10 @@ test("R56-IM-007 sidecar bots do not bump the v11 IM schema or get misread as We
     assert.equal(state.runtimeBundled, true);
     assert.equal(state.releaseEvidence, "source-only");
     assert.equal(typeof state.capabilityEvidence.authentication, "string");
+    assert.equal(typeof state.capabilityEvidence.question, "string");
+    assert.equal(typeof state.capabilityEvidence.approval, "string");
+    assert.equal(typeof state.capabilityEvidence.recovery, "string");
+    assert.ok(state.connectionHint.en.length > 0);
   }
   assert.equal(rt.store.schemaVersion(), 12);
   assert.equal(host.listBindings().some((row) => row.channel === "weixin" && row.accountId === "docs"), false);
@@ -203,7 +232,7 @@ test("R56-IM-007 sidecar bots do not bump the v11 IM schema or get misread as We
         workspaceId: "w",
         sessionId: "s1",
       }),
-    /CHANNEL_BINDING_UNAVAILABLE/,
+    /IM_PEER_APPROVAL_REQUIRED/,
   );
   rt.store.close();
 });

--- a/packages/im/src/registry.ts
+++ b/packages/im/src/registry.ts
@@ -22,11 +22,31 @@ export const CHANNEL_RELEASE_EVIDENCE = ["source-only", "installed", "owner-live
 export type ChannelReleaseEvidence = (typeof CHANNEL_RELEASE_EVIDENCE)[number];
 export const CHANNEL_CAPABILITY_EVIDENCE = ["source-tested", "not-proven", "not-supported"] as const;
 export type ChannelCapabilityEvidenceLevel = (typeof CHANNEL_CAPABILITY_EVIDENCE)[number];
+export const CHANNEL_WORKFLOW_CAPABILITIES = [
+  "authentication",
+  "inboundText",
+  "outboundText",
+  "file",
+  "voice",
+  "question",
+  "approval",
+  "recovery",
+  "image",
+  "audio",
+  "reconnect",
+  "exit",
+] as const;
+export type ChannelWorkflowCapability = (typeof CHANNEL_WORKFLOW_CAPABILITIES)[number];
 
 export interface ChannelCapabilityEvidence {
   authentication: ChannelCapabilityEvidenceLevel;
   inboundText: ChannelCapabilityEvidenceLevel;
   outboundText: ChannelCapabilityEvidenceLevel;
+  file: ChannelCapabilityEvidenceLevel;
+  voice: ChannelCapabilityEvidenceLevel;
+  question: ChannelCapabilityEvidenceLevel;
+  approval: ChannelCapabilityEvidenceLevel;
+  recovery: ChannelCapabilityEvidenceLevel;
   image: ChannelCapabilityEvidenceLevel;
   audio: ChannelCapabilityEvidenceLevel;
   reconnect: ChannelCapabilityEvidenceLevel;
@@ -42,6 +62,7 @@ export interface ChannelManifestV1 {
   readonly runtimeBundled: true;
   readonly releaseEvidence: ChannelReleaseEvidence;
   readonly capabilityEvidence: Readonly<ChannelCapabilityEvidence>;
+  readonly connectionHint: { readonly en: string; readonly zh: string };
   readonly limits: { readonly textChars: number; readonly fileBytes: number; readonly requestsPerMinute: number };
   readonly defaultEnabled: boolean;
   readonly docsUrl: string;
@@ -51,6 +72,11 @@ const SOURCE_TEXT: ChannelCapabilityEvidence = {
   authentication: "source-tested",
   inboundText: "source-tested",
   outboundText: "source-tested",
+  file: "not-supported",
+  voice: "not-supported",
+  question: "not-supported",
+  approval: "not-supported",
+  recovery: "not-proven",
   image: "not-supported",
   audio: "not-supported",
   reconnect: "not-proven",
@@ -59,6 +85,8 @@ const SOURCE_TEXT: ChannelCapabilityEvidence = {
 
 const SOURCE_MEDIA: ChannelCapabilityEvidence = {
   ...SOURCE_TEXT,
+  file: "source-tested",
+  voice: "source-tested",
   image: "source-tested",
   audio: "source-tested",
 };
@@ -66,16 +94,25 @@ const SOURCE_MEDIA: ChannelCapabilityEvidence = {
 function manifest(row: ChannelManifestV1): ChannelManifestV1 {
   parseClosedEnum(row.adapterMode, CHANNEL_ADAPTER_MODES, "CHANNEL_ADAPTER_MODE", "SECURITY_POLICY");
   parseClosedEnum(row.releaseEvidence, CHANNEL_RELEASE_EVIDENCE, "CHANNEL_RELEASE_EVIDENCE", "SECURITY_POLICY");
-  for (const [capability, evidence] of Object.entries(row.capabilityEvidence)) {
-    parseClosedEnum(evidence, CHANNEL_CAPABILITY_EVIDENCE, `CHANNEL_CAPABILITY_${capability}`, "SECURITY_POLICY");
+  for (const capability of CHANNEL_WORKFLOW_CAPABILITIES) {
+    parseClosedEnum(
+      row.capabilityEvidence[capability],
+      CHANNEL_CAPABILITY_EVIDENCE,
+      `CHANNEL_CAPABILITY_${capability}`,
+      "SECURITY_POLICY",
+    );
   }
   const expectedMode = (NATIVE_CHANNEL_IDS as readonly string[]).includes(row.id) ? "native" : "bundled-sidecar";
   if (row.adapterMode !== expectedMode) throw new PenglaiError("SECURITY_POLICY", "CHANNEL_ADAPTER_MODE_MISMATCH");
+  if (!row.connectionHint.en.trim() || !row.connectionHint.zh.trim()) {
+    throw new PenglaiError("SECURITY_POLICY", "CHANNEL_CONNECTION_HINT");
+  }
   return Object.freeze({
     ...row,
     displayName: Object.freeze({ ...row.displayName }),
     connectionMethods: Object.freeze([...row.connectionMethods]),
     capabilityEvidence: Object.freeze({ ...row.capabilityEvidence }),
+    connectionHint: Object.freeze({ ...row.connectionHint }),
     limits: Object.freeze({ ...row.limits }),
   });
 }
@@ -89,7 +126,17 @@ export const CHANNEL_MANIFESTS: Record<ChannelId, ChannelManifestV1> = {
     adapterMode: "native",
     runtimeBundled: true,
     releaseEvidence: "source-only",
-    capabilityEvidence: { ...SOURCE_MEDIA, exit: "source-tested" },
+    capabilityEvidence: {
+      ...SOURCE_MEDIA,
+      question: "source-tested",
+      approval: "source-tested",
+      recovery: "source-tested",
+      exit: "source-tested",
+    },
+    connectionHint: {
+      en: "Scan the official Weixin QR. Unknown senders do not consume the receive cursor. Questions and approvals are official durable requests, not generic chat consent.",
+      zh: "扫描官方微信二维码。未知发送者不会推进接收游标。提问和审批是官方持久请求，不是普通聊天同意。",
+    },
     limits: { textChars: 4000, fileBytes: 8 * 1024 * 1024, requestsPerMinute: 20 },
     defaultEnabled: false,
     docsUrl: "https://developers.weixin.qq.com/",
@@ -102,7 +149,16 @@ export const CHANNEL_MANIFESTS: Record<ChannelId, ChannelManifestV1> = {
     adapterMode: "native",
     runtimeBundled: true,
     releaseEvidence: "source-only",
-    capabilityEvidence: SOURCE_MEDIA,
+    capabilityEvidence: {
+      ...SOURCE_MEDIA,
+      question: "source-tested",
+      approval: "source-tested",
+      recovery: "source-tested",
+    },
+    connectionHint: {
+      en: "Create the Feishu app, then scan or paste official credentials. Card replies must match the exact request identity and expire; replayed or foreign-account cards are rejected.",
+      zh: "创建飞书应用，然后扫码或粘贴官方凭据。卡片回复必须匹配精确请求身份并会过期；重放或他号卡片会被拒绝。",
+    },
     limits: { textChars: 8000, fileBytes: 8 * 1024 * 1024, requestsPerMinute: 20 },
     defaultEnabled: false,
     docsUrl: "https://open.feishu.cn/app",
@@ -116,6 +172,10 @@ export const CHANNEL_MANIFESTS: Record<ChannelId, ChannelManifestV1> = {
     runtimeBundled: true,
     releaseEvidence: "source-only",
     capabilityEvidence: SOURCE_TEXT,
+    connectionHint: {
+      en: "Scan the official DingTalk device QR, or paste Client ID and Secret into Vault. Official questions and approvals are not supported on this channel.",
+      zh: "扫描官方钉钉设备二维码，或把 Client ID 和 Secret 写入保险库。此通道不支持官方提问和审批。",
+    },
     limits: { textChars: 4000, fileBytes: 8 * 1024 * 1024, requestsPerMinute: 20 },
     defaultEnabled: false,
     docsUrl: "https://open.dingtalk.com/",
@@ -129,6 +189,10 @@ export const CHANNEL_MANIFESTS: Record<ChannelId, ChannelManifestV1> = {
     runtimeBundled: true,
     releaseEvidence: "source-only",
     capabilityEvidence: { ...SOURCE_TEXT, inboundText: "not-proven" },
+    connectionHint: {
+      en: "Scan the official WeCom intelligent-bot QR, or paste Bot ID and Secret. Inbound text is not yet proven; questions and approvals are not supported.",
+      zh: "扫描官方企业微信智能机器人二维码，或粘贴 Bot ID 和 Secret。入站文本尚未取证；不支持提问和审批。",
+    },
     limits: { textChars: 4000, fileBytes: 8 * 1024 * 1024, requestsPerMinute: 20 },
     defaultEnabled: false,
     docsUrl: "https://developer.work.weixin.qq.com/",
@@ -142,6 +206,10 @@ export const CHANNEL_MANIFESTS: Record<ChannelId, ChannelManifestV1> = {
     runtimeBundled: true,
     releaseEvidence: "source-only",
     capabilityEvidence: { ...SOURCE_TEXT, inboundText: "not-proven" },
+    connectionHint: {
+      en: "Scan with mobile QQ to create an official bot. Do not simulate a personal QQ login. Questions and approvals are not supported.",
+      zh: "用手机 QQ 扫码创建官方机器人。不要模拟个人号登录。不支持提问和审批。",
+    },
     limits: { textChars: 4000, fileBytes: 8 * 1024 * 1024, requestsPerMinute: 20 },
     defaultEnabled: false,
     docsUrl: "https://bot.q.qq.com/",
@@ -155,6 +223,10 @@ export const CHANNEL_MANIFESTS: Record<ChannelId, ChannelManifestV1> = {
     runtimeBundled: true,
     releaseEvidence: "source-only",
     capabilityEvidence: { ...SOURCE_TEXT, reconnect: "source-tested" },
+    connectionHint: {
+      en: "There is no QR shortcut. Create a Slack app from the official manifest, install with OAuth, and paste the bot token into Vault.",
+      zh: "没有二维码捷径。用官方 Manifest 创建 Slack 应用，通过 OAuth 安装，并把 Bot Token 写入保险库。",
+    },
     limits: { textChars: 4000, fileBytes: 8 * 1024 * 1024, requestsPerMinute: 20 },
     defaultEnabled: false,
     docsUrl: "https://api.slack.com/authentication/oauth-v2",
@@ -167,7 +239,11 @@ export const CHANNEL_MANIFESTS: Record<ChannelId, ChannelManifestV1> = {
     adapterMode: "bundled-sidecar",
     runtimeBundled: true,
     releaseEvidence: "source-only",
-    capabilityEvidence: SOURCE_TEXT,
+    capabilityEvidence: { ...SOURCE_TEXT, recovery: "source-tested" },
+    connectionHint: {
+      en: "Talk to BotFather, copy the HTTP API token once, and paste it into Vault. Operation keys include chat identity so the same vendor id in another chat is a different request. Questions and approvals are not supported.",
+      zh: "在 BotFather 创建机器人，复制一次 HTTP API Token 并写入保险库。操作键包含会话身份，另一聊天中的相同厂商 ID 是不同请求。不支持提问和审批。",
+    },
     limits: { textChars: 4000, fileBytes: 8 * 1024 * 1024, requestsPerMinute: 20 },
     defaultEnabled: false,
     docsUrl: "https://core.telegram.org/bots/tutorial",
@@ -181,6 +257,10 @@ export const CHANNEL_MANIFESTS: Record<ChannelId, ChannelManifestV1> = {
     runtimeBundled: true,
     releaseEvidence: "source-only",
     capabilityEvidence: { ...SOURCE_TEXT, outboundText: "not-proven", exit: "source-tested" },
+    connectionHint: {
+      en: "There is no QR shortcut. Create a bot with the minimum intents in the Discord Developer Portal and paste the token into Vault. Outbound text is not yet proven.",
+      zh: "没有二维码捷径。在 Discord Developer Portal 用最小 intents 创建 Bot，并把 Token 写入保险库。出站文本尚未取证。",
+    },
     limits: { textChars: 2000, fileBytes: 8 * 1024 * 1024, requestsPerMinute: 20 },
     defaultEnabled: false,
     docsUrl: "https://discord.com/developers/docs/quick-start/getting-started",

--- a/packages/memory/src/dsh-client.js
+++ b/packages/memory/src/dsh-client.js
@@ -74,6 +74,7 @@ window.__ModuleLoader__.load({
     const REMOTE = {
       package: "@penglai/memory",
       descriptors: [
+        "queryLibrary",
         "status",
         "write",
         "deleteScope",
@@ -136,6 +137,11 @@ window.__ModuleLoader__.load({
         importConfirm: "导入检查过的旧版记忆",
         sources: "记忆来源",
         sourcesHint: "可选：授权本地资料，让蓬莱在对应范围内建立只读索引。",
+        library: "记忆库",
+        librarySearch: "搜索记忆",
+        libraryEmpty: "没有匹配的记忆。",
+        libraryMore: "下一页",
+        libraryProvenance: "来源",
       },
       en: {
         title: "Penglai Memory",
@@ -176,6 +182,11 @@ window.__ModuleLoader__.load({
         importConfirm: "Import legacy memory",
         sources: "Memory sources",
         sourcesHint: "Optional: authorize local material for read-only indexing in the selected scope.",
+        library: "Memory library",
+        librarySearch: "Search memory",
+        libraryEmpty: "No matching memories.",
+        libraryMore: "Next page",
+        libraryProvenance: "Source",
       },
     };
     const copy = () =>
@@ -225,6 +236,10 @@ window.__ModuleLoader__.load({
         correctText: "",
         importNote: "",
         skillConfirmed: false,
+        libraryQuery: "",
+        libraryRows: [],
+        libraryTotal: 0,
+        libraryOffset: 0,
       });
       const refresh = React.useCallback(() => {
         const expectedGeneration = generationRef.current;
@@ -259,6 +274,35 @@ window.__ModuleLoader__.load({
       React.useEffect(() => {
         refresh();
       }, [refresh, connectionGeneration]);
+      const refreshLibrary = React.useCallback(() => {
+        const expectedGeneration = generationRef.current;
+        if (expectedGeneration === undefined || !api?.queryLibrary) return;
+        Promise.resolve(
+          api.queryLibrary({
+            q: v.libraryQuery,
+            scope: v.scope === "workspace" ? "workspace" : v.scope === "global" ? "personal" : undefined,
+            ...(v.workspaceId ? { workspaceId: v.workspaceId } : {}),
+            limit: 20,
+            offset: v.libraryOffset,
+          }),
+        )
+          .then((raw) => {
+            if (generationRef.current !== expectedGeneration) return;
+            const x = unwrap(raw) || {};
+            set((s) => ({
+              ...s,
+              libraryRows: x.rows || [],
+              libraryTotal: x.total || 0,
+            }));
+          })
+          .catch(() => {
+            if (generationRef.current !== expectedGeneration) return;
+            set((s) => ({ ...s, libraryRows: [], libraryTotal: 0 }));
+          });
+      }, [api, v.libraryQuery, v.libraryOffset, v.scope, v.workspaceId]);
+      React.useEffect(() => {
+        refreshLibrary();
+      }, [refreshLibrary, connectionGeneration]);
       const run = (method, input, done) => {
         set((x) => ({ ...x, busy: true, error: "", notice: "" }));
         return Promise.resolve(api[method](input))
@@ -413,6 +457,42 @@ window.__ModuleLoader__.load({
                 ),
               })
             : null,
+          jsx.jsxs("section", {
+            "data-penglai-memory-library": "1",
+            children: [
+              jsx.jsx("h3", { children: t.library }),
+              jsx.jsx("input", {
+                "data-penglai-memory-library-search": "1",
+                value: v.libraryQuery,
+                placeholder: t.librarySearch,
+                onChange: (e) => set((x) => ({ ...x, libraryQuery: String(e.target.value), libraryOffset: 0 })),
+              }),
+              jsx.jsx("ul", {
+                children: v.libraryRows.length
+                  ? v.libraryRows.map((r) =>
+                      jsx.jsxs("li", {
+                        "data-penglai-memory-library-row": String(r.id),
+                        children: [
+                          String(r.content || r.text || r.id),
+                          jsx.jsx("small", {
+                            style: { display: "block", opacity: 0.75 },
+                            children: `${t.libraryProvenance}: ${String(r.source || "")} · ${String(r.createdAt || "")} · ${String(r.status || "")}`,
+                          }),
+                        ],
+                      }, String(r.id)),
+                    )
+                  : jsx.jsx("li", { children: t.libraryEmpty }),
+              }),
+              v.libraryOffset + 20 < v.libraryTotal
+                ? jsx.jsx("button", {
+                    type: "button",
+                    "data-penglai-memory-library-more": "1",
+                    onClick: () => set((x) => ({ ...x, libraryOffset: x.libraryOffset + 20 })),
+                    children: t.libraryMore,
+                  })
+                : null,
+            ],
+          }),
           jsx.jsx("ul", {
             children: v.rows.length
               ? v.rows.map((r) =>

--- a/packages/memory/src/engine/journal.ts
+++ b/packages/memory/src/engine/journal.ts
@@ -94,6 +94,38 @@ export class MemoryJournal {
     return rows.slice(Math.max(0, offset), Math.max(0, offset) + Math.min(200, Math.max(1, limit)));
   }
 
+  queryLibrary(input: {
+    q?: string;
+    scope?: "personal" | "workspace";
+    workspaceId?: string;
+    includeForgotten?: boolean;
+    limit?: number;
+    offset?: number;
+  }): { total: number; offset: number; limit: number; rows: JournalRow[] } {
+    const limit = Math.min(200, Math.max(1, input.limit ?? 50));
+    const offset = Math.max(0, input.offset ?? 0);
+    const needle = (input.q ?? "").trim().toLowerCase();
+    const statuses = input.includeForgotten ? ["committed", "forgotten", "superseded"] : ["committed"];
+    let sql = `SELECT * FROM memory_journal WHERE status IN (${statuses.map(() => "?").join(",")})`;
+    const params: Array<string | number> = [...statuses];
+    if (input.scope) {
+      sql += ` AND scope = ?`;
+      params.push(input.scope);
+      if (input.scope === "workspace") {
+        sql += ` AND workspace_id = ?`;
+        params.push(input.workspaceId ?? "");
+      }
+    } else if (input.workspaceId) {
+      sql += ` AND ((scope = 'workspace' AND workspace_id = ?) OR scope = 'personal')`;
+      params.push(input.workspaceId);
+    }
+    const all = (this.db.prepare(sql).all(...params) as Record<string, string | null>[])
+      .map((row) => this.map(row))
+      .filter((row) => !needle || row.content.toLowerCase().includes(needle) || row.source.toLowerCase().includes(needle) || row.tags.toLowerCase().includes(needle))
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+    return { total: all.length, offset, limit, rows: all.slice(offset, offset + limit) };
+  }
+
   listActive(scope: "personal" | "workspace", workspaceId?: string): JournalRow[] {
     if (scope === "personal") {
       return (this.db.prepare("SELECT * FROM memory_journal WHERE scope = 'personal' AND status = 'committed'").all() as Record<string, string | null>[]).map((row) => this.map(row));

--- a/packages/memory/src/engine/service.test.ts
+++ b/packages/memory/src/engine/service.test.ts
@@ -35,6 +35,22 @@ test("mnemon service remembers, isolates workspaces, and forgets", async () => {
   memory.close();
 });
 
+test("memory library query paginates, searches, and stays inside one Workspace", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "penglai-mnemon-lib-"));
+  const memory = new MnemonMemoryService(dir, { binaryPath, allowUnpinnedTestBinary: true });
+  await memory.remember({ text: "alpha fact about Penglai", workspaceId: "ws-a", tags: "project", source: "turn:1" });
+  await memory.remember({ text: "beta secret in B", workspaceId: "ws-b", tags: "project", source: "turn:2" });
+  await memory.remember({ text: "personal preference", source: "user" });
+  const page = memory.queryLibrary({ q: "Penglai", scope: "workspace", workspaceId: "ws-a", limit: 10, offset: 0 });
+  assert.equal(page.total, 1);
+  assert.equal(page.rows[0]?.content.includes("Penglai"), true);
+  assert.equal(page.rows[0]?.workspaceId, "ws-a");
+  const other = memory.queryLibrary({ q: "Penglai", scope: "workspace", workspaceId: "ws-b", limit: 10, offset: 0 });
+  assert.equal(other.total, 0);
+  assert.throws(() => memory.queryLibrary({ scope: "workspace" }), /official Workspace/);
+  memory.close();
+});
+
 test("production service rejects an explicit unpinned Mnemon executable", () => {
   assert.throws(
     () => new MnemonMemoryService(mkdtempSync(join(tmpdir(), "penglai-mnemon-pin-")), { binaryPath }),

--- a/packages/memory/src/engine/service.ts
+++ b/packages/memory/src/engine/service.ts
@@ -196,6 +196,20 @@ export class MnemonMemoryService {
     };
   }
 
+  queryLibrary(input: {
+    q?: string;
+    scope?: "personal" | "workspace";
+    workspaceId?: string;
+    includeForgotten?: boolean;
+    limit?: number;
+    offset?: number;
+  }) {
+    if (input.scope === "workspace" && !input.workspaceId) {
+      throw new PenglaiError("UNAUTHORIZED", "memory library requires the current official Workspace");
+    }
+    return this.journal.queryLibrary(input);
+  }
+
   async export(workspaceId?: string, includePersonal = false) {
     this.requireEnabled();
     const workspaceRows = workspaceId ? this.journal.listActive("workspace", workspaceId) : [];

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -362,6 +362,10 @@ export function createDurableMemoryService(opts: {
       if (!input.receipt) throw new PenglaiError("SECURITY_POLICY", "memory broker receipt required");
       const hit = v2.getCandidate(input.candidateId);
       if (!hit || hit.status !== "pending") throw new PenglaiError("INVALID_INPUT", "MEMORY_CANDIDATE_MISSING");
+      v2.validateDecision(input.candidateId, "accepted", {
+        actionId: input.actionId,
+        ...(input.personal ? { personal: true } : {}),
+      });
       const sourceDigest = candidateDigest(hit);
       const reservation = reserveMemoryOwnerProof(opts.owner, {
         action: input.personal ? MEMORY_OWNER_ACTIONS.personal : MEMORY_OWNER_ACTIONS.accept,
@@ -482,6 +486,16 @@ export function createDurableMemoryService(opts: {
         pending: workspaceId ? v2.listCandidates(workspaceId).length : 0,
         mode: v2.mode(),
       };
+    },
+    queryLibrary(input: {
+      q?: string;
+      scope?: "personal" | "workspace";
+      workspaceId?: string;
+      includeForgotten?: boolean;
+      limit?: number;
+      offset?: number;
+    }) {
+      return engine.queryLibrary(input);
     },
     memoryV2: v2,
     deleteScope() {

--- a/packages/memory/src/production-wiring.test.ts
+++ b/packages/memory/src/production-wiring.test.ts
@@ -72,3 +72,30 @@ test("memory accept/forget cannot be satisfied by a UUID or ownerConfirmed boole
   );
   svc.close();
 });
+
+test("rejected personal candidate is checked before engine materialization or receipt reservation", async () => {
+  const root = mkdtempSync(join(tmpdir(), "penglai-mem-policy-"));
+  const owner = new OwnerApprovalBroker(root, { dialog: async () => "approved" });
+  const svc = createDurableMemoryService({
+    userData: root, skills: { snapshot: async () => ({ skills: [], complete: true }) }, owner,
+  });
+  svc.setMemoryMode("suggest");
+  const candidate = svc.memoryV2.enqueue({
+    workspaceId: "ws-a", sessionId: "s1", turnId: "t1", kind: "preference",
+    text: "Always remember to use English in every workspace", rationale: "claim",
+    confidence: 0.9, sourceDigest: "b".repeat(64),
+  });
+  if (!("candidateId" in candidate)) throw new Error("expected candidate");
+  const proposed = svc.proposeAction({ action: "memory.personal", objectId: candidate.candidateId, workspaceId: "ws-a" });
+  const decision = await owner.requestOwnerApproval(proposed.actionId);
+  if (decision.decision !== "approved") throw new Error("expected receipt");
+  let writes = 0;
+  svc.engine.remember = async () => { writes++; throw new Error("unexpected engine write"); };
+  await assert.rejects(svc.acceptCandidate({
+    candidateId: candidate.candidateId, actionId: proposed.actionId, receipt: decision.receipt, personal: true,
+  }), /MEMORY_PERSONAL_NOT_INFERRED/);
+  assert.equal(writes, 0);
+  assert.equal(svc.memoryV2.getCandidate(candidate.candidateId)?.status, "pending");
+  assert.notEqual(owner.inspect(proposed.actionId).state, "reserved");
+  svc.close();
+});

--- a/packages/memory/src/remote.ts
+++ b/packages/memory/src/remote.ts
@@ -17,6 +17,14 @@ interface MemorySettingsHost {
   importConfirm?(proof: { actionId: string; receipt: string }): Promise<unknown>;
   list?(scope: MemoryScope, workspaceId?: string): Array<{ id: string | number; text: string; workspaceId?: string | null }>;
   count?(workspaceId?: string): { workspace: number; personal: number; pending: number; mode: string };
+  queryLibrary?(input: {
+    q?: string;
+    scope?: "personal" | "workspace";
+    workspaceId?: string;
+    includeForgotten?: boolean;
+    limit?: number;
+    offset?: number;
+  }): unknown;
   acceptCandidate?(input: { candidateId: string; actionId: string; receipt: string; personal?: boolean }): unknown;
   rejectCandidate?(input: { candidateId: string }): unknown;
   setMemoryMode?(mode: string): unknown;
@@ -60,6 +68,18 @@ export function createMemorySettingsApi(
     return sources;
   };
   return {
+    async queryLibrary(input: {
+      q?: string;
+      scope?: "personal" | "workspace";
+      workspaceId?: string;
+      includeForgotten?: boolean;
+      limit?: number;
+      offset?: number;
+    }) {
+      if (!service.queryLibrary) throw new PenglaiError("DSH_UNAVAILABLE", "memory library unavailable");
+      if (input.scope === "workspace") requireWorkspace(input.workspaceId);
+      return service.queryLibrary(input);
+    },
     async status(input: { scope: MemoryScope; workspaceId?: string }) {
       requireScope(input.scope);
       if (input.scope === "workspace" || input.scope === "candidate") requireWorkspace(input.workspaceId);
@@ -185,6 +205,7 @@ export function createMemorySettingsApi(
 
 export class PenglaiMemoryRemote extends TypertRemoteService {
   constructor(ctx: Context, private readonly api: ReturnType<typeof createMemorySettingsApi>) { super(ctx, "penglaiMemorySettings"); }
+  @PenglaiRemote queryLibrary(input: { q?: string; scope?: "personal" | "workspace"; workspaceId?: string; includeForgotten?: boolean; limit?: number; offset?: number }) { return this.api.queryLibrary(input); }
   @PenglaiRemote status(input: { scope: MemoryScope; workspaceId?: string }) { return this.api.status(input); }
   @PenglaiRemote setMode(input: { mode: string }) { return this.api.setMode(input); }
   @PenglaiRemote proposeAction(input: { action: string; objectId: string; workspaceId?: string; sessionId?: string; sourceText?: string }) { return this.api.proposeAction(input); }
@@ -210,6 +231,7 @@ export class PenglaiMemoryRemote extends TypertRemoteService {
 export const TYPERT_REMOTE = {
   package: "@penglai/memory",
   descriptors: [
+    "queryLibrary",
     "status", "write", "deleteScope", "promoteSop", "why", "correct", "forget", "graph", "export",
     "importPreview", "importConfirm", "setMode", "proposeAction", "acceptCandidate", "rejectCandidate",
     "sourcesStatus", "sourcesIngestCapability", "sourcesReindex",

--- a/packages/memory/src/v2/candidates.test.ts
+++ b/packages/memory/src/v2/candidates.test.ts
@@ -271,6 +271,31 @@ test("auto-workspace uses local risk policy and ignores model confidence", () =>
   v2.close();
 });
 
+test("pending candidate CAS rejects a second decide from another store handle", () => {
+  const root = mkdtempSync(join(tmpdir(), "penglai-mem-cas-"));
+  const path = join(root, "v2.sqlite3");
+  const first = new MemoryV2Store(path);
+  const row = first.enqueue({
+    workspaceId: "ws-a",
+    sessionId: "s1",
+    turnId: "t-cas",
+    kind: "project_fact",
+    text: "Office writes still need Owner confirmation",
+    rationale: "fact",
+    confidence: 0.9,
+    sourceDigest: digest,
+  });
+  assert.equal("candidateId" in row, true);
+  if (!("candidateId" in row)) throw new Error("expected candidate");
+  first.decide(row.candidateId, "accepted");
+  assert.throws(() => first.decide(row.candidateId, "rejected"), /MEMORY_CANDIDATE_STATE/);
+  const second = new MemoryV2Store(path);
+  assert.throws(() => second.decide(row.candidateId, "rejected"), /MEMORY_CANDIDATE_STATE/);
+  assert.equal(second.getCandidate(row.candidateId)?.status, "accepted");
+  first.close();
+  second.close();
+});
+
 test("R56-MEM-012 recall set stays within 20 items and 2048 tokens", () => {
   const v2 = store();
   const confirmed = Array.from({ length: 40 }, (_, i) => ({

--- a/packages/memory/src/v2/candidates.ts
+++ b/packages/memory/src/v2/candidates.ts
@@ -256,7 +256,7 @@ export class MemoryV2Store {
     return raw ? this.map(raw) : undefined;
   }
 
-  decide(
+  validateDecision(
     candidateId: string,
     status: "accepted" | "rejected",
     opts?: { personal?: boolean; actionId?: string },
@@ -277,7 +277,17 @@ export class MemoryV2Store {
         throw new PenglaiError("SECURITY_POLICY", "MEMORY_PERSONAL_NOT_INFERRED");
       }
     }
-    this.db.prepare(`UPDATE candidates SET status = ? WHERE candidate_id = ?`).run(status, candidateId);
+    return row;
+  }
+
+  decide(
+    candidateId: string,
+    status: "accepted" | "rejected",
+    opts?: { personal?: boolean; actionId?: string },
+  ): MemoryCandidateV1 {
+    const row = this.validateDecision(candidateId, status, opts);
+    const changed = this.db.prepare(`UPDATE candidates SET status = ? WHERE candidate_id = ? AND status = 'pending'`).run(status, candidateId);
+    if (changed.changes !== 1) throw new PenglaiError("SECURITY_POLICY", "MEMORY_CANDIDATE_STATE");
     if (status === "rejected") {
       this.db.prepare(`INSERT OR REPLACE INTO negatives(digest, workspace_id, expires_at) VALUES (?, ?, ?)`).run(
         row.sourceDigest.replace(/^sha256:/, ""),

--- a/packages/moss-tts/src/models.ts
+++ b/packages/moss-tts/src/models.ts
@@ -827,7 +827,14 @@ export class TtsModelManager {
 
   private persistOperations(): void {
     const temp = `${this.operationsPath}.${randomUUID()}.part`;
-    writeFileSync(temp, JSON.stringify([...this.operations.values()], null, 2), { mode: 0o600, flag: "wx" });
+    const rows = [...this.operations.values()]
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+      .slice(0, 32);
+    const keep = new Set(rows.map((row) => row.operationId));
+    for (const id of [...this.operations.keys()]) {
+      if (!keep.has(id)) this.operations.delete(id);
+    }
+    writeFileSync(temp, JSON.stringify(rows, null, 2), { mode: 0o600, flag: "wx" });
     renameSync(temp, this.operationsPath);
   }
 

--- a/packages/moss-tts/src/output-registry.ts
+++ b/packages/moss-tts/src/output-registry.ts
@@ -6,6 +6,7 @@ import {
   readFileSync,
   readdirSync,
   renameSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { lstat, open, rename, unlink } from "node:fs/promises";
@@ -174,12 +175,19 @@ export class TtsOutputRegistry {
       for (const value of raw) {
         if (!this.valid(value)) throw new Error("ledger row");
         const record = value as StoredOutput;
+        const wav = join(this.root, record.file);
+        if (!existsSync(wav)) continue;
         this.records.set(record.id, record);
       }
       const allowed = new Set(["outputs.json", ...[...this.records.values()].map((record) => record.file)]);
       for (const entry of readdirSync(this.root)) {
+        if (entry.endsWith(".part")) {
+          try { unlinkSync(join(this.root, entry)); } catch { /* leftover staging */ }
+          continue;
+        }
         if (!allowed.has(entry)) throw new Error("unknown output file");
       }
+      this.persist();
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
       throw new PenglaiError("STORE_CORRUPT", "TTS output ledger corrupt");

--- a/packages/office/src/adapters/docx.ts
+++ b/packages/office/src/adapters/docx.ts
@@ -15,6 +15,21 @@ function xmlText(xml: string): string {
     .trim();
 }
 
+function replaceBlockText(block: string, escaped: string): string {
+  let inserted = false;
+  const replaced = block.replace(/<w:t(?:\s[^>]*)?>[\s\S]*?<\/w:t>|<w:(?:tab|br|cr)\b[^>]*\/>/g, (node) => {
+    if (!/^<w:t(?:\s|>)/.test(node)) return "";
+    const text = inserted ? "" : escaped;
+    inserted = true;
+    return `<w:t xml:space="preserve">${text}</w:t>`;
+  });
+  if (inserted) return replaced;
+  const run = `<w:r><w:t xml:space="preserve">${escaped}</w:t></w:r>`;
+  if (/<\/w:p>/.test(replaced)) return replaced.replace(/<\/w:p>/, `${run}</w:p>`);
+  if (/<w:p\b[^>]*\/>/.test(replaced)) return replaced.replace(/<w:p\b([^>]*)\/>/, `<w:p$1>${run}</w:p>`);
+  return replaced.replace(/<\/w:tc>/, `<w:p>${run}</w:p></w:tc>`);
+}
+
 export async function createDocx(text: string): Promise<Buffer> {
   const doc = new Document({
     sections: [{ children: [new Paragraph({ children: [new TextRun(text)] })] }],
@@ -46,9 +61,8 @@ export async function inspectDocx(bytes: Buffer): Promise<{ text: string; parts:
   assertAuthorizedBytes(bytes);
   const entries = readZip(bytes);
   const document = entries.find((entry) => entry.name === "word/document.xml")?.data.toString("utf8") ?? "";
-  const paragraphs = [...document.matchAll(/<w:p\b[\s\S]*?<\/w:p>/g)]
-    .map((match) => xmlText(match[0] ?? ""))
-    .filter(Boolean);
+  const paragraphs = [...document.matchAll(/<w:p\b[^>]*\/>|<w:p\b[^>]*>[\s\S]*?<\/w:p>/g)]
+    .map((match) => xmlText(match[0] ?? ""));
   const headers = entries.filter((entry) => /^word\/(?:header|footer)\d+\.xml$/.test(entry.name)).map((entry) => xmlText(entry.data.toString("utf8"))).filter(Boolean);
   const tables = [...document.matchAll(/<w:tbl\b[\s\S]*?<\/w:tbl>/g)].map((match) => xmlText(match[0] ?? "")).filter(Boolean);
   const title = paragraphs[0] ?? "";
@@ -93,26 +107,22 @@ export function editDocx(bytes: Buffer, op:
           let cellIndex = 0;
           return row.replace(/<w:tc\b[\s\S]*?<\/w:tc>/g, (cell) => {
             if (cellIndex++ !== op.cellIndex) return cell;
-            if (/<w:t[\s>]/.test(cell)) return cell.replace(/<w:t(?:\s[^>]*)?>[\s\S]*?<\/w:t>/, `<w:t xml:space="preserve">${escaped}</w:t>`);
-            return cell.replace(/<\/w:tc>/, `<w:p><w:r><w:t xml:space="preserve">${escaped}</w:t></w:r></w:p></w:tc>`);
+            return replaceBlockText(cell, escaped);
           });
         });
       });
       if (patched === xml) throw new PenglaiError("INVALID_INPUT", "docx table cell out of range");
     } else {
-      const blocks = xml.match(/<w:p\b[\s\S]*?<\/w:p>/g) ?? [];
+      const blocks = xml.match(/<w:p\b[^>]*\/>|<w:p\b[^>]*>[\s\S]*?<\/w:p>/g) ?? [];
       if (op.paragraphIndex < 0 || op.paragraphIndex >= blocks.length) throw new PenglaiError("INVALID_INPUT", "docx paragraph index out of range");
       let index = 0;
-      patched = xml.replace(/<w:p\b[\s\S]*?<\/w:p>/g, (block) => {
+      patched = xml.replace(/<w:p\b[^>]*\/>|<w:p\b[^>]*>[\s\S]*?<\/w:p>/g, (block) => {
         if (index++ !== op.paragraphIndex) return block;
         if (op.kind === "docx.insertParagraph") {
           const added = `<w:p><w:r><w:t xml:space="preserve">${escaped}</w:t></w:r></w:p>`;
           return op.position === "before" ? `${added}${block}` : `${block}${added}`;
         }
-        if (/<w:t[\s>]/.test(block)) {
-          return block.replace(/<w:t(?:\s[^>]*)?>[\s\S]*?<\/w:t>/, `<w:t xml:space="preserve">${escaped}</w:t>`);
-        }
-        return block.replace(/<\/w:p>/, `<w:r><w:t xml:space="preserve">${escaped}</w:t></w:r></w:p>`);
+        return replaceBlockText(block, escaped);
       });
     }
     if (patched === xml) {

--- a/packages/office/src/adapters/pdf.ts
+++ b/packages/office/src/adapters/pdf.ts
@@ -84,10 +84,25 @@ export async function inspectPdf(bytes: Buffer): Promise<{
   };
 }
 
+function collectBetween(source: string, open: string, close: string, limit = 4_000): string[] {
+  const out: string[] = [];
+  let from = 0;
+  while (out.length < limit) {
+    const start = source.indexOf(open, from);
+    if (start < 0) break;
+    const body = start + open.length;
+    const end = source.indexOf(close, body);
+    if (end < 0) break;
+    out.push(source.slice(body, end));
+    from = end + close.length;
+  }
+  return out;
+}
+
 function extractPdfPageTexts(latin1: string, pageCount: number): string[] {
   const decoded = inflatePdfStreams(latin1);
   const cmap = parseToUnicode(decoded);
-  const blocks = [...decoded.matchAll(/BT([\s\S]*?)ET/g)].map((match) => decodePdfOperators(match[1] ?? "", cmap));
+  const blocks = collectBetween(decoded, "BT", "ET").map((block) => decodePdfOperators(block, cmap));
   if (blocks.length === 0) {
     const loose = decodePdfOperators(decoded, cmap);
     return Array.from({ length: Math.max(1, pageCount) }, (_, index) => (index === 0 ? loose : ""));
@@ -114,34 +129,68 @@ function parseToUnicode(decoded: string): Map<string, string> {
 
 function inflatePdfStreams(latin1: string): string {
   let out = latin1;
-  const re = /stream\r?\n([\s\S]*?)endstream/g;
-  for (const match of latin1.matchAll(re)) {
-    const raw = match[1] ?? "";
+  let from = 0;
+  while (from < latin1.length) {
+    const start = latin1.indexOf("stream", from);
+    if (start < 0) break;
+    let body = start + 6;
+    if (latin1.charCodeAt(body) === 13) body += 1;
+    if (latin1.charCodeAt(body) !== 10) {
+      from = start + 6;
+      continue;
+    }
+    body += 1;
+    const end = latin1.indexOf("endstream", body);
+    if (end < 0) break;
+    const raw = latin1.slice(body, end);
     try {
       const inflated = inflateSync(Buffer.from(raw, "latin1"));
       out += `\n${inflated.toString("latin1")}`;
     } catch {
       try {
-        const inflated = inflateSync(Buffer.from(raw.replace(/^\r?\n/, "").replace(/\r?\n$/, ""), "latin1"));
+        const trimmed = raw.startsWith("\n") || raw.startsWith("\r")
+          ? raw.replace(/^\r?\n/, "").replace(/\r?\n$/, "")
+          : raw;
+        const inflated = inflateSync(Buffer.from(trimmed, "latin1"));
         out += `\n${inflated.toString("latin1")}`;
       } catch {
         /* keep the original compressed payload */
       }
     }
+    from = end + 9;
   }
   return out;
 }
 
-function decodePdfOperators(operators: string, cmap: Map<string, string> = new Map()): string {
+function extractPdfLiteralStrings(operators: string): string[] {
   const parts: string[] = [];
-  for (const match of operators.matchAll(/\((?:\\.|[^\\)])*\)/g)) {
-    parts.push((match[0] ?? "").slice(1, -1).replace(/\\([()\\nrt])/g, (_, ch: string) => {
-      if (ch === "n") return "\n";
-      if (ch === "r") return "\r";
-      if (ch === "t") return "\t";
-      return ch;
-    }));
+  for (let i = 0; i < operators.length; i += 1) {
+    if (operators.charCodeAt(i) !== 40) continue;
+    let text = "";
+    let j = i + 1;
+    while (j < operators.length) {
+      const code = operators.charCodeAt(j);
+      if (code === 92 && j + 1 < operators.length) {
+        const next = operators[j + 1] ?? "";
+        if (next === "n") text += "\n";
+        else if (next === "r") text += "\r";
+        else if (next === "t") text += "\t";
+        else text += next;
+        j += 2;
+        continue;
+      }
+      if (code === 41) break;
+      text += operators[j] ?? "";
+      j += 1;
+    }
+    parts.push(text);
+    i = j;
   }
+  return parts;
+}
+
+function decodePdfOperators(operators: string, cmap: Map<string, string> = new Map()): string {
+  const parts: string[] = extractPdfLiteralStrings(operators);
   for (const match of operators.matchAll(/<([0-9A-Fa-f]+)>/g)) {
     const hex = (match[1] ?? "").toLowerCase();
     if (!hex) continue;

--- a/packages/office/src/adapters/pdf.ts
+++ b/packages/office/src/adapters/pdf.ts
@@ -1,3 +1,4 @@
+import { inflateSync } from "node:zlib";
 import { PDFDocument, degrees, rgb } from "pdf-lib";
 import fontkit from "@pdf-lib/fontkit";
 import { PenglaiError } from "@penglai/contracts";
@@ -12,20 +13,8 @@ async function embedPenglaiFont(pdf: PDFDocument) {
   return pdf.embedFont(loadPenglaiCjkFont(), { subset: true });
 }
 
-function decodePdfText(raw: string): string {
-  const parts: string[] = [];
-  for (const match of raw.matchAll(/\(([^()\\]*)\)/g)) parts.push(match[1] ?? "");
-  return parts.join(" ").replace(/\s+/g, " ").trim();
-}
-
 export async function createPdf(text: string): Promise<Buffer> {
-  const pdf = await PDFDocument.create();
-  pdf.setTitle(text);
-  pdf.setSubject(text);
-  const page = pdf.addPage([612, 792]);
-  const font = await embedPenglaiFont(pdf);
-  page.drawText(text.slice(0, 180), { x: 72, y: 720, size: 12, font, color: rgb(0, 0, 0) });
-  return Buffer.from(await pdf.save());
+  return createPdfFromSpec({ format: "pdf", paragraphs: text.split(/\r?\n/) });
 }
 
 export async function createPdfFromSpec(spec: PdfCreateSpec): Promise<Buffer> {
@@ -57,17 +46,123 @@ function wrapText(value: string, chars: number): string[] {
   return out;
 }
 
-export async function inspectPdf(bytes: Buffer): Promise<{ text: string; parts: string[]; pages: number }> {
+export async function inspectPdf(bytes: Buffer): Promise<{
+  text: string;
+  parts: string[];
+  pages: number;
+  pageTexts: string[];
+  encrypted?: boolean;
+  scanned?: boolean;
+}> {
   assertAuthorizedBytes(bytes);
   if (bytes.subarray(0, 4).toString("latin1") !== "%PDF") throw new PenglaiError("INVALID_INPUT", "unsupported office format");
+  let encrypted = false;
+  try {
+    await PDFDocument.load(bytes, { ignoreEncryption: false, updateMetadata: false });
+  } catch {
+    encrypted = true;
+  }
   const pdf = await PDFDocument.load(bytes, { ignoreEncryption: true, updateMetadata: false });
   const pages = pdf.getPageCount();
-  const meta = [pdf.getTitle(), pdf.getSubject()].filter(Boolean).join(" ");
+  const pageTexts = extractPdfPageTexts(bytes.toString("latin1"), pages);
+  const body = pageTexts.join("\n").replace(/\s+/g, " ").trim();
+  const scanned = pages > 0 && !body && !encrypted;
+  const title = pdf.getTitle()?.trim() ?? "";
   return {
-    text: [meta, decodePdfText(bytes.toString("latin1"))].filter(Boolean).join(" "),
-    parts: [`pages:${pages}`],
+    text: [title, body].filter(Boolean).join(" ").slice(0, 64_000),
+    parts: [
+      `pages:${pages}`,
+      ...(title ? [`title:${title.slice(0, 120)}`] : []),
+      ...(encrypted ? ["encrypted:true"] : []),
+      ...(scanned ? ["scanned:ocr-required"] : []),
+      ...pageTexts.slice(0, 200).map((text, index) => `page${index}:${text.slice(0, 240)}`),
+    ],
     pages,
+    pageTexts,
+    ...(encrypted ? { encrypted: true } : {}),
+    ...(scanned ? { scanned: true } : {}),
   };
+}
+
+function extractPdfPageTexts(latin1: string, pageCount: number): string[] {
+  const decoded = inflatePdfStreams(latin1);
+  const cmap = parseToUnicode(decoded);
+  const blocks = [...decoded.matchAll(/BT([\s\S]*?)ET/g)].map((match) => decodePdfOperators(match[1] ?? "", cmap));
+  if (blocks.length === 0) {
+    const loose = decodePdfOperators(decoded, cmap);
+    return Array.from({ length: Math.max(1, pageCount) }, (_, index) => (index === 0 ? loose : ""));
+  }
+  if (pageCount <= 1) return [blocks.join(" ").replace(/\s+/g, " ").trim()];
+  const per = Math.max(1, Math.ceil(blocks.length / pageCount));
+  return Array.from({ length: pageCount }, (_, index) => blocks.slice(index * per, (index + 1) * per).join(" ").replace(/\s+/g, " ").trim());
+}
+
+function parseToUnicode(decoded: string): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const match of decoded.matchAll(/<([0-9A-Fa-f]+)>\s*<([0-9A-Fa-f]+)>/g)) {
+    const from = (match[1] ?? "").toLowerCase();
+    const to = match[2] ?? "";
+    if (!from || to.length % 4 !== 0 || map.has(from)) continue;
+    let text = "";
+    for (let i = 0; i < to.length; i += 4) {
+      text += String.fromCharCode(Number.parseInt(to.slice(i, i + 4), 16));
+    }
+    map.set(from, text);
+  }
+  return map;
+}
+
+function inflatePdfStreams(latin1: string): string {
+  let out = latin1;
+  const re = /stream\r?\n([\s\S]*?)endstream/g;
+  for (const match of latin1.matchAll(re)) {
+    const raw = match[1] ?? "";
+    try {
+      const inflated = inflateSync(Buffer.from(raw, "latin1"));
+      out += `\n${inflated.toString("latin1")}`;
+    } catch {
+      try {
+        const inflated = inflateSync(Buffer.from(raw.replace(/^\r?\n/, "").replace(/\r?\n$/, ""), "latin1"));
+        out += `\n${inflated.toString("latin1")}`;
+      } catch {
+        /* keep the original compressed payload */
+      }
+    }
+  }
+  return out;
+}
+
+function decodePdfOperators(operators: string, cmap: Map<string, string> = new Map()): string {
+  const parts: string[] = [];
+  for (const match of operators.matchAll(/\((?:\\.|[^\\)])*\)/g)) {
+    parts.push((match[0] ?? "").slice(1, -1).replace(/\\([()\\nrt])/g, (_, ch: string) => {
+      if (ch === "n") return "\n";
+      if (ch === "r") return "\r";
+      if (ch === "t") return "\t";
+      return ch;
+    }));
+  }
+  for (const match of operators.matchAll(/<([0-9A-Fa-f]+)>/g)) {
+    const hex = (match[1] ?? "").toLowerCase();
+    if (!hex) continue;
+    if (cmap.size) {
+      let text = "";
+      const width = [...cmap.keys()][0]?.length ?? 4;
+      for (let i = 0; i < hex.length; i += width) {
+        text += cmap.get(hex.slice(i, i + width)) ?? "";
+      }
+      if (text) {
+        parts.push(text);
+        continue;
+      }
+    }
+    if (hex.length % 2 !== 0) continue;
+    const raw = Buffer.from(hex, "hex");
+    let utf16 = "";
+    for (let i = 0; i + 1 < raw.length; i += 2) utf16 += String.fromCharCode(raw.readUInt16BE(i));
+    parts.push(utf16);
+  }
+  return parts.join(" ");
 }
 
 export async function editPdf(bytes: Buffer, op: { text: string }): Promise<Buffer> {

--- a/packages/office/src/adapters/xlsx.ts
+++ b/packages/office/src/adapters/xlsx.ts
@@ -28,22 +28,33 @@ export async function createXlsxFromSpec(spec: XlsxCreateSpec): Promise<Buffer> 
   return Buffer.from(await wb.xlsx.writeBuffer());
 }
 
-export async function inspectXlsx(bytes: Buffer): Promise<{ text: string; parts: string[] }> {
+export async function inspectXlsx(bytes: Buffer): Promise<{
+  text: string;
+  parts: string[];
+  formulaCount: number;
+  calculationStatus: "stored-formulas";
+}> {
   assertAuthorizedBytes(bytes);
   const wb = new ExcelJS.Workbook();
   await wb.xlsx.load(bytes as never);
   const cells: string[] = [];
   const parts: string[] = [];
+  let formulaCount = 0;
   wb.eachSheet((sheet) => {
     parts.push(sheet.name);
     sheet.eachRow((row) => {
       row.eachCell((cell) => {
-        const value = cell.formula ? `=${cell.formula}` : String(cell.value ?? "");
+        if (cell.formula) {
+          formulaCount += 1;
+          cells.push(`=${cell.formula}`);
+          return;
+        }
+        const value = String(cell.value ?? "");
         if (value) cells.push(value);
       });
     });
   });
-  return { text: cells.join(" "), parts };
+  return { text: cells.join(" "), parts, formulaCount, calculationStatus: "stored-formulas" };
 }
 
 export async function editXlsx(

--- a/packages/office/src/docx-content.test.ts
+++ b/packages/office/src/docx-content.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createDocx, editDocx, inspectDocx } from "./adapters/docx.js";
+import { readZip, writeZip } from "./zip.js";
+
+test("DOCX paragraph indices include empty paragraphs and replacement clears all old text runs", async () => {
+  const seed = await createDocx("seed");
+  const bytes = writeZip(readZip(seed).map((entry) => ({
+    name: entry.name,
+    data: entry.name === "word/document.xml" ? Buffer.from(entry.data.toString().replace(
+      /<w:body>[\s\S]*?<w:sectPr/,
+      '<w:body><w:p/><w:p><w:pPr><w:keepNext/></w:pPr><w:r><w:rPr><w:b/></w:rPr><w:t>old first</w:t></w:r><w:r><w:t>old tail</w:t><w:br/></w:r></w:p><w:p><w:r><w:t>unrelated</w:t></w:r></w:p><w:sectPr',
+    )) : entry.data,
+  })));
+  assert.deepEqual((await inspectDocx(bytes)).paragraphs, ["", "old first old tail", "unrelated"]);
+  const changed = editDocx(bytes, { kind: "docx.replaceParagraph", paragraphIndex: 1, text: "new content" });
+  assert.deepEqual((await inspectDocx(changed)).paragraphs, ["", "new content", "unrelated"]);
+  const xml = readZip(changed).find((entry) => entry.name === "word/document.xml")!.data.toString();
+  assert.match(xml, /<w:keepNext\/>/);
+  assert.match(xml, /<w:rPr><w:b\/><\/w:rPr>/);
+  const filled = editDocx(changed, { kind: "docx.replaceParagraph", paragraphIndex: 0, text: "filled" });
+  assert.deepEqual((await inspectDocx(filled)).paragraphs, ["filled", "new content", "unrelated"]);
+});
+
+test("DOCX table-cell replacement clears every paragraph but preserves neighboring cells", async () => {
+  const seed = await createDocx("seed");
+  const bytes = writeZip(readZip(seed).map((entry) => ({
+    name: entry.name,
+    data: entry.name === "word/document.xml" ? Buffer.from(entry.data.toString().replace(
+      /<w:body>[\s\S]*?<w:sectPr/,
+      '<w:body><w:tbl><w:tr><w:tc><w:tcPr><w:shd w:fill="FFFF00"/></w:tcPr><w:p><w:r><w:t>old first</w:t></w:r></w:p><w:p><w:r><w:t>old second</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>neighbor</w:t></w:r></w:p></w:tc></w:tr></w:tbl><w:sectPr',
+    )) : entry.data,
+  })));
+  const changed = editDocx(bytes, { kind: "docx.replaceTableCell", tableIndex: 0, rowIndex: 0, cellIndex: 0, text: "new cell" });
+  const seen = await inspectDocx(changed);
+  assert.deepEqual(seen.paragraphs, ["new cell", "", "neighbor"]);
+  assert.doesNotMatch(seen.text, /old first|old second/);
+  assert.match(readZip(changed).find((entry) => entry.name === "word/document.xml")!.data.toString(), /w:fill="FFFF00"/);
+});

--- a/packages/office/src/index.ts
+++ b/packages/office/src/index.ts
@@ -20,6 +20,8 @@ export { OFFICE_TEMPLATES } from "./templates/catalog.js";
 export { assertAuthorizedBytes } from "./authorization.js";
 export { registerOfficeTools } from "./tools.js";
 export { loadPenglaiCjkFont, PENGLAI_CJK_FONT_SHA256, PENGLAI_CJK_FONT_LICENSE } from "./cjk-font.js";
+export { previewPdfPages, artifactDigest } from "./pdf-preview.js";
+export { previewOfficeStructure, bindOfficePreviewDigest, externalOpenPlan } from "./structural-preview.js";
 
 interface OfficeContext {
   tools?: { register(definition: Record<string, unknown>): unknown };

--- a/packages/office/src/office.test.ts
+++ b/packages/office/src/office.test.ts
@@ -106,6 +106,7 @@ test("office remote inspect/create/edit drive the shipped service", async () => 
       ?.data.toString("utf8"),
     "<w:hdr>KEEP</w:hdr>",
   );
+  await assert.rejects(() => api.preview({ jobId: created.id }), /not bound to this Workspace and Session/);
 });
 
 test("office settings client presents ordinary-language capabilities and structured templates", async () => {

--- a/packages/office/src/office57.test.ts
+++ b/packages/office/src/office57.test.ts
@@ -120,7 +120,10 @@ test("0.5.7 PDF merge accepts only distinct session-bound handles and produces a
   objects.bind(rightHandle, { sessionId: "sess-1", workspaceId: "ws-1" });
   const merged = await svc.mergeAttached(leftHandle, rightHandle, "sess-1", "ws-1");
   assert.equal(merged.format, "pdf");
-  assert.deepEqual((await inspect(merged.bytes)).parts, ["pages:2"]);
+  const mergedParts = (await inspect(merged.bytes)).parts;
+  assert.equal(mergedParts[0], "pages:2");
+  assert.ok(mergedParts.some((part) => part.startsWith("page0:")));
+  assert.ok(mergedParts.some((part) => part.startsWith("page1:")));
   assert.equal(svc.job(merged.id).state, "PREVIEW_READY");
   await assert.rejects(() => svc.mergeAttached(leftHandle, leftHandle, "sess-1", "ws-1"), /different handles/);
   await assert.rejects(() => svc.mergeAttached(leftHandle, rightHandle, "sess-other", "ws-1"), /bound|UNAUTHORIZED/i);

--- a/packages/office/src/pdf-preview.test.ts
+++ b/packages/office/src/pdf-preview.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createHash } from "node:crypto";
+import { createPdf, inspectPdf } from "./adapters/pdf.js";
+import { artifactDigest, previewPdfPages } from "./pdf-preview.js";
+
+test("PDF inspect keeps full created body and does not treat title metadata as the page", async () => {
+  const body = "alpha-line\n".repeat(40);
+  const bytes = await createPdf(body);
+  const seen = await inspectPdf(bytes);
+  assert.ok(seen.text.includes("alpha-line"));
+  assert.ok(seen.text.length > 180);
+  assert.ok(seen.parts.some((part) => part.startsWith("page0:") && part.includes("alpha-line")));
+});
+
+test("PDF page preview is bound to the reviewed artifact digest", async () => {
+  const bytes = await createPdf("preview-body-one\npreview-body-two");
+  const digest = artifactDigest(bytes);
+  const preview = await previewPdfPages(bytes, digest);
+  assert.equal(preview.digest, digest);
+  assert.ok(preview.pagePreviews.some((page) => page.text.includes("preview-body-one")));
+  const other = await createPdf("different-document");
+  await assert.rejects(() => previewPdfPages(other, digest), /digest mismatch/);
+  assert.equal(createHash("sha256").update(bytes).digest("hex"), digest);
+});

--- a/packages/office/src/pdf-preview.test.ts
+++ b/packages/office/src/pdf-preview.test.ts
@@ -4,6 +4,14 @@ import { createHash } from "node:crypto";
 import { createPdf, inspectPdf } from "./adapters/pdf.js";
 import { artifactDigest, previewPdfPages } from "./pdf-preview.js";
 
+test("PDF inspect stays linear on BT-repeat noise inside a real created document", async () => {
+  const bytes = await createPdf(`BT-noise ${"BTa".repeat(8_000)} visible-marker`);
+  const started = Date.now();
+  const seen = await inspectPdf(bytes);
+  assert.match(seen.text, /visible-marker/);
+  assert.ok(Date.now() - started < 2_000);
+});
+
 test("PDF inspect keeps full created body and does not treat title metadata as the page", async () => {
   const body = "alpha-line\n".repeat(40);
   const bytes = await createPdf(body);

--- a/packages/office/src/pdf-preview.ts
+++ b/packages/office/src/pdf-preview.ts
@@ -1,0 +1,76 @@
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PenglaiError } from "@penglai/contracts";
+import { inspectPdf } from "./adapters/pdf.js";
+
+export interface PdfPagePreview {
+  index: number;
+  text: string;
+  width: number;
+  height: number;
+  raster?: { mediaType: "image/png"; bytes: Buffer };
+}
+
+export interface PdfPreview {
+  digest: string;
+  pages: number;
+  encrypted?: boolean;
+  scanned?: boolean;
+  pagePreviews: PdfPagePreview[];
+}
+
+export function artifactDigest(bytes: Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function assertPreviewDigest(bytes: Buffer, digest: string): string {
+  const actual = artifactDigest(bytes);
+  const expected = digest.replace(/^sha256:/, "").toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(expected) || actual !== expected) {
+    throw new PenglaiError("SECURITY_POLICY", "PDF preview digest mismatch");
+  }
+  return actual;
+}
+
+export async function previewPdfPages(bytes: Buffer, digest: string): Promise<PdfPreview> {
+  const bound = assertPreviewDigest(bytes, digest);
+  const seen = await inspectPdf(bytes);
+  const rasters = renderPdfRasters(bytes);
+  return {
+    digest: bound,
+    pages: seen.pages,
+    ...(seen.encrypted ? { encrypted: true } : {}),
+    ...(seen.scanned ? { scanned: true } : {}),
+    pagePreviews: seen.pageTexts.map((text, index) => ({
+      index,
+      text,
+      width: 612,
+      height: 792,
+      ...(rasters[index] ? { raster: { mediaType: "image/png" as const, bytes: rasters[index]! } } : {}),
+    })),
+  };
+}
+
+function renderPdfRasters(bytes: Buffer): Buffer[] {
+  const pdftoppm = spawnSync("which", ["pdftoppm"], { encoding: "utf8" });
+  if (pdftoppm.status !== 0) return [];
+  const bin = pdftoppm.stdout.trim();
+  if (!bin) return [];
+  const dir = mkdtempSync(join(tmpdir(), "penglai-pdf-preview-"));
+  try {
+    const prefix = join(dir, "page");
+    const input = join(dir, "in.pdf");
+    writeFileSync(input, bytes);
+    const rendered = spawnSync(bin, ["-png", "-r", "36", input, prefix], { encoding: "utf8" });
+    if (rendered.status !== 0) return [];
+    return readdirSync(dir)
+      .filter((name) => name.endsWith(".png"))
+      .sort()
+      .map((name) => readFileSync(join(dir, name)));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}

--- a/packages/office/src/remote.ts
+++ b/packages/office/src/remote.ts
@@ -62,13 +62,26 @@ export function createOfficeRemoteApi(impl: ReturnType<typeof createOfficeServic
         bytesBase64: job.bytes.toString("base64"),
       };
     },
-    async preview(input: { jobId: string }) {
-      return impl.preview(input.jobId);
+    async preview(input: { jobId: string; sessionId?: string; workspaceId?: string }) {
+      if (!input.sessionId || !input.workspaceId) {
+        throw new PenglaiError("UNAUTHORIZED", "office job is not bound to this Workspace and Session");
+      }
+      return impl.preview(input.jobId, { sessionId: input.sessionId, workspaceId: input.workspaceId });
     },
-    async approve(input: { jobId: string }) {
-      return { receipt: await impl.approve(input.jobId) };
+    async approve(input: { jobId: string; sessionId?: string; workspaceId?: string }) {
+      if (!input.sessionId || !input.workspaceId) {
+        throw new PenglaiError("UNAUTHORIZED", "office job is not bound to this Workspace and Session");
+      }
+      return { receipt: await impl.approve(input.jobId, "commit", "", { sessionId: input.sessionId, workspaceId: input.workspaceId }) };
     },
-    commit(input: { jobId: string; receipt: string }) {
+    commit(input: { jobId: string; receipt: string; sessionId?: string; workspaceId?: string }) {
+      if (!input.sessionId || !input.workspaceId) {
+        throw new PenglaiError("UNAUTHORIZED", "office job is not bound to this Workspace and Session");
+      }
+      const job = impl.job(input.jobId);
+      if (job.sessionId !== input.sessionId || job.workspaceId !== input.workspaceId) {
+        throw new PenglaiError("UNAUTHORIZED", "office job is not bound to this Workspace and Session");
+      }
       const bytes = impl.commit(input.jobId, input.receipt);
       return { bytesBase64: bytes.toString("base64") };
     },

--- a/packages/office/src/service.ts
+++ b/packages/office/src/service.ts
@@ -46,6 +46,7 @@ export interface DocumentInventory {
   text: string;
   parts: string[];
   warnings: string[];
+  spreadsheet?: { calculationStatus: "stored-formulas"; formulaCount: number };
 }
 
 export interface OfficeJob {
@@ -67,6 +68,21 @@ export interface OfficeOutbound {
     bytes: Buffer;
     digest: string;
   }): Promise<{ channel: "weixin" | "feishu"; delivered: true }>;
+}
+
+export interface OfficeJobScope {
+  workspaceId?: string;
+  sessionId?: string;
+}
+
+function assertJobScope(job: { workspaceId?: string; sessionId?: string }, scope?: OfficeJobScope): void {
+  if (!scope) return;
+  if (scope.workspaceId !== undefined && job.workspaceId !== scope.workspaceId) {
+    throw new PenglaiError("UNAUTHORIZED", "office job is not bound to this Workspace and Session");
+  }
+  if (scope.sessionId !== undefined && job.sessionId !== scope.sessionId) {
+    throw new PenglaiError("UNAUTHORIZED", "office job is not bound to this Workspace and Session");
+  }
 }
 
 const SECRET = /api[_-]?key|password|private key/i;
@@ -107,7 +123,13 @@ async function inspectRaw(bytes: Buffer): Promise<DocumentInventory> {
   }
   if (format === "xlsx") {
     const seen = await inspectXlsx(bytes);
-    return { format, text: seen.text, parts: seen.parts, warnings: [OFFICE_LIMITS.xlsx] };
+    return {
+      format,
+      text: seen.text,
+      parts: seen.parts,
+      warnings: [OFFICE_LIMITS.xlsx],
+      spreadsheet: { calculationStatus: seen.calculationStatus, formulaCount: seen.formulaCount },
+    };
   }
   if (format === "pptx") {
     const seen = await inspectPptx(bytes);
@@ -293,7 +315,7 @@ export function createOfficeService(opts?: {
       ingestJobBytes(job, `attached.${seen.format}`);
       return { ...toPublic(job), handle };
     },
-    async inspectWorkspaceFile(absPath: string, workspaceRoot: string, workspaceId: string) {
+    async inspectWorkspaceFile(absPath: string, workspaceRoot: string, workspaceId: string, sessionId?: string) {
       const dest = assertPathInWorkspace(absPath, workspaceRoot);
       if (basename(dest) !== basename(absPath)) {
         throw new PenglaiError("SECURITY_POLICY", "office inspect filename escaped");
@@ -307,6 +329,7 @@ export function createOfficeService(opts?: {
         parts: seen.parts,
         warnings: seen.warnings,
         workspaceId,
+        ...(sessionId ? { sessionId } : {}),
         sourcePath: dest,
       });
       if (opts?.artifacts) {
@@ -315,6 +338,7 @@ export function createOfficeService(opts?: {
           source: "office",
           scope: "workspace",
           workspaceId,
+        ...(sessionId ? { sessionId } : {}),
         });
         job.artifactId = ref.id;
       }
@@ -327,16 +351,20 @@ export function createOfficeService(opts?: {
       return created;
     },
     edit,
-    async preview(jobId: string) {
+    async preview(jobId: string, scope?: OfficeJobScope) {
       const job = getJob(jobId);
+      assertJobScope(job, scope);
       if (job.state === "INSPECTED" || job.state === "PLAN_READY") setJobState(jobId, "PREVIEW_READY", "preview");
       return previewJob(job);
     },
-    async diff(jobId: string) {
-      return diffJob(getJob(jobId));
-    },
-    accept(jobId: string) {
+    async diff(jobId: string, scope?: OfficeJobScope) {
       const job = getJob(jobId);
+      assertJobScope(job, scope);
+      return diffJob(job);
+    },
+    accept(jobId: string, scope?: OfficeJobScope) {
+      const job = getJob(jobId);
+      assertJobScope(job, scope);
       assertPreviewMatchesResult(job);
       if (!opts?.artifacts) throw new PenglaiError("DSH_UNAVAILABLE", "office Artifact service is not configured");
       if (job.resultArtifactId) return opts.artifacts.ref(job.resultArtifactId);
@@ -353,9 +381,10 @@ export function createOfficeService(opts?: {
       setJobState(jobId, "VERIFIED", "artifact accepted");
       return ref;
     },
-    async approve(jobId: string, action: OfficeReceiptAction = "commit", target = "") {
+    async approve(jobId: string, action: OfficeReceiptAction = "commit", target = "", scope?: OfficeJobScope) {
       const job = getJob(jobId);
-      if (!["PREVIEW_READY", "PLAN_READY", "INSPECTED", "OWNER_APPROVED", "COMMITTED", "UNDO_READY"].includes(job.state)) {
+      assertJobScope(job, scope);
+      if (!["PREVIEW_READY", "PLAN_READY", "INSPECTED", "OWNER_APPROVED", "VERIFIED", "COMMITTED", "UNDO_READY"].includes(job.state)) {
         throw new PenglaiError("SECURITY_POLICY", "office job is not ready for approval");
       }
       if (!opts?.owner) throw new PenglaiError("SECURITY_POLICY", "office broker is not configured");
@@ -386,8 +415,9 @@ export function createOfficeService(opts?: {
       }
       return decided.receipt;
     },
-    async verify(jobId: string) {
+    async verify(jobId: string, scope?: OfficeJobScope) {
       const job = getJob(jobId);
+      assertJobScope(job, scope);
       if (job.format === "xlsx") await verifyXlsx(job.bytes);
       setJobState(jobId, "VERIFIED");
       return { ok: true, format: job.format, digest: job.digest };
@@ -396,6 +426,7 @@ export function createOfficeService(opts?: {
       if (typeof job !== "string") return Buffer.from(job.bytes);
       if (!receipt) throw new PenglaiError("SECURITY_POLICY", "office commit requires owner receipt");
       const record = getJob(job);
+      assertJobScope(record);
       const finish = consumeReceipt(record, "commit", receipt);
       assertPreviewMatchesResult(record);
       record.stagedBytes = Buffer.from(record.bytes);
@@ -407,8 +438,9 @@ export function createOfficeService(opts?: {
       finish();
       return Buffer.from(record.bytes);
     },
-    commitToPath(jobId: string, receipt: string, destPath: string, workspaceRoot: string) {
+    commitToPath(jobId: string, receipt: string, destPath: string, workspaceRoot: string, scope?: OfficeJobScope) {
       const record = getJob(jobId);
+      assertJobScope(record, scope);
       const dest = assertPathInWorkspace(destPath, workspaceRoot);
       const finish = consumeReceipt(record, "commit-to-path", receipt, dest);
       assertPreviewMatchesResult(record);
@@ -433,8 +465,9 @@ export function createOfficeService(opts?: {
       finish();
       return { dest, digest: result.destDigest, backup };
     },
-    undo(jobId: string, receipt: string) {
+    undo(jobId: string, receipt: string, scope?: OfficeJobScope) {
       const record = getJob(jobId);
+      assertJobScope(record, scope);
       const finish = consumeReceipt(record, "undo", receipt);
       if (record.state !== "UNDO_READY" && record.state !== "COMMITTED") {
         throw new PenglaiError("SECURITY_POLICY", "office job is not undoable");
@@ -463,9 +496,10 @@ export function createOfficeService(opts?: {
       finish();
       return Buffer.from(record.bytes);
     },
-    async discard(jobId: string, receipt: string) {
+    async discard(jobId: string, receipt: string, scope?: OfficeJobScope) {
       if (!receipt) throw new PenglaiError("SECURITY_POLICY", "office discard requires owner receipt");
       const record = getJob(jobId);
+      assertJobScope(record, scope);
       const finish = consumeReceipt(record, "discard", receipt);
       discardJob(jobId);
       finish();
@@ -473,9 +507,10 @@ export function createOfficeService(opts?: {
     bindHandle(handle: string, bind: { sessionId: string; workspaceId?: string; routeId?: string }) {
       objects.bind(handle, bind);
     },
-    async export(jobId: string, target: OfficeFormat, receipt: string) {
+    async export(jobId: string, target: OfficeFormat, receipt: string, scope?: OfficeJobScope) {
       if (!receipt) throw new PenglaiError("SECURITY_POLICY", "office export requires owner receipt");
       const job = getJob(jobId);
+      assertJobScope(job, scope);
       if (target !== job.format) throw new PenglaiError("INVALID_INPUT", "office format conversion is not implemented");
       const finish = consumeReceipt(job, "export", receipt, target);
       assertPreviewMatchesResult(job);
@@ -483,8 +518,9 @@ export function createOfficeService(opts?: {
       finish();
       return { bytes: Buffer.from(job.bytes), format: job.format, filename: `penglai.${job.format}`, digest: job.digest, ...(job.artifactId ? { artifactId: job.artifactId } : {}) };
     },
-    async returnToChannel(jobId: string, receipt: string) {
+    async returnToChannel(jobId: string, receipt: string, scope?: OfficeJobScope) {
       const job = getJob(jobId);
+      assertJobScope(job, scope);
       if (!job.routeId || !job.sessionId) {
         throw new PenglaiError("INVALID_INPUT", "office job has no original IM route");
       }
@@ -513,7 +549,8 @@ export function createOfficeService(opts?: {
       finish();
       return { ...result, filename: exported.filename, digest: exported.digest, bytes: exported.bytes.length };
     },
-    async cancel(jobId: string) {
+    async cancel(jobId: string, scope?: OfficeJobScope) {
+      assertJobScope(getJob(jobId), scope);
       cancelJob(jobId);
     },
     async rotate(bytes: Buffer) {

--- a/packages/office/src/structural-preview.test.ts
+++ b/packages/office/src/structural-preview.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createHash } from "node:crypto";
+import { createDocument, createStructuredDocument, edit } from "./service.js";
+import { bindOfficePreviewDigest, externalOpenPlan, previewOfficeStructure } from "./structural-preview.js";
+
+test("structural previews bind digest and expose spreadsheet formula status, not ZIP names alone", async () => {
+  const created = await createStructuredDocument({
+    format: "xlsx",
+    sheets: [{ name: "预算", rows: [["科目", "金额"], ["研发", 100]] }],
+  });
+  const xlsx = await edit(created.bytes, { kind: "xlsx.setCell", sheet: "预算", cell: "C2", value: "B2*2", formula: true });
+  const digest = createHash("sha256").update(xlsx.bytes).digest("hex");
+  const preview = await previewOfficeStructure(xlsx.bytes, digest, "预算表.xlsx");
+  assert.equal(preview.format, "xlsx");
+  assert.match(preview.text, /研发/);
+  assert.match(preview.text, /=B2\*2/);
+  assert.equal(preview.parts.some((part) => part === "预算"), true);
+  assert.equal(preview.parts.every((part) => part.includes("/")), false);
+  assert.equal(preview.spreadsheet?.calculationStatus, "stored-formulas");
+  assert.equal((preview.spreadsheet?.formulaCount ?? 0) >= 1, true);
+  assert.equal(preview.imagePpt.status, "not-supported");
+  assert.deepEqual(preview.externalOpen, { allowed: true, filename: "预算表.xlsx" });
+  assert.throws(() => bindOfficePreviewDigest(xlsx.bytes, "a".repeat(64)), /digest mismatch/);
+  assert.equal(externalOpenPlan({ bytes: xlsx.bytes, digest, filename: "../escape.xlsx" }).allowed, false);
+});
+
+test("PPTX structural preview is slide text and does not claim image rasterization", async () => {
+  const pptx = await createDocument("pptx", "发布说明");
+  const digest = createHash("sha256").update(pptx.bytes).digest("hex");
+  const preview = await previewOfficeStructure(pptx.bytes, digest, "deck.pptx");
+  assert.equal(preview.format, "pptx");
+  assert.match(preview.text, /发布说明/);
+  assert.match(preview.parts.join("\n"), /slide0:/);
+  assert.equal(preview.imagePpt.status, "not-supported");
+  assert.match(preview.imagePpt.reason, /does not rasterize/i);
+  assert.equal(preview.externalOpen.allowed, true);
+});
+
+test("DOCX structural preview uses paragraph text rather than package metadata", async () => {
+  const docx = await createDocument("docx", "正文段落");
+  const digest = createHash("sha256").update(docx.bytes).digest("hex");
+  const preview = await previewOfficeStructure(docx.bytes, digest, "note.docx");
+  assert.match(preview.text, /正文段落/);
+  assert.equal(preview.parts.some((part) => part.startsWith("p0:") && part.includes("正文段落")), true);
+  assert.equal(preview.parts.includes("word/document.xml"), false);
+});

--- a/packages/office/src/structural-preview.ts
+++ b/packages/office/src/structural-preview.ts
@@ -1,0 +1,76 @@
+import { basename } from "node:path";
+import { PenglaiError } from "@penglai/contracts";
+import { artifactDigest } from "./pdf-preview.js";
+import { detect, inspect } from "./service.js";
+import { safeWorkspaceFilename } from "./transaction.js";
+import type { OfficeFormat } from "./formats.js";
+
+export type SpreadsheetCalculationStatus = "stored-formulas" | "calculated" | "unavailable";
+
+export interface OfficeStructuralPreview {
+  digest: string;
+  format: OfficeFormat;
+  text: string;
+  parts: string[];
+  externalOpen: { allowed: true; filename: string } | { allowed: false; reason: string };
+  spreadsheet?: { calculationStatus: SpreadsheetCalculationStatus; formulaCount: number };
+  imagePpt: { status: "not-supported"; reason: string };
+}
+
+export function bindOfficePreviewDigest(bytes: Buffer, digest: string): string {
+  const actual = artifactDigest(bytes);
+  const expected = digest.replace(/^sha256:/, "").toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(expected) || actual !== expected) {
+    throw new PenglaiError("SECURITY_POLICY", "office preview digest mismatch");
+  }
+  return actual;
+}
+
+export function externalOpenPlan(input: {
+  bytes: Buffer;
+  digest: string;
+  filename?: string;
+}): { allowed: true; filename: string } | { allowed: false; reason: string } {
+  try {
+    bindOfficePreviewDigest(input.bytes, input.digest);
+  } catch {
+    return { allowed: false, reason: "digest mismatch" };
+  }
+  const raw = input.filename ?? "";
+  if (!raw) return { allowed: false, reason: "filename required" };
+  if (raw !== basename(raw) || raw.includes("..") || raw.includes("/") || raw.includes("\\")) {
+    return { allowed: false, reason: "filename must be a workspace basename" };
+  }
+  try {
+    return { allowed: true, filename: safeWorkspaceFilename(raw) };
+  } catch (error) {
+    return { allowed: false, reason: error instanceof Error ? error.message : "filename rejected" };
+  }
+}
+
+const IMAGE_PPT = {
+  status: "not-supported" as const,
+  reason: "Penglai does not rasterize PowerPoint slides. Use inspect text or an Owner-approved external open.",
+};
+
+export async function previewOfficeStructure(
+  bytes: Buffer,
+  digest: string,
+  filename?: string,
+): Promise<OfficeStructuralPreview> {
+  const bound = bindOfficePreviewDigest(bytes, digest);
+  const format = detect(bytes);
+  const seen = await inspect(bytes);
+  if (seen.parts.length > 0 && seen.parts.every((part) => part.includes("/"))) {
+    throw new PenglaiError("INVALID_INPUT", "office structural preview cannot be ZIP entry names alone");
+  }
+  return {
+    digest: bound,
+    format,
+    text: seen.text,
+    parts: seen.parts,
+    externalOpen: externalOpenPlan({ bytes, digest: bound, ...(filename ? { filename } : {}) }),
+    ...(format === "xlsx" && seen.spreadsheet ? { spreadsheet: seen.spreadsheet } : {}),
+    imagePpt: IMAGE_PPT,
+  };
+}

--- a/packages/office/src/tools.test.ts
+++ b/packages/office/src/tools.test.ts
@@ -3,11 +3,12 @@ import test from "node:test";
 import { mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { ArtifactService } from "@penglai/artifacts";
 import { ObjectStore } from "@penglai/contracts";
 import { OwnerApprovalBroker } from "@penglai/runtime";
 import { createOfficeService } from "./service.js";
 import { registerOfficeTools } from "./tools.js";
-import { atomicCommitFile, assertTrustedWorkspacePath } from "./transaction.js";
+import { atomicCommitFile, assertTrustedWorkspacePath, safeWorkspaceFilename } from "./transaction.js";
 import { PENGLAI_CJK_FONT_LICENSE, PENGLAI_CJK_FONT_SHA256, loadPenglaiCjkFont } from "./cjk-font.js";
 
 function liveOffice(userData: string, extra?: Parameters<typeof createOfficeService>[0]) {
@@ -163,4 +164,69 @@ test("bundled CJK OFL font is hashed and embeddable", () => {
   assert.equal(PENGLAI_CJK_FONT_LICENSE, "OFL-1.1");
   assert.equal(PENGLAI_CJK_FONT_SHA256.length, 64);
   assert.ok(font.length > 10_000_000);
+});
+
+
+test("office job tools reject another Session and Workspace before reads or actions", async () => {
+  const { tools, dir, ctx } = registered([]);
+  ctx.workspaceRegistry.list = () => [
+    { id: "ws1", path: dir, sessionIds: ["sess-1", "sess-2"] },
+    { id: "ws2", path: dir, sessionIds: ["sess-3"] },
+  ];
+  let approvals = 0;
+  const owner = new OwnerApprovalBroker(dir, { dialog: async () => { approvals++; return "approved"; } });
+  const svc = liveOffice(dir, { owner });
+  registerOfficeTools(ctx, svc);
+  const created = await tools.get("penglai_office_create")!.execute(
+    { format: "docx", text: "private session content" }, { agent: { id: "sess-1" } },
+  ) as { id: string };
+  for (const sessionId of ["sess-2", "sess-3"]) {
+    for (const name of ["preview", "plan", "accept", "discard", "commit", "undo", "return_to_channel"]) {
+      await assert.rejects(async () => tools.get(`penglai_office_${name}`)!.execute({
+        job_id: created.id, filename: "stolen.docx",
+        operation: { kind: "docx.replaceParagraph", paragraphIndex: 0, text: "overwritten" },
+      }, { agent: { id: sessionId } }), /not bound to this Workspace and Session/);
+    }
+  }
+  assert.equal(approvals, 0);
+  assert.equal(svc.job(created.id).state, "INSPECTED");
+  assert.match(svc.job(created.id).text, /private session content/);
+  svc.cancel(created.id);
+});
+
+test("accepted office artifact can be saved with separate exact action approval and undone", async () => {
+  const { tools, dir, ctx } = registered([]);
+  const artifacts = new ArtifactService(join(dir, "artifacts"));
+  let approvals = 0;
+  const owner = new OwnerApprovalBroker(dir, { dialog: async () => { approvals++; return "approved"; } });
+  const svc = liveOffice(dir, { owner, artifacts });
+  registerOfficeTools(ctx, svc);
+  const exec = { agent: { id: "sess-1" } };
+  const filename = "项目 汇报.docx";
+  const original = await svc.create("docx", "original content");
+  writeFileSync(join(dir, filename), original.bytes);
+  const inspected = await tools.get("penglai_office_inspect")!.execute({ filename }, exec) as { id: string };
+  assert.equal(svc.job(inspected.id).sessionId, "sess-1");
+  const planned = await tools.get("penglai_office_plan")!.execute({
+    job_id: inspected.id, operation: { kind: "docx.replaceParagraph", paragraphIndex: 0, text: "accepted content" },
+  }, exec) as { id: string };
+  await tools.get("penglai_office_preview")!.execute({ job_id: planned.id }, exec);
+  await tools.get("penglai_office_accept")!.execute({ job_id: planned.id }, exec);
+  assert.equal(approvals, 0);
+  assert.equal(svc.job(planned.id).state, "VERIFIED");
+  await tools.get("penglai_office_commit")!.execute({ job_id: planned.id, filename }, exec);
+  assert.equal(approvals, 1);
+  assert.match((await svc.inspect(readFileSync(join(dir, filename)))).text, /accepted content/);
+  await tools.get("penglai_office_undo")!.execute({ job_id: planned.id }, exec);
+  assert.equal(approvals, 2);
+  assert.deepEqual(readFileSync(join(dir, filename)), original.bytes);
+  artifacts.close();
+});
+
+
+test("office Unicode filenames retain basename safety across supported platforms", () => {
+  for (const name of ["项目 汇报.docx", "Quarterly report.xlsx", "résumé.pdf"]) assert.equal(safeWorkspaceFilename(name), name);
+  for (const name of ["../report.docx", "folder/report.docx", "folder\\report.docx", "CON.docx", "report?.pdf", " report.pdf", "report\n.pdf"]) {
+    assert.throws(() => safeWorkspaceFilename(name), /bounded workspace basename/);
+  }
 });

--- a/packages/office/src/tools.ts
+++ b/packages/office/src/tools.ts
@@ -3,6 +3,8 @@ import { PenglaiError } from "@penglai/contracts";
 import type { OfficeFormat, OfficeJob, OfficeService } from "./service.js";
 import { parseOfficeOperation } from "./operations.js";
 import { safeWorkspaceFilename } from "./transaction.js";
+import { previewPdfPages } from "./pdf-preview.js";
+import { previewOfficeStructure } from "./structural-preview.js";
 
 interface CordisTools {
   tools?: { register(definition: Record<string, unknown>): unknown };
@@ -29,6 +31,15 @@ function boundWorkspace(ctx: CordisTools, exec: unknown): { id: string; path: st
   const hit = workspaces.find((row) => row.sessionIds?.includes(agentId) || row.id === agentId);
   if (!hit?.path) throw new PenglaiError("UNAUTHORIZED", "agent is not bound to an official Workspace path");
   return { id: hit.id, path: hit.path, sessionId: agentId };
+}
+
+function boundJob(ctx: CordisTools, svc: OfficeService, exec: unknown, jobId: string) {
+  const ws = boundWorkspace(ctx, exec);
+  const job = svc.job(jobId);
+  if (job.workspaceId !== ws.id || job.sessionId !== ws.sessionId) {
+    throw new PenglaiError("UNAUTHORIZED", "office job is not bound to this Workspace and Session");
+  }
+  return job;
 }
 
 function asFormat(value: unknown): OfficeFormat {
@@ -82,7 +93,8 @@ export function registerOfficeTools(ctx: CordisTools, svc: OfficeService): void 
       const ws = boundWorkspace(ctx, exec);
       if (input.handle) return publicJob(await svc.inspectAttached(input.handle, ws.sessionId));
       if (!input.filename) throw new PenglaiError("INVALID_INPUT", "office inspect requires filename or handle");
-      return publicJob(await svc.inspectWorkspaceFile(join(ws.path, safeWorkspaceFilename(input.filename)), ws.path, ws.id));
+      const inspected = await svc.inspectWorkspaceFile(join(ws.path, safeWorkspaceFilename(input.filename)), ws.path, ws.id, ws.sessionId);
+      return publicJob(inspected);
     },
   });
   ctx.tools.register({
@@ -166,7 +178,7 @@ export function registerOfficeTools(ctx: CordisTools, svc: OfficeService): void 
         return publicJob(edited);
       }
       if (!input.job_id) throw new PenglaiError("INVALID_INPUT", "office plan requires job_id or handle");
-      const source = svc.job(input.job_id);
+      const source = boundJob(ctx, svc, exec, input.job_id);
       const edited = await svc.edit(source.bytes, op);
       svc.job(edited.id).workspaceId = ws.id;
       svc.job(edited.id).sessionId = ws.sessionId;
@@ -186,10 +198,20 @@ export function registerOfficeTools(ctx: CordisTools, svc: OfficeService): void 
     },
     output: jsonOutput("office preview"),
     async execute(args: unknown, exec?: unknown) {
-      boundWorkspace(ctx, exec);
       const jobId = String((args as { job_id?: string }).job_id);
+      boundJob(ctx, svc, exec, jobId);
       const [preview, diff] = await Promise.all([svc.preview(jobId), svc.diff(jobId)]);
-      return { preview, diff };
+      const job = svc.job(jobId);
+      const structural = await previewOfficeStructure(
+        job.bytes,
+        job.digest.replace(/^sha256:/, ""),
+        job.sourcePath,
+      );
+      if (job.format === "pdf") {
+        const pdfPreview = await previewPdfPages(job.bytes, job.digest.replace(/^sha256:/, ""));
+        return { preview, diff, structural, pdfPreview: { digest: pdfPreview.digest, pages: pdfPreview.pages, scanned: pdfPreview.scanned, encrypted: pdfPreview.encrypted, pageTexts: pdfPreview.pagePreviews.map((page) => page.text) } };
+      }
+      return { preview, diff, structural };
     },
   });
   ctx.tools.register({
@@ -203,8 +225,9 @@ export function registerOfficeTools(ctx: CordisTools, svc: OfficeService): void 
     },
     output: jsonOutput("office accept"),
     execute(args: unknown, exec?: unknown) {
-      boundWorkspace(ctx, exec);
-      return svc.accept(String((args as { job_id?: string }).job_id));
+      const jobId = String((args as { job_id?: string }).job_id);
+      boundJob(ctx, svc, exec, jobId);
+      return svc.accept(jobId);
     },
   });
   ctx.tools.register({
@@ -238,8 +261,9 @@ export function registerOfficeTools(ctx: CordisTools, svc: OfficeService): void 
     },
     output: jsonOutput("office discard"),
     execute(args: unknown, exec?: unknown) {
-      boundWorkspace(ctx, exec);
-      return Promise.resolve(svc.cancel(String((args as { job_id?: string }).job_id))).then(() => ({ discarded: true as const }));
+      const jobId = String((args as { job_id?: string }).job_id);
+      boundJob(ctx, svc, exec, jobId);
+      return Promise.resolve(svc.cancel(jobId)).then(() => ({ discarded: true as const }));
     },
   });
   ctx.tools.register({
@@ -261,8 +285,8 @@ export function registerOfficeTools(ctx: CordisTools, svc: OfficeService): void 
       const ws = boundWorkspace(ctx, exec);
       const jobId = String(input.job_id);
       const filename = safeWorkspaceFilename(String(input.filename));
-      const job = svc.job(jobId);
-      if (job.state !== "PREVIEW_READY" && job.state !== "OWNER_APPROVED") {
+      const job = boundJob(ctx, svc, exec, jobId);
+      if (job.state !== "PREVIEW_READY" && job.state !== "OWNER_APPROVED" && job.state !== "VERIFIED") {
         throw new PenglaiError("SECURITY_POLICY", "office commit requires preview then Owner confirmation");
       }
       const dest = join(ws.path, filename);
@@ -286,8 +310,8 @@ export function registerOfficeTools(ctx: CordisTools, svc: OfficeService): void 
     },
     output: jsonOutput("office undo"),
     async execute(args: unknown, exec?: unknown) {
-      boundWorkspace(ctx, exec);
       const jobId = String((args as { job_id?: string }).job_id);
+      boundJob(ctx, svc, exec, jobId);
       if (!svc.job(jobId).receipt) await svc.approve(jobId, "undo");
       const receipt = svc.job(jobId).receipt;
       if (!receipt) throw new PenglaiError("SECURITY_POLICY", "office undo requires owner receipt");
@@ -305,8 +329,8 @@ export function registerOfficeTools(ctx: CordisTools, svc: OfficeService): void 
     },
     output: jsonOutput("office return"),
     async execute(args: unknown, exec?: unknown) {
-      boundWorkspace(ctx, exec);
       const jobId = String((args as { job_id?: string }).job_id);
+      boundJob(ctx, svc, exec, jobId);
       if (!svc.job(jobId).receipt) await svc.approve(jobId, "return-to-channel");
       const receipt = svc.job(jobId).receipt;
       if (!receipt) throw new PenglaiError("SECURITY_POLICY", "office return requires owner receipt");

--- a/packages/office/src/transaction.ts
+++ b/packages/office/src/transaction.ts
@@ -63,7 +63,12 @@ export function assertPathInWorkspace(path: string, workspaceRoot: string): stri
 }
 
 export function safeWorkspaceFilename(name: string): string {
-  if (!/^[A-Za-z0-9._-]{1,80}\.(docx|xlsx|pptx|pdf)$/.test(name)) {
+  if (
+    name.length > 80 || Buffer.byteLength(name, "utf8") > 240 ||
+    !/^[^\x00-\x1f\x7f<>:"/\\|?*]+\.(docx|xlsx|pptx|pdf)$/i.test(name) ||
+    name !== name.trim() || name.startsWith(".") ||
+    /^(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(?:\.|$)/i.test(name)
+  ) {
     throw new PenglaiError("INVALID_INPUT", "office filename must be a bounded workspace basename");
   }
   return name;

--- a/packages/persistence/src/index.ts
+++ b/packages/persistence/src/index.ts
@@ -424,6 +424,23 @@ export class Store {
     return { created: true, operationId: input.operationId };
   }
 
+  peekInboundOperation(routeId: string, vendorMessageKey: string): { operationId: string; inboundId?: string; turnId?: string } | undefined {
+    const existing = this.db
+      .prepare(
+        `SELECT operation_id, inbound_id, turn_id FROM inbound_operations
+         WHERE vendor_message_key = ? AND route_id = ?`,
+      )
+      .get(vendorMessageKey, routeId) as
+      | { operation_id: string; inbound_id?: string | null; turn_id?: string | null }
+      | undefined;
+    if (!existing) return undefined;
+    return {
+      operationId: existing.operation_id,
+      ...(existing.inbound_id ? { inboundId: existing.inbound_id } : {}),
+      ...(existing.turn_id ? { turnId: existing.turn_id } : {}),
+    };
+  }
+
   putVendorReplyTarget(routeId: string, vendorTarget: string): void {
     this.db
       .prepare(

--- a/packages/plugin-center/src/diagnostics-export.test.ts
+++ b/packages/plugin-center/src/diagnostics-export.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { exportRedactedCenterDiagnostics } from "./diagnostics-export.js";
+
+test("redacted Center diagnostics omit credentials, chat, QR and private paths", () => {
+  const seen = exportRedactedCenterDiagnostics({
+    catalog: [
+      { id: "@penglai/im", desired: "0.5.10", installed: "0.5.10", loaded: true, healthy: true, actual: "active" },
+      { id: "@penglai/office", desired: "0.5.10", installed: "0.5.10", loaded: false, healthy: false, actual: "failed" },
+    ],
+    now: () => Date.parse("2026-09-07T00:00:00Z"),
+  });
+  const json = JSON.stringify(seen);
+  assert.equal(seen.schema, 1);
+  assert.match(json, /reinstall-signed-catalog/);
+  assert.doesNotMatch(json, /api[_-]?key|sk-|otpauth|\/Users\/|chat body/i);
+  assert.throws(
+    () => exportRedactedCenterDiagnostics({
+      catalog: [{ id: "@penglai/im", error: "token=sk-live-secret /Users/agent/.penglai" }],
+    }),
+    /CENTER_DIAGNOSTIC_REDACTION/,
+  );
+});

--- a/packages/plugin-center/src/diagnostics-export.ts
+++ b/packages/plugin-center/src/diagnostics-export.ts
@@ -1,0 +1,68 @@
+import { PenglaiError } from "@penglai/contracts";
+import { readPluginTransactionDiagnostic } from "./profile-tx.js";
+
+const SECRET = /api[_-]?key|token|password|secret|authorization|private key/i;
+const PATH = /(?:\/(?:Users|home|var|tmp|private)|[A-Za-z]:\\)/;
+const QR = /data:image\/|otpauth:|\bqr\b/i;
+
+export interface RedactedCenterDiagnostics {
+  schema: 1;
+  generatedAt: string;
+  plugins: Array<{
+    id: string;
+    desired: string;
+    installed: string;
+    loaded: boolean;
+    healthy: boolean;
+    actual: string;
+    recovery?: string;
+  }>;
+  transaction: ReturnType<typeof readPluginTransactionDiagnostic>;
+}
+
+export function exportRedactedCenterDiagnostics(input: {
+  catalog: Array<{
+    id: string;
+    desired?: string;
+    installed?: string;
+    loaded?: boolean;
+    healthy?: boolean;
+    actual?: string;
+    error?: string;
+  }>;
+  txDir?: string;
+  now?: () => number;
+}): RedactedCenterDiagnostics {
+  const plugins = input.catalog.map((row) => {
+    if (looksPrivate(row.id) || looksPrivate(row.error)) {
+      throw new PenglaiError("SECURITY_POLICY", "CENTER_DIAGNOSTIC_REDACTION");
+    }
+    return {
+      id: row.id,
+      desired: String(row.desired ?? ""),
+      installed: String(row.installed ?? ""),
+      loaded: row.loaded === true,
+      healthy: row.healthy === true,
+      actual: String(row.actual ?? "unknown"),
+      ...(row.healthy === false
+        ? { recovery: row.loaded ? "restart-runtime" : "reinstall-signed-catalog" }
+        : {}),
+    };
+  });
+  const transaction = input.txDir ? readPluginTransactionDiagnostic(input.txDir) : null;
+  const json = JSON.stringify({ plugins, transaction });
+  if (SECRET.test(json) || PATH.test(json) || QR.test(json)) {
+    throw new PenglaiError("SECURITY_POLICY", "CENTER_DIAGNOSTIC_REDACTION");
+  }
+  return {
+    schema: 1,
+    generatedAt: new Date(input.now?.() ?? Date.now()).toISOString(),
+    plugins,
+    transaction,
+  };
+}
+
+function looksPrivate(value: unknown): boolean {
+  if (typeof value !== "string" || !value) return false;
+  return SECRET.test(value) || PATH.test(value) || QR.test(value);
+}

--- a/packages/plugin-center/src/dsh-client.js
+++ b/packages/plugin-center/src/dsh-client.js
@@ -105,8 +105,10 @@ window.__ModuleLoader__.load({
             "download",
             "installDisabled",
             "installEnable",
+            "exportDiagnostics",
+            "conversationUsage",
           ],
-          ["enable", "disable", "update", "rollback", "download", "installDisabled", "installEnable"],
+          ["enable", "disable", "update", "rollback", "download", "installDisabled", "installEnable", "conversationUsage"],
         ),
       ],
     };

--- a/packages/plugin-center/src/last-good.test.ts
+++ b/packages/plugin-center/src/last-good.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { healLastGoodArtifacts } from "./profile-tx.js";
+import { healLastGoodArtifacts, recoverInterruptedTransaction } from "./profile-tx.js";
 
 test("last-good recovery promotes next then prev after a crash window", () => {
   const root = mkdtempSync(join(tmpdir(), "penglai-last-good-"));
@@ -30,6 +30,38 @@ test("last-good recovery promotes next then prev after a crash window", () => {
     const healed = healLastGoodArtifacts(both);
     assert.equal(healed, join(both, "last-good"));
     assert.equal(readFileSync(join(both, "last-good", "marker"), "utf8"), "next");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("interrupted second transaction restores the latest successful profile, not the first snapshot", () => {
+  const root = mkdtempSync(join(tmpdir(), "penglai-last-good-seq-"));
+  try {
+    const profile = join(root, "profiles", "web");
+    const txDir = join(root, "profiles", "center-tx");
+    mkdirSync(profile, { recursive: true });
+    mkdirSync(txDir, { recursive: true });
+    writeFileSync(join(profile, "marker"), "C-interrupted");
+    mkdirSync(join(txDir, "last-good"), { recursive: true });
+    writeFileSync(join(txDir, "last-good", "marker"), "B-success");
+    writeFileSync(join(txDir, "journal.json"), JSON.stringify({
+      schema: 3,
+      operationId: "op-2",
+      phase: "activating",
+      lastGoodPhase: "promote-done",
+      id: "@penglai/im",
+      action: "enable",
+      previousEnabled: true,
+    }));
+    const recovered = recoverInterruptedTransaction({
+      userDataRoot: root,
+      profileDir: profile,
+      txDir,
+      id: "@penglai/im",
+    });
+    assert.equal(recovered.phase, "rolled_back");
+    assert.equal(readFileSync(join(profile, "marker"), "utf8"), "B-success");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/packages/plugin-center/src/onboarding.test.ts
+++ b/packages/plugin-center/src/onboarding.test.ts
@@ -17,6 +17,8 @@ import {
   emptyOnboarding,
   loadOnboarding,
   persistOnboarding,
+  createOnboardingHost,
+  resumeOnboardingCurrent,
   supportsOfficialOpenAiCompatible,
   onboardingApiTestCwd,
   releaseOnboardingTestWorkspaces,
@@ -90,6 +92,48 @@ function officialServices(opts: {
     },
   };
 }
+
+test("onboarding snapshot recovery refuses skip-ahead COMPLETE and keeps retryable lastError", () => {
+  assert.equal(resumeOnboardingCurrent(["welcome-v1"], "first-turn-v1"), "appearance-locale-v1");
+  assert.equal(resumeOnboardingCurrent(["welcome-v1"], "COMPLETE"), "appearance-locale-v1");
+  assert.equal(resumeOnboardingCurrent([...ONBOARDING_STEPS], "COMPLETE"), "COMPLETE");
+  assert.equal(
+    resumeOnboardingCurrent(["welcome-v1", "appearance-locale-v1", "privacy-v1", "model-provider-v1"], "credential-v1"),
+    "credential-v1",
+  );
+
+  const dir = mkdtempSync(join(tmpdir(), "penglai-onb-resume-"));
+  persistOnboarding(dir, {
+    schema: 2,
+    completed: ["welcome-v1"],
+    current: "first-turn-v1",
+    advanceToken: "tok",
+  });
+  const loaded = loadOnboarding(dir);
+  assert.equal(loaded.current, "appearance-locale-v1");
+  assert.deepEqual(loaded.completed, ["welcome-v1"]);
+
+  const host = createOnboardingHost({ dir: mkdtempSync(join(tmpdir(), "penglai-onb-error-")) });
+  assert.throws(() => host.advance("privacy-v1"), /expected welcome-v1/);
+  const failed = host.status();
+  assert.equal(failed.current, "welcome-v1");
+  assert.equal(failed.lastError?.step, "privacy-v1");
+  assert.equal(failed.lastError?.retryable, true);
+  assert.equal(failed.lastError?.code.includes("expected welcome-v1"), true);
+  host.advance("welcome-v1", { officialWelcomeAck: true });
+  assert.equal(host.status().lastError, undefined);
+  assert.equal(host.status().current, "appearance-locale-v1");
+  const factsDir = mkdtempSync(join(tmpdir(), "penglai-onb-rewind-error-"));
+  const rewindHost = createOnboardingHost({ dir: factsDir });
+  rewindHost.advance("welcome-v1", { officialWelcomeAck: true });
+  rewindHost.advance("appearance-locale-v1", { locale: "zh", theme: "system" });
+  rewindHost.advance("privacy-v1");
+  assert.throws(() => rewindHost.advance("credential-v1"), /expected model-provider-v1/);
+  assert.equal(rewindHost.status().lastError?.retryable, true);
+  rewindHost.rewind("model-provider-v1");
+  assert.equal(rewindHost.facts().lastError, undefined);
+  assert.equal(rewindHost.status().current, "model-provider-v1");
+});
 
 test("R2I-ONB-001/002 onboarding steps are ordered and durable", () => {
   let state = emptyOnboarding();
@@ -274,6 +318,14 @@ test("R50-ONB-003/006 server validates model and API test exact Session final", 
   assert.equal((result as { passed?: boolean }).passed, true);
   assert.equal("final" in (result as object), false);
   assert.equal(passed.status().current, "workspace-v1");
+});
+
+test("wizard resume follows persisted current and surfaces retryable lastError", () => {
+  const wizard = readFileSync(new URL("../../../apps/desktop/static/wizard/wizard.js", import.meta.url), "utf8");
+  assert.match(wizard, /state\.current = status\.current/);
+  assert.match(wizard, /status\.lastError/);
+  assert.match(wizard, /screenForLedger\(state\.current\)/);
+  assert.match(wizard, /rewindOnboarding|rpc\("rewind/);
 });
 
 test("R50-ONB-003 wizard lists official providers and models through penglaiOnboarding", () => {

--- a/packages/plugin-center/src/onboarding.ts
+++ b/packages/plugin-center/src/onboarding.ts
@@ -135,6 +135,7 @@ export interface OnboardingFacts {
   workspaceId?: string;
   workspacePath?: string;
   firstConversation?: { sessionId: string; messageDigest: string; finalDigest: string };
+  lastError?: { step: OnboardingStepId; code: string; retryable: boolean; at: string };
 }
 
 export function emptyOnboarding(): OnboardingState {
@@ -661,13 +662,33 @@ export function createOnboardingHost(opts: {
         ...(catalogError ? { catalogError } : {}),
         ...(facts.selection ? { selection: facts.selection } : {}),
         ...(facts.workspaceId ? { workspaceId: facts.workspaceId } : {}),
+        ...(facts.lastError ? { lastError: facts.lastError } : {}),
       };
     },
     advance(id, evidence = {}) {
       const state = load();
-      const next = completeStepWithEvidence(state, id, state.advanceToken, evidence);
-      persistOnboarding(opts.dir, next);
-      return next;
+      try {
+        const next = completeStepWithEvidence(state, id, state.advanceToken, evidence);
+        const facts = loadOnboardingFacts(opts.dir);
+        if (facts.lastError) {
+          delete facts.lastError;
+          persistOnboardingFacts(opts.dir, facts);
+        }
+        persistOnboarding(opts.dir, next);
+        return next;
+      } catch (error) {
+        const retryable = error instanceof PenglaiError && (error.errorClass === "INVALID_INPUT" || error.message.startsWith("MISSING_CREDENTIAL"));
+        persistOnboardingFacts(opts.dir, {
+          ...loadOnboardingFacts(opts.dir),
+          lastError: {
+            step: id,
+            code: error instanceof PenglaiError ? error.message : "ONBOARDING_ADVANCE_FAILED",
+            retryable,
+            at: new Date().toISOString(),
+          },
+        });
+        throw error;
+      }
     },
     rewind(id) {
       const state = load();
@@ -692,6 +713,7 @@ export function createOnboardingHost(opts: {
         delete facts.workspacePath;
       }
       if (target <= ONBOARDING_STEPS.indexOf("first-turn-v1")) delete facts.firstConversation;
+      delete facts.lastError;
       persistOnboardingFacts(opts.dir, facts);
       persistOnboarding(opts.dir, next);
       return next;
@@ -759,7 +781,38 @@ export function loadOnboardingFacts(dir: string): OnboardingFacts {
   ) {
     facts.firstConversation = { ...raw.firstConversation };
   }
+  if (
+    raw.lastError &&
+    (ONBOARDING_STEPS as readonly string[]).includes(String(raw.lastError.step)) &&
+    typeof raw.lastError.code === "string" &&
+    raw.lastError.code.length <= 200 &&
+    typeof raw.lastError.retryable === "boolean" &&
+    typeof raw.lastError.at === "string"
+  ) {
+    facts.lastError = {
+      step: raw.lastError.step as OnboardingStepId,
+      code: raw.lastError.code,
+      retryable: raw.lastError.retryable,
+      at: raw.lastError.at,
+    };
+  }
   return facts;
+}
+
+export function resumeOnboardingCurrent(
+  completed: readonly OnboardingStepId[],
+  persisted?: string,
+): OnboardingStepId | "COMPLETE" {
+  const derived = nextStep(completed);
+  if (!persisted) return derived;
+  if (persisted === "COMPLETE") return derived === "COMPLETE" ? "COMPLETE" : derived;
+  if (!(ONBOARDING_STEPS as readonly string[]).includes(persisted)) return derived;
+  const persistedIndex = ONBOARDING_STEPS.indexOf(persisted as OnboardingStepId);
+  const skippedAhead = completed.some((step) => ONBOARDING_STEPS.indexOf(step) >= persistedIndex);
+  if (skippedAhead) return derived;
+  const missingEarlier = ONBOARDING_STEPS.slice(0, persistedIndex).some((step) => !completed.includes(step));
+  if (missingEarlier) return derived;
+  return persisted as OnboardingStepId;
 }
 
 export function loadOnboarding(dir: string): OnboardingState {
@@ -768,13 +821,15 @@ export function loadOnboarding(dir: string): OnboardingState {
   const raw = JSON.parse(readFileSync(p, "utf8")) as {
     schema?: number;
     completed?: OnboardingStepId[];
+    current?: string;
     advanceToken?: string;
   };
   if (raw.schema !== 1 && raw.schema !== 2) return emptyOnboarding();
+  const completed = raw.completed ?? [];
   return {
     schema: 2,
-    completed: raw.completed ?? [],
-    current: nextStep(raw.completed ?? []),
+    completed,
+    current: resumeOnboardingCurrent(completed, raw.current),
     advanceToken: raw.advanceToken || randomUUID(),
   };
 }

--- a/packages/plugin-center/src/profile-tx.ts
+++ b/packages/plugin-center/src/profile-tx.ts
@@ -15,7 +15,7 @@ import {
 } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import { PenglaiError, redactedDiagnosticReference } from "@penglai/contracts";
+import { PenglaiError, redactedDiagnosticReference, CENTER_JOURNAL_SCHEMA, assertCenterJournalHeader, centerProfileWasUntouched } from "@penglai/contracts";
 import {
   assertPluginPackageManifest,
   extractTarGz,
@@ -93,7 +93,7 @@ export interface PluginTransactionDiagnostic {
 }
 
 interface TransactionJournal {
-  schema: 3;
+  schema: typeof CENTER_JOURNAL_SCHEMA;
   operationId: string;
   phase: "staging" | "activating" | "verifying" | "committed" | "rolled_back";
   lastGoodPhase?: "snapshot" | "snapshot-ready" | "promote-prev" | "promote-next" | "promote-done";
@@ -626,7 +626,7 @@ export async function runProfileTransaction(opts: {
         : opts.previousEnabled;
   const previousPresent = opts.previousPresent ?? true;
   const journal: TransactionJournal = {
-    schema: 3,
+    schema: CENTER_JOURNAL_SCHEMA,
     operationId,
     phase: "staging",
     id: opts.entry.id,
@@ -674,10 +674,18 @@ export async function runProfileTransaction(opts: {
     copyDir(opts.profileDir, lastGoodNext);
     journal.lastGoodPhase = "snapshot-ready";
     atomicJournal(journalPath, journal);
-    if (!existsSync(lastGood)) {
+    if (existsSync(lastGoodNext)) {
+      const lastGoodPrev = join(opts.txDir, `last-good-prev-${operationId}`);
+      journal.lastGoodPhase = "promote-prev";
+      atomicJournal(journalPath, journal);
+      if (existsSync(lastGood)) renameSync(lastGood, lastGoodPrev);
+      journal.lastGoodPhase = "promote-next";
+      atomicJournal(journalPath, journal);
       renameSync(lastGoodNext, lastGood);
+      journal.lastGoodPhase = "promote-done";
+      atomicJournal(journalPath, journal);
+      if (existsSync(lastGood)) rmSync(lastGoodPrev, { recursive: true, force: true });
     }
-    atomicJournal(journalPath, journal);
     copyDir(opts.profileDir, staging);
     const patchPath = join(staging, "cordis.patch.yml");
     if (!existsSync(patchPath)) {
@@ -768,18 +776,6 @@ export async function runProfileTransaction(opts: {
     journal.phase = "committed";
     atomicJournal(journalPath, journal);
     rmSync(backup, { recursive: true, force: true });
-    if (existsSync(lastGoodNext)) {
-      const lastGoodPrev = join(opts.txDir, `last-good-prev-${operationId}`);
-      journal.lastGoodPhase = "promote-prev";
-      atomicJournal(journalPath, journal);
-      if (existsSync(lastGood)) renameSync(lastGood, lastGoodPrev);
-      journal.lastGoodPhase = "promote-next";
-      atomicJournal(journalPath, journal);
-      renameSync(lastGoodNext, lastGood);
-      journal.lastGoodPhase = "promote-done";
-      atomicJournal(journalPath, journal);
-      if (existsSync(lastGood)) rmSync(lastGoodPrev, { recursive: true, force: true });
-    }
     return {
       phase: "committed",
       id: opts.entry.id,
@@ -835,7 +831,7 @@ export async function runProfileTransaction(opts: {
         `Center transaction and rollback failed for ${opts.entry.id}`,
       );
     } finally {
-      journal.phase = "rolled_back";
+      journal.phase = journal.rollback.outcome === "verified" ? "rolled_back" : "verifying";
       journal.errorClass =
         error instanceof PenglaiError ? error.errorClass : "DSH_UNAVAILABLE";
       atomicJournal(journalPath, journal);
@@ -878,7 +874,6 @@ export function recoverInterruptedTransaction(opts: {
   id?: string;
 }): ProfileTxResult | { phase: "idle" | "committed" } {
   assertTransactionPaths(opts);
-  healLastGoodArtifacts(opts.txDir);
   const journalPath = join(opts.txDir, "journal.json");
   const lockPath = join(opts.txDir, "active.lock");
   if (!existsSync(journalPath)) {
@@ -890,6 +885,13 @@ export function recoverInterruptedTransaction(opts: {
     id?: string;
     previousEnabled?: boolean;
   };
+  assertCenterJournalHeader(raw);
+  if (centerProfileWasUntouched(raw)) {
+    if (raw.lastGoodPhase === "snapshot") rmSync(join(opts.txDir, `last-good-next-${raw.operationId}`), { recursive: true, force: true });
+    atomicJournal(journalPath, { ...raw, phase: "rolled_back" });
+    rmSync(lockPath, { force: true });
+    return { phase: "rolled_back", id: raw.id, action: "rollback", previousEnabled: raw.previousEnabled };
+  }
   if (raw.phase === "committed") {
     rmSync(lockPath, { force: true });
     return { phase: "committed" };
@@ -917,7 +919,15 @@ export function rollbackLastGood(opts: {
   id: string;
 }): ProfileTxResult {
   assertTransactionPaths(opts);
-  const lastGood = healLastGoodArtifacts(opts.txDir) ?? join(opts.txDir, "last-good");
+  let lastGood = join(opts.txDir, "last-good");
+  const existingJournal = join(opts.txDir, "journal.json");
+  if (existsSync(existingJournal)) {
+    const journal: unknown = JSON.parse(readFileSync(existingJournal, "utf8"));
+    assertCenterJournalHeader(journal);
+    const next = join(opts.txDir, `last-good-next-${journal.operationId}`);
+    if (journal.lastGoodPhase === "snapshot-ready" && existsSync(next)) lastGood = next;
+    else lastGood = healLastGoodArtifacts(opts.txDir) ?? lastGood;
+  } else lastGood = healLastGoodArtifacts(opts.txDir) ?? lastGood;
   if (!existsSync(lastGood)) {
     throw new PenglaiError("STORE_CORRUPT", "last-good missing");
   }

--- a/packages/plugin-center/src/remotes-security.test.ts
+++ b/packages/plugin-center/src/remotes-security.test.ts
@@ -118,9 +118,11 @@ test("DSH Center remote cannot open installers or plan filesystem deletion", asy
   assert.equal("openVerifiedInstaller" in remote, false);
   assert.equal("planUninstall" in remote, false);
   assert.deepEqual(Object.keys(remote).sort(), [
+    "conversationUsage",
     "disable",
     "download",
     "enable",
+    "exportDiagnostics",
     "installDisabled",
     "installEnable",
     "list",
@@ -314,4 +316,36 @@ test("signed remote package stages only in the app-private registry root", (cont
       }),
     /symlink|outside userData/,
   );
+});
+
+test("staged registry bytes must match the catalog digest, not the declared package hash", () => {
+  const root = mkdtempSync(join(tmpdir(), "penglai-registry-digest-"));
+  const cached = join(root, "cache.tgz");
+  const bytes = Buffer.from("actual-registry-package-bytes");
+  const declared = createHash("sha256").update("other-bytes").digest("hex");
+  writeFileSync(cached, bytes, { mode: 0o600 });
+  const entry = {
+    ...TEST_CATALOG[0]!,
+    id: "@penglai/office-reader",
+    version: "0.1.1",
+    packageFile: "penglai-office-reader-0.1.1.tgz",
+    source: "penglai-plugin-registry" as const,
+    sha256: declared,
+  };
+  assert.throws(
+    () =>
+      stageRegistryPackage({
+        pkg: {
+          id: entry.id,
+          version: entry.version,
+          sha256: declared,
+          size: bytes.length,
+          path: cached,
+        } as never,
+        entry,
+        userDataRoot: root,
+      }),
+    /activation digest mismatch/,
+  );
+  assert.equal(existsSync(join(root, "plugins", "packages", entry.packageFile)), false);
 });

--- a/packages/plugin-center/src/remotes.ts
+++ b/packages/plugin-center/src/remotes.ts
@@ -17,6 +17,8 @@ import { isAbsolute, join, relative, resolve } from "node:path";
 import { TypertRemoteService } from "@deepseek-ai/dsh-typert-protocol";
 import type { Context } from "@deepseek-ai/cordis";
 import { PenglaiError, PenglaiRemote, t } from "@penglai/contracts";
+import { exportRedactedCenterDiagnostics } from "./diagnostics-export.js";
+import { projectOfficialUsage } from "./usage-projection.js";
 import {
   PluginDistributionClient,
   selectCatalogArtifact,
@@ -31,6 +33,9 @@ import {
   runtimePluginTarget,
   OwnerApprovalBroker,
   createHostOwnerDialog,
+  resolvePluginCatalogEntry,
+  writeInstalledOverlay,
+  assertActivationDigest,
   type PluginCatalogEntry,
   type PluginOwnerAction,
   type ProductPluginTarget,
@@ -108,25 +113,30 @@ export interface CenterRemote {
   refreshRegistry(): Promise<unknown>;
   download(id: string): Promise<unknown>;
   installDisabled(id: string, proof?: CenterOwnerProof | string): Promise<unknown>;
+  exportDiagnostics(): unknown;
+  conversationUsage(input?: Record<string, unknown>): unknown;
 }
 
-function catalogEntry(
-  entries: readonly PluginCatalogEntry[],
-  id: string,
-  registry?: PluginDistributionClient,
-  hostTarget: ProductPluginTarget = runtimePluginTarget(),
+function remoteCatalogIdentity(
+  remote: {
+    id: string;
+    version: string;
+    capabilities: string[];
+    permissions: string[];
+    provenanceClass: string;
+    license: string;
+    migration: string;
+    entry: string;
+    clientEntry?: string;
+    networkOrigins?: string[];
+    dataPaths?: string[];
+    nativeCode?: boolean;
+    publisher?: string;
+  },
+  artifactSha256: string,
+  hostTarget: ProductPluginTarget,
+  bundled?: PluginCatalogEntry,
 ): PluginCatalogEntry {
-  const entry = entries.find((candidate) => candidate.id === id);
-  if (entry) return entry;
-  if (!registry) throw new PenglaiError("INVALID_INPUT", "unlisted package");
-  const remote = registry.entry(id);
-  const artifact = selectCatalogArtifact(remote.artifacts, hostTarget);
-  if (remote.dsh.exact !== PINNED_PLUGIN_DSH) {
-    throw new PenglaiError(
-      "SECURITY_POLICY",
-      `${id} DSH pin is not ${PINNED_PLUGIN_DSH}`,
-    );
-  }
   return {
     id: remote.id,
     version: remote.version,
@@ -135,7 +145,7 @@ function catalogEntry(
     platforms: ["darwin-arm64", "darwin-x64", "win32-x64"],
     capabilities: remote.capabilities,
     permissions: remote.permissions,
-    defaultEnabled: false,
+    defaultEnabled: bundled?.defaultEnabled ?? false,
     builtIn: false,
     source: "penglai-plugin-registry",
     provenanceClass:
@@ -149,19 +159,54 @@ function catalogEntry(
       remote.provenanceClass === "community-reviewed"
         ? "community-reviewed"
         : "optional-first-party",
-    userVisible: false,
+    userVisible: bundled?.userVisible ?? false,
     updatePolicy: "signed-overlay",
-    resourcePolicy: "none",
-    sha256: artifact.sha256,
+    resourcePolicy: bundled?.resourcePolicy ?? "none",
+    sha256: artifactSha256,
     target: hostTarget,
     hasClient: Boolean(remote.clientEntry),
     entry: remote.entry,
     ...(remote.clientEntry ? { clientEntry: remote.clientEntry } : {}),
-    networkOrigins: remote.networkOrigins,
-    dataPaths: remote.dataPaths,
-    nativeCode: remote.nativeCode,
-    publisher: remote.publisher,
+    ...(remote.networkOrigins ? { networkOrigins: remote.networkOrigins } : {}),
+    ...(remote.dataPaths ? { dataPaths: remote.dataPaths } : {}),
+    ...(remote.nativeCode !== undefined ? { nativeCode: remote.nativeCode } : {}),
+    ...(remote.publisher ? { publisher: remote.publisher } : {}),
   };
+}
+
+function catalogEntry(
+  entries: readonly PluginCatalogEntry[],
+  id: string,
+  registry?: PluginDistributionClient,
+  hostTarget: ProductPluginTarget = runtimePluginTarget(),
+): PluginCatalogEntry {
+  const bundled = entries.find((candidate) => candidate.id === id);
+  if (registry) {
+    try {
+      const remote = registry.entry(id);
+      const artifact = selectCatalogArtifact(remote.artifacts, hostTarget);
+      const resolved = resolvePluginCatalogEntry({
+        ...(bundled ? { bundled } : {}),
+        remote: { id: remote.id, version: remote.version, sha256: artifact.sha256, dshExact: remote.dsh.exact },
+      });
+      if (resolved.source === "remote") {
+        return remoteCatalogIdentity(remote, artifact.sha256, hostTarget, bundled);
+      }
+    } catch {
+      /* fall through to bundled identity */
+    }
+  }
+  if (bundled) return bundled;
+  if (!registry) throw new PenglaiError("INVALID_INPUT", "unlisted package");
+  const remote = registry.entry(id);
+  const artifact = selectCatalogArtifact(remote.artifacts, hostTarget);
+  if (remote.dsh.exact !== PINNED_PLUGIN_DSH) {
+    throw new PenglaiError(
+      "SECURITY_POLICY",
+      `${id} DSH pin is not ${PINNED_PLUGIN_DSH}`,
+    );
+  }
+  return remoteCatalogIdentity(remote, artifact.sha256, hostTarget);
 }
 
 export function inventoryActivationObservation(
@@ -429,12 +474,7 @@ export function stageRegistryPackage(input: {
   } finally {
     if (packageFd !== undefined) closeSync(packageFd);
   }
-  if (createHash("sha256").update(bytes).digest("hex") !== input.entry.sha256) {
-    throw new PenglaiError(
-      "SECURITY_POLICY",
-      "downloaded package checksum mismatch",
-    );
-  }
+  assertActivationDigest(createHash("sha256").update(bytes).digest("hex"), input.entry.sha256);
   const destination = join(root, input.entry.packageFile);
   if (!isUnder(root, destination)) {
     throw new PenglaiError(
@@ -786,6 +826,24 @@ export function createCenterRemote(opts: {
       finishOwnerAction();
       return out;
     },
+    exportDiagnostics() {
+      return exportRedactedCenterDiagnostics({
+        catalog: opts.host.reconcile(),
+        txDir: opts.txDir,
+      });
+    },
+    conversationUsage(input?: Record<string, unknown>) {
+      const row = input ?? {};
+      return projectOfficialUsage({
+        occupancyTokens: row.occupancyTokens,
+        inputTokens: row.inputTokens,
+        outputTokens: row.outputTokens,
+        cacheReadTokens: row.cacheReadTokens,
+        cacheWriteTokens: row.cacheWriteTokens,
+        estimatedCost: row.estimatedCost,
+        estimatedCurrency: row.estimatedCurrency,
+      });
+    },
   };
 }
 
@@ -840,5 +898,15 @@ export class PenglaiCenterRemote extends TypertRemoteService {
   @PenglaiRemote
   installDisabled(input: { id: string; actionId?: string; receipt?: string; capabilityId?: string }) {
     return this.impl.installDisabled(input.id, input.actionId && input.receipt ? { actionId: input.actionId, receipt: input.receipt } : input.capabilityId);
+  }
+
+  @PenglaiRemote
+  exportDiagnostics() {
+    return this.impl.exportDiagnostics();
+  }
+
+  @PenglaiRemote
+  conversationUsage(input?: Record<string, unknown>) {
+    return this.impl.conversationUsage(input);
   }
 }

--- a/packages/plugin-center/src/usage-projection.ts
+++ b/packages/plugin-center/src/usage-projection.ts
@@ -1,0 +1,39 @@
+type UsageAvailability = "available" | "unavailable" | "estimated";
+
+function finiteCount(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+/** Local copy of the read-only official usage projection so tests do not need a rebuilt contracts dist. */
+export function projectOfficialUsage(input: {
+  occupancyTokens?: unknown;
+  inputTokens?: unknown;
+  outputTokens?: unknown;
+  cacheReadTokens?: unknown;
+  cacheWriteTokens?: unknown;
+  estimatedCost?: unknown;
+  estimatedCurrency?: unknown;
+}) {
+  const occupancy = finiteCount(input.occupancyTokens);
+  const inputTokens = finiteCount(input.inputTokens);
+  const outputTokens = finiteCount(input.outputTokens);
+  const cacheRead = finiteCount(input.cacheReadTokens);
+  const cacheWrite = finiteCount(input.cacheWriteTokens);
+  const amount = typeof input.estimatedCost === "number" && Number.isFinite(input.estimatedCost) ? input.estimatedCost : undefined;
+  const currency = typeof input.estimatedCurrency === "string" && /^[A-Z]{3}$/.test(input.estimatedCurrency) ? input.estimatedCurrency : undefined;
+  return {
+    occupancy: occupancy === undefined ? { availability: "unavailable" as UsageAvailability } : { tokens: occupancy, availability: "available" as const },
+    cumulative:
+      inputTokens === undefined && outputTokens === undefined
+        ? { availability: "unavailable" as const }
+        : { ...(inputTokens !== undefined ? { inputTokens } : {}), ...(outputTokens !== undefined ? { outputTokens } : {}), availability: "available" as const },
+    cache:
+      cacheRead === undefined && cacheWrite === undefined
+        ? { availability: "unavailable" as const }
+        : { ...(cacheRead !== undefined ? { readTokens: cacheRead } : {}), ...(cacheWrite !== undefined ? { writeTokens: cacheWrite } : {}), availability: "available" as const },
+    estimatedCost:
+      amount === undefined
+        ? { availability: "unavailable" as const }
+        : { amount, ...(currency ? { currency } : {}), availability: "estimated" as const },
+  };
+}

--- a/packages/release-identity/src/evidence-v2.test.ts
+++ b/packages/release-identity/src/evidence-v2.test.ts
@@ -2,14 +2,17 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { recordAssertion } from "./assertion.js";
 import {
+  aggregateSlotEvaluations,
   bindArtifactFreshness,
   evaluateEvidenceV2,
+  evaluateOneSlotRecord,
   evidenceKey,
   requiredSlots,
   resolveSubgateVerdict,
   soakSampleSetAccepted,
   tagCollection,
 } from "./evidence-v2.js";
+import { evaluateEvidenceV3 } from "./evidence-v3.js";
 import type { AcceptanceEntry } from "./registry.js";
 
 const HEAD = "ddcafb557652b01def03c62054cfcc4fa8944cb4";
@@ -246,6 +249,42 @@ test("verify:release prefers JSON INCOMPLETE/FAIL over a process that printed PA
   });
   assert.equal(fail.verdict, "FAIL");
   assert.equal(fail.exit, 1);
+});
+
+test("conflicting FAIL and PASS on one slot stay FAIL regardless of record order", () => {
+  const contract = entry("R50-TRUTH-001", "contract/all");
+  const pass = rec({
+    acceptanceId: "R50-TRUTH-001",
+    runnerClass: "contract",
+    target: "source",
+    assertionId: "pass-later",
+    status: "PASS",
+  });
+  const fail = rec({
+    acceptanceId: "R50-TRUTH-001",
+    runnerClass: "contract",
+    target: "source",
+    assertionId: "fail-first",
+    status: "FAIL",
+  });
+  const slot = requiredSlots(contract)[0]!;
+  const passEval = evaluateOneSlotRecord(pass, slot);
+  const failEval = evaluateOneSlotRecord(fail, slot);
+  assert.equal(aggregateSlotEvaluations([passEval, failEval]).status, "FAIL");
+  assert.equal(aggregateSlotEvaluations([failEval, passEval]).status, "FAIL");
+
+  for (const records of [
+    [pass, fail],
+    [fail, pass],
+  ]) {
+    const v2 = evaluateEvidenceV2({ registry: [contract], candidateSha: HEAD, records });
+    assert.equal(v2.results[0]?.status, "FAIL");
+    assert.equal(v2.verdict, "FAIL");
+    assert.equal(v2.ids[0]?.slots[0]?.status, "FAIL");
+    const v3 = evaluateEvidenceV3({ registry: [contract], candidateSha: HEAD, records });
+    assert.equal(v3.results[0]?.status, "FAIL");
+    assert.equal(v3.verdict, "FAIL");
+  }
 });
 
 test("evidence key is acceptanceId+runnerClass+target+assertionId", () => {

--- a/packages/release-identity/src/evidence-v2.ts
+++ b/packages/release-identity/src/evidence-v2.ts
@@ -162,6 +162,42 @@ export function recordFillsSlot(rec: EvidenceV2Record, slot: EvidenceSlot): bool
   return cls === slot.runnerFamily || rec.runnerId === slot.runnerFamily;
 }
 
+const SLOT_STATUS_RANK: ResultStatus[] = ["FAIL", "STALE", "NOT_RUN", "PASS"];
+
+export function evaluateOneSlotRecord(
+  rec: EvidenceV2Record,
+  slot: EvidenceSlot,
+  currentArtifact?: string,
+): SlotEvaluation {
+  if (rec.status === "FAIL") {
+    return { slot, status: "FAIL", reason: "runner reported FAIL", assertionId: rec.assertionId };
+  }
+  if (rec.status !== "PASS") {
+    return { slot, status: "NOT_RUN", reason: `runner reported ${rec.status}`, assertionId: rec.assertionId };
+  }
+  const incomplete = assertPassRecordComplete(rec);
+  if (incomplete) {
+    return { slot, status: "FAIL", reason: incomplete, assertionId: rec.assertionId };
+  }
+  if (rec.artifactSha256 && currentArtifact && rec.artifactSha256 !== currentArtifact) {
+    return {
+      slot,
+      status: "STALE",
+      reason: `artifact ${rec.artifactSha256} != current ${currentArtifact}`,
+      assertionId: rec.assertionId,
+    };
+  }
+  return { slot, status: "PASS", reason: "attributed", assertionId: rec.assertionId };
+}
+
+/** Worst status wins. A later PASS must not hide an earlier FAIL (or the reverse). */
+export function aggregateSlotEvaluations(evals: readonly SlotEvaluation[]): SlotEvaluation {
+  if (evals.length === 0) {
+    throw new Error("aggregateSlotEvaluations requires at least one evaluation");
+  }
+  return [...evals].sort((a, b) => SLOT_STATUS_RANK.indexOf(a.status) - SLOT_STATUS_RANK.indexOf(b.status))[0]!;
+}
+
 export function assertPassRecordComplete(rec: EvidenceV2Record): string | undefined {
   if (!rec.acceptanceId) return "missing acceptanceId";
   if (!rec.assertionId) return "missing assertionId";
@@ -273,8 +309,7 @@ export function evaluateEvidenceV2(opts: {
       }
       const usable = hits.filter((rec) => rec.candidateSourceSha === opts.candidateSha);
       const staleHits = hits.filter((rec) => rec.candidateSourceSha !== opts.candidateSha);
-      const rec = usable[0];
-      if (!rec) {
+      if (usable.length === 0) {
         const fromRunner = staleHits.some(
           (hit) => hit.collectionClass === "installed-runner" || hit.collectionClass === "soak-runner" || hit.collectionClass === "live-runner" || hit.collectionClass === "export-runner",
         );
@@ -299,29 +334,12 @@ export function evaluateEvidenceV2(opts: {
         }
         continue;
       }
-      // A runner that reports FAIL for this slot must surface as FAIL, not be
-      // silently dropped to NOT_RUN (which would hide the failure).
-      if (rec.status === "FAIL") {
-        slotEvals.push({ slot, status: "FAIL", reason: "runner reported FAIL", assertionId: rec.assertionId });
-        fail = true;
-        continue;
-      }
-      if (rec.status !== "PASS") {
-        slotEvals.push({ slot, status: "NOT_RUN", reason: `runner reported ${rec.status}`, assertionId: rec.assertionId });
-        continue;
-      }
-      const incomplete = assertPassRecordComplete(rec);
-      if (incomplete) {
-        slotEvals.push({ slot, status: "FAIL", reason: incomplete, assertionId: rec.assertionId });
-        fail = true;
-        continue;
-      }
-      if (rec.artifactSha256 && opts.currentArtifactByTarget?.[slot.target] && rec.artifactSha256 !== opts.currentArtifactByTarget[slot.target]) {
-        slotEvals.push({ slot, status: "STALE", reason: `artifact ${rec.artifactSha256} != current ${opts.currentArtifactByTarget[slot.target]}`, assertionId: rec.assertionId });
-        stale = true;
-        continue;
-      }
-      slotEvals.push({ slot, status: "PASS", reason: "attributed", assertionId: rec.assertionId });
+      const chosen = aggregateSlotEvaluations(
+        usable.map((hit) => evaluateOneSlotRecord(hit, slot, opts.currentArtifactByTarget?.[slot.target])),
+      );
+      slotEvals.push(chosen);
+      if (chosen.status === "FAIL") fail = true;
+      else if (chosen.status === "STALE") stale = true;
     }
     const missingTargets = slotEvals.filter((s) => s.status === "NOT_RUN").map((s) => s.slot.target);
     let status: ResultStatus = "PASS";

--- a/packages/release-identity/src/freeze.test.ts
+++ b/packages/release-identity/src/freeze.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { PenglaiError } from "@penglai/contracts";
+import { PRODUCT_VERSION } from "./pins.js";
+import {
+  assertCohortFreeze,
+  COHORT_FREEZE_KIND,
+  REJECTED_DSH_SUCCESSOR_TAG,
+  type CohortFreezeRecord,
+} from "./freeze.js";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+function loadFreeze(): CohortFreezeRecord {
+  return JSON.parse(readFileSync(join(root, "docs/0.5.11/COHORT_FREEZE.json"), "utf8")) as CohortFreezeRecord;
+}
+
+function loadContract() {
+  return JSON.parse(readFileSync(join(root, "release-contract.json"), "utf8")) as {
+    version: string;
+    dshVersion: string;
+    dshSource: { tag: string; commit: string; packageCount: number; closureManifestSha256?: string; cliTarballSha256?: string };
+    publication: { tag: string };
+  };
+}
+
+test("0.5.11 development freeze retains the rc.1 cohort and does not retitle 0.5.10", () => {
+  const freeze = loadFreeze();
+  const releaseContract = loadContract();
+  const productVersion = JSON.parse(readFileSync(join(root, "package.json"), "utf8")).version as string;
+  assertCohortFreeze({ freeze, productVersion, releaseContract });
+  assert.equal(freeze.kind, COHORT_FREEZE_KIND);
+  assert.equal(freeze.dsh.rejectedSuccessor.tag, REJECTED_DSH_SUCCESSOR_TAG);
+  assert.equal(productVersion, PRODUCT_VERSION);
+  assert.equal(releaseContract.publication.tag, "v0.5.10");
+  assert.equal(readFileSync(join(root, "packages/contracts/src/index.ts"), "utf8").includes('export const RELEASE = "0.5.10"'), true);
+});
+
+test("cohort freeze rejects mixed DSH generations and a silent 0.5.11 identity retitle", () => {
+  const freeze = loadFreeze();
+  const releaseContract = loadContract();
+  const productVersion = "0.5.10";
+  assert.throws(
+    () =>
+      assertCohortFreeze({
+        freeze: {
+          ...freeze,
+          dsh: { ...freeze.dsh, version: "0.1.3-alpha.1" },
+        },
+        productVersion,
+        releaseContract,
+      }),
+    (error: unknown) => error instanceof PenglaiError && /pinned DSH identity/.test(error.message),
+  );
+  assert.throws(
+    () =>
+      assertCohortFreeze({
+        freeze: {
+          ...freeze,
+          development: { ...freeze.development, identityRetitled: true as never },
+        },
+        productVersion,
+        releaseContract,
+      }),
+    /identity retitle requires publication authorization/,
+  );
+  assert.throws(
+    () =>
+      assertCohortFreeze({
+        freeze: {
+          ...freeze,
+          publicRelease: { ...freeze.publicRelease, productVersion: "0.5.11" },
+        },
+        productVersion,
+        releaseContract,
+      }),
+    /public release identity drifted/,
+  );
+});

--- a/packages/release-identity/src/freeze.ts
+++ b/packages/release-identity/src/freeze.ts
@@ -3,8 +3,13 @@ import {
   PINNED_DSH,
   PINNED_DSH_COMMIT,
   PINNED_DSH_CLOSURE_MANIFEST_SHA256,
+  PINNED_DSH_CLOSURE_PACKAGE_COUNT,
+  PINNED_DSH_TAG,
   PINNED_DSH_TARBALL_SHA256,
   PINNED_ELECTRON,
+  PINNED_NODE,
+  PINNED_PNPM,
+  PRODUCT_VERSION,
   PINNED_LARK_COMMIT,
   PINNED_LARK_SDK,
   PINNED_LIBOPUS_WASM,
@@ -16,7 +21,6 @@ import {
   PINNED_MOSS_RUNTIME_SHA256,
   PINNED_MOSS_TTS_COMMIT,
   PINNED_MOSS_TTS_MODEL_REVISION,
-  PINNED_NODE,
   PINNED_ONNXRUNTIME_NODE,
   PINNED_ONNXRUNTIME_NODE_INTEGRITY,
   PINNED_SHERPA_ONNX,
@@ -145,5 +149,100 @@ export function assertNoLatestDownloads(text: string): void {
   const documentedRefusal = ["拒绝", "禁止", "must not", "不得"].some((token) => lower.includes(token));
   if (unsafeLatestUrl && !documentedRefusal) {
     throw new PenglaiError("SECURITY_POLICY", "unqualified latest download URL");
+  }
+}
+
+export const COHORT_FREEZE_KIND = "penglai-0.5.11-development-cohort-freeze" as const;
+export const REJECTED_DSH_SUCCESSOR_TAG = "dsh-v0.1.3-alpha.1" as const;
+
+export interface CohortFreezeRecord {
+  schema: 1;
+  kind: typeof COHORT_FREEZE_KIND;
+  status: "development-frozen";
+  publicRelease: { productVersion: string; tag: string; immutable: true };
+  development: {
+    versionLabel: "0.5.11";
+    publicationAuthorized: false;
+    identityRetitled: false;
+  };
+  dsh: {
+    version: string;
+    tag: string;
+    commit: string;
+    packageCount: number;
+    tarballSha256: string;
+    closureManifestSha256: string;
+    rejectedSuccessor: { tag: string; reason: string };
+  };
+  runtime: { node: string; electron: string; pnpm: string };
+  migration: {
+    homeGeneration: string;
+    center: string;
+    windowsUpgrade: string;
+    mixedDshGenerations: "forbidden";
+  };
+}
+
+export function assertCohortFreeze(input: {
+  freeze: CohortFreezeRecord;
+  productVersion: string;
+  releaseContract: {
+    version: string;
+    dshVersion: string;
+    dshSource: { tag: string; commit: string; packageCount: number; closureManifestSha256?: string; cliTarballSha256?: string };
+  };
+}): void {
+  const { freeze, productVersion, releaseContract } = input;
+  const pins = freezePins();
+  if (freeze.schema !== 1 || freeze.kind !== COHORT_FREEZE_KIND || freeze.status !== "development-frozen") {
+    throw new PenglaiError("INVALID_INPUT", "cohort freeze identity");
+  }
+  if (freeze.publicRelease.immutable !== true) {
+    throw new PenglaiError("SECURITY_POLICY", "published 0.5.10 identity must stay immutable");
+  }
+  if (
+    freeze.publicRelease.productVersion !== PRODUCT_VERSION ||
+    freeze.publicRelease.productVersion !== productVersion ||
+    freeze.publicRelease.productVersion !== releaseContract.version ||
+    freeze.publicRelease.tag !== `v${PRODUCT_VERSION}`
+  ) {
+    throw new PenglaiError("SECURITY_POLICY", "public release identity drifted from 0.5.10 freeze");
+  }
+  if (freeze.development.publicationAuthorized !== false || freeze.development.identityRetitled !== false) {
+    throw new PenglaiError("SECURITY_POLICY", "0.5.11 identity retitle requires publication authorization");
+  }
+  if (
+    freeze.dsh.version !== pins.dsh ||
+    freeze.dsh.tag !== PINNED_DSH_TAG ||
+    freeze.dsh.commit !== pins.dshCommit ||
+    freeze.dsh.packageCount !== PINNED_DSH_CLOSURE_PACKAGE_COUNT ||
+    freeze.dsh.tarballSha256 !== pins.dshTarballSha256 ||
+    freeze.dsh.closureManifestSha256 !== pins.dshClosureManifestSha256
+  ) {
+    throw new PenglaiError("DSH_CONTRACT_DRIFT", "cohort freeze does not match pinned DSH identity");
+  }
+  if (
+    freeze.dsh.version !== releaseContract.dshVersion ||
+    freeze.dsh.tag !== releaseContract.dshSource.tag ||
+    freeze.dsh.commit !== releaseContract.dshSource.commit ||
+    freeze.dsh.packageCount !== releaseContract.dshSource.packageCount
+  ) {
+    throw new PenglaiError("DSH_CONTRACT_DRIFT", "cohort freeze does not match release-contract DSH identity");
+  }
+  if (freeze.dsh.rejectedSuccessor.tag !== REJECTED_DSH_SUCCESSOR_TAG || !freeze.dsh.rejectedSuccessor.reason.trim()) {
+    throw new PenglaiError("SECURITY_POLICY", "incomplete DSH successor must stay rejected");
+  }
+  if (
+    freeze.runtime.node !== PINNED_NODE ||
+    freeze.runtime.electron !== PINNED_ELECTRON ||
+    freeze.runtime.pnpm !== PINNED_PNPM
+  ) {
+    throw new PenglaiError("DSH_CONTRACT_DRIFT", "cohort freeze runtime pins drifted");
+  }
+  if (freeze.migration.mixedDshGenerations !== "forbidden") {
+    throw new PenglaiError("SECURITY_POLICY", "mixed DSH generations must stay forbidden");
+  }
+  if (!freeze.migration.homeGeneration || !freeze.migration.center || !freeze.migration.windowsUpgrade) {
+    throw new PenglaiError("INVALID_INPUT", "cohort freeze missing migration/rollback design");
   }
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -19,7 +19,7 @@ import { userInfo } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import { createConnection, createServer } from "node:net";
-import { PenglaiError, readExactRegularFile } from "@penglai/contracts";
+import { PenglaiError, readExactRegularFile, assertCenterJournalHeader, centerProfileWasUntouched } from "@penglai/contracts";
 import {
   clearIdentity,
   killIdentity,
@@ -38,8 +38,10 @@ import {
   runtimePluginTarget,
 } from "./plugin-catalog.js";
 import { extractTarGz } from "./safe-tar.js";
-import { applyWindowsCredentialAcl, readOwnedWindowsJobReport, spawnOwnedDshProcess } from "./windows-host.js";
+import { applyWindowsCredentialAcl, readOwnedWindowsJobReport, spawnOwnedDshProcess, windowsNativeHostStatus } from "./windows-host.js";
 import { writeFileAtomic } from "./permissions.js";
+import { compareSemver } from "./update.js";
+import { readInstalledOverlay, shouldPreserveInstalledPlugin, writeInstalledOverlay } from "./plugin-resolution.js";
 import {
   IDLE_SUPERVISOR_RECOVERY,
   nextSupervisorHealthDecision,
@@ -525,6 +527,27 @@ export function installFirstPartyPlugins(
   for (const entry of catalog.entries) {
     const short = entry.id.replace("@penglai/", "");
     const dest = join(nm, short);
+    if (existsSync(join(dest, "package.json"))) {
+      try {
+        const installed = JSON.parse(readFileSync(join(dest, "package.json"), "utf8")) as { version?: string };
+        const overlay = readInstalledOverlay(dest);
+        if (
+          shouldPreserveInstalledPlugin({
+            bundledVersion: entry.version,
+            ...(overlay?.version ?? installed.version
+              ? { installedVersion: overlay?.version ?? installed.version }
+              : {}),
+            ...(overlay?.sha256 ? { installedSha256: overlay.sha256 } : {}),
+            ...(entry.sha256 ? { bundledSha256: entry.sha256 } : {}),
+          })
+        ) {
+          continue;
+        }
+        if (typeof installed.version === "string" && compareSemver(installed.version, entry.version) > 0) continue;
+      } catch {
+        /* invalid installed manifest is replaced by the bundled catalog entry */
+      }
+    }
     const shouldInstall =
       entry.defaultEnabled ||
       requested.has(entry.id) ||
@@ -545,6 +568,7 @@ export function installFirstPartyPlugins(
     assertPluginJsClosure(inner, id);
     rmSync(dest, { recursive: true, force: true });
     copyDir(inner, dest);
+    writeInstalledOverlay(dest, { version: entry.version, sha256: entry.sha256 });
     rmSync(tmp, { recursive: true, force: true });
   }
 }
@@ -825,11 +849,10 @@ export function recoverCenterProfileTransaction(user: UserLayout): CenterPreboot
   const txDir = join(user.root, "profiles", "center-tx");
   const journalPath = join(txDir, "journal.json");
   const lockPath = join(txDir, "active.lock");
-  const lastGood = join(txDir, "last-good");
+  let lastGood = join(txDir, "last-good");
   const activationBackup = `${user.profileWeb}.center-backup`;
   assertOwnedCenterPath(user, txDir, "Center transaction directory");
   assertOwnedCenterPath(user, user.profileWeb, "Center profile");
-  healCenterLastGoodArtifacts(txDir);
   if (!existsSync(journalPath)) {
     rmSync(lockPath, { force: true });
     return { phase: "idle" };
@@ -841,6 +864,17 @@ export function recoverCenterProfileTransaction(user: UserLayout): CenterPreboot
     id?: unknown;
     previousEnabled?: unknown;
   };
+  assertCenterJournalHeader(raw);
+  if (centerProfileWasUntouched(raw)) {
+    const partial = join(txDir, `last-good-next-${raw.operationId}`);
+    if (raw.lastGoodPhase === "snapshot") {
+      assertOwnedCenterPath(user, partial, "Center partial snapshot");
+      rmSync(partial, { recursive: true, force: true });
+    }
+    atomicJson(journalPath, { ...raw, phase: "rolled_back", recoveredAt: new Date().toISOString() });
+    rmSync(lockPath, { force: true });
+    return { phase: "rolled_back", id: raw.id, previousEnabled: raw.previousEnabled };
+  }
   if (raw.phase === "committed" || raw.phase === "rolled_back") {
     rmSync(lockPath, { force: true });
     if (raw.phase === "committed") {
@@ -853,7 +887,6 @@ export function recoverCenterProfileTransaction(user: UserLayout): CenterPreboot
   const knownId = FIRST_PARTY_PLUGIN_METADATA.some((entry) => entry.id === raw.id);
   if (
     !active ||
-    raw.schema !== 2 ||
     typeof raw.operationId !== "string" ||
     typeof raw.id !== "string" ||
     !knownId ||
@@ -861,6 +894,9 @@ export function recoverCenterProfileTransaction(user: UserLayout): CenterPreboot
   ) {
     throw new PenglaiError("STORE_CORRUPT", "Center preboot recovery journal invalid");
   }
+  const completedNext = join(txDir, `last-good-next-${raw.operationId}`);
+  if (raw.lastGoodPhase === "snapshot-ready" && existsSync(completedNext)) lastGood = completedNext;
+  else healCenterLastGoodArtifacts(txDir);
   assertOwnedCenterPath(user, lastGood, "Center last-good profile");
   if (!existsSync(lastGood) || !lstatSync(lastGood).isDirectory()) {
     throw new PenglaiError("STORE_CORRUPT", "Center last-good profile missing");
@@ -1186,7 +1222,7 @@ export function killStaleSupervisor(layout: RuntimeLayout, user: UserLayout): vo
     killIdentity({ ...previous, appRoot: layout.appRoot }, "SIGKILL");
     clearIdentity(user);
   }
-  reapDshOrphans(layout);
+  reapDshOrphans(layout, undefined, user);
 }
 
 /**
@@ -1485,7 +1521,7 @@ export class EmbeddedDshSupervisor {
     if (identity) killIdentity(identity, "SIGKILL");
     else if (child?.pid) killProcessTree(child.pid, "SIGKILL");
     if (child) await waitChildExit(child, 1000);
-    reapDshOrphans(this.layout);
+    reapDshOrphans(this.layout, undefined, user);
     if (user) clearIdentity(user);
     this.child = undefined;
     this.identity = undefined;
@@ -1597,6 +1633,8 @@ export class EmbeddedDshSupervisor {
         owner: report.owner,
         jobAssigned: true,
         supervisorPid,
+        supervisorStartMs: readProcessStartMs(supervisorPid, "win32", this.layout.appRoot),
+        supervisorExecutable: windowsNativeHostStatus("win32", this.layout.appRoot).executable ?? "",
       };
       writeIdentity(user, this.identity);
     } else {

--- a/packages/runtime/src/leftover.test.ts
+++ b/packages/runtime/src/leftover.test.ts
@@ -228,6 +228,37 @@ test("R50-DIST: packaged identity is Penglai 0.5.10 and Windows NSIS stays curre
   assertWindowsNsisScript(readFileSync(new URL("../../../scripts/nsis/Penglai.nsi", import.meta.url), "utf8"));
 });
 
+test("Windows upgrade refuses the old live-tree delete-then-copy pattern", async () => {
+  const { assertWindowsUpgradeStaging, assertWindowsNsisScript } = await import("./packaging.js");
+  const live = readFileSync(new URL("../../../scripts/nsis/Penglai.nsi", import.meta.url), "utf8");
+  assertWindowsUpgradeStaging(live);
+  assertWindowsNsisScript(live);
+  const oldLiveDeleteThenCopy = `
+RequestExecutionLevel user
+Section "Penglai"
+  RMDir /r "$LOCALAPPDATA\\Penglai\\app\\0.5"
+  SetOutPath "$INSTDIR"
+  File /r payload\\*.*
+SectionEnd
+Section "Uninstall"
+SectionEnd
+`;
+  assert.throws(
+    () => assertWindowsUpgradeStaging(oldLiveDeleteThenCopy),
+    /stage into INSTDIR\.pending|must not delete the live app tree|copy the payload before renaming/,
+  );
+  const copyAfterRename = `
+    Rename "$INSTDIR" "$INSTDIR.previous"
+    StrCpy $R2 "$INSTDIR.pending"
+    SetOutPath "$R2"
+    upgrade_copy_failed:
+    previous install was left in place
+    upgrade_activate_failed:
+    $INSTDIR.previous
+  `;
+  assert.throws(() => assertWindowsUpgradeStaging(copyAfterRename), /copy the payload before renaming/);
+});
+
 test("R50-SEC: Windows Job/ACL contract refuses POSIX impersonation", async () => {
   const { applyWindowsCredentialAcl, assertWindowsJobHonest, refusePosixModeAsWindowsAcl, windowsJobObjectPlan } =
     await import("./windows-host.js");

--- a/packages/runtime/src/lifecycle.test.ts
+++ b/packages/runtime/src/lifecycle.test.ts
@@ -294,3 +294,22 @@ test("managed layout keeps settings DSH credentials memory and cache as disjoint
     /workspace never deleted/,
   );
 });
+
+test("deletion rejects parent symlink escapes and canonical Workspace aliases", async () => {
+  const { mkdirSync, mkdtempSync, symlinkSync, writeFileSync, readFileSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const root = mkdtempSync(join(tmpdir(), "penglai-delete-parent-"));
+  const data = join(root, "data");
+  const workspace = join(root, "workspace");
+  mkdirSync(data);
+  mkdirSync(workspace);
+  writeFileSync(join(workspace, "keep.txt"), "keep");
+  symlinkSync(workspace, join(data, "nested"), process.platform === "win32" ? "junction" : undefined);
+  assert.throws(() => assertSafeDeletePath(join(data, "nested", "keep.txt"), data, [workspace], []), /workspace never deleted/);
+  assert.throws(() => assertSafeDeletePath(join(data, "nested", "keep.txt"), data, [], []), /canonical|symlink/);
+  const alias = join(root, "data-alias");
+  symlinkSync(workspace, alias, process.platform === "win32" ? "junction" : undefined);
+  assert.throws(() => assertSafeDeletePath(join(alias, "keep.txt"), alias, [workspace], []), /workspace never deleted/);
+  assert.equal(readFileSync(join(workspace, "keep.txt"), "utf8"), "keep");
+});

--- a/packages/runtime/src/owner-broker.test.ts
+++ b/packages/runtime/src/owner-broker.test.ts
@@ -124,6 +124,36 @@ test("R56-OWN-007 renderer may pass only actionId and Main rejects substitute fi
   }, /RENDERER_CONTRACT/);
 });
 
+test("two Owner brokers sharing one root cannot consume the same receipt twice", async () => {
+  const root = mkdtempSync(join(tmpdir(), "penglai-broker-two-"));
+  const first = broker(root);
+  const proposal = first.owner.createProposal({
+    action: "office.commit",
+    pluginId: "@penglai/office",
+    objectId: "job-shared",
+    sourceDigest: "a".repeat(64),
+  });
+  const approved = await first.owner.requestOwnerApproval(proposal.actionId);
+  if (approved.decision !== "approved") throw new Error("expected receipt");
+  const second = broker(root);
+  const input = {
+    receipt: approved.receipt,
+    intentDigest: first.owner.inspect(proposal.actionId).intentDigest,
+    actionId: proposal.actionId,
+  };
+  const outcomes = await Promise.allSettled([
+    Promise.resolve().then(() => first.owner.consumeApproval(input)),
+    Promise.resolve().then(() => second.owner.consumeApproval(input)),
+  ]);
+  const reserved = outcomes.filter((row) => row.status === "fulfilled");
+  const rejected = outcomes.filter((row) => row.status === "rejected");
+  assert.equal(reserved.length, 1);
+  assert.equal(rejected.length, 1);
+  assert.match(String((rejected[0] as PromiseRejectedResult).reason), /REPLAY/);
+  assert.equal(first.owner.inspect(proposal.actionId).state, "reserved");
+  assert.equal(second.owner.inspect(proposal.actionId).state, "reserved");
+});
+
 test("R56-OWN-008 destination labels cannot carry paths or secrets", () => {
   const root = mkdtempSync(join(tmpdir(), "penglai-broker-label-"));
   const { owner } = broker(root);

--- a/packages/runtime/src/owner-broker.ts
+++ b/packages/runtime/src/owner-broker.ts
@@ -284,6 +284,14 @@ export class OwnerApprovalBroker {
       ...(row.intent.workspaceId ? { workspaceLabel: row.intent.workspaceId } : {}),
       ...(row.intent.destinationLabel ? { destinationLabel: row.intent.destinationLabel } : {}),
     });
+    const current = this.load(actionId);
+    if (current.state !== "proposed" || current.intentDigest !== row.intentDigest) fail("OWNER_PROPOSAL_STATE");
+    if (Date.parse(current.intent.expiresAt) <= this.now()) {
+      current.state = "expired";
+      this.save(current);
+      this.log(current, "expired");
+      fail("OWNER_PROPOSAL_EXPIRED");
+    }
     if (decision !== "approved") {
       row.state = "denied";
       this.save(row);

--- a/packages/runtime/src/owner-dialog.test.ts
+++ b/packages/runtime/src/owner-dialog.test.ts
@@ -54,3 +54,25 @@ test("host owner dialog allow yields a one-shot receipt", async () => {
   });
   assert.equal(owner.inspect(proposal.actionId).state, "committed");
 });
+
+test("concurrent Main drains present a request once and produce one consumable receipt", async () => {
+  const root = mkdtempSync(join(tmpdir(), "penglai-owner-dialog-concurrent-"));
+  const owner = new OwnerApprovalBroker(root, { dialog: createHostOwnerDialog(root, { timeoutMs: 2_000, pollMs: 5 }) });
+  const proposal = owner.createProposal({ action: "office.commit", pluginId: "@penglai/office", objectId: "job", sourceDigest: "a".repeat(64) });
+  const pending = owner.requestOwnerApproval(proposal.actionId);
+  let calls = 0;
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  const dialog = async () => { calls++; await gate; return "approved" as const; };
+  const first = drainOwnerDialogRequests(root, dialog);
+  const second = drainOwnerDialogRequests(root, dialog);
+  await Promise.resolve();
+  assert.equal(calls, 1);
+  release();
+  await Promise.all([first, second]);
+  const decision = await pending;
+  if (decision.decision !== "approved") throw new Error("expected receipt");
+  const input = { receipt: decision.receipt, actionId: proposal.actionId, intentDigest: owner.inspect(proposal.actionId).intentDigest };
+  owner.consumeApproval(input);
+  assert.throws(() => owner.consumeApproval(input), /REPLAY/);
+});

--- a/packages/runtime/src/owner-dialog.ts
+++ b/packages/runtime/src/owner-dialog.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { OwnerDialogPort, OwnerDialogRequest } from "./owner-broker.js";
 
@@ -50,16 +50,31 @@ export function createHostOwnerDialog(
   };
 }
 
-export async function drainOwnerDialogRequests(root: string, dialog: OwnerDialogPort): Promise<number> {
+const activeDrains = new Map<string, Promise<number>>();
+
+export function drainOwnerDialogRequests(root: string, dialog: OwnerDialogPort): Promise<number> {
+  const key = resolve(root);
+  const active = activeDrains.get(key);
+  if (active) return active;
+  const drain = Promise.resolve().then(() => drainRequests(key, dialog)).finally(() => {
+    if (activeDrains.get(key) === drain) activeDrains.delete(key);
+  });
+  activeDrains.set(key, drain);
+  return drain;
+}
+
+async function drainRequests(root: string, dialog: OwnerDialogPort): Promise<number> {
   const dir = join(root, ...REQUEST_DIR);
   if (!existsSync(dir)) return 0;
   let handled = 0;
   for (const name of readdirSync(dir)) {
     if (!name.endsWith(".json") || name.includes(".tmp")) continue;
     const path = join(dir, name);
-    const raw = JSON.parse(readFileSync(path, "utf8")) as OwnerDialogRequest;
+    const source = readFileSync(path, "utf8");
+    const raw = JSON.parse(source) as OwnerDialogRequest;
     if (!raw?.actionId || !raw.action || !raw.pluginId) continue;
     const decision = await dialog(raw);
+    if (!existsSync(path) || readFileSync(path, "utf8") !== source) continue;
     writeJsonAtomic(ownerDialogResultPath(root, raw.actionId), { decision });
     rmSync(path, { force: true });
     handled += 1;

--- a/packages/runtime/src/packaging.ts
+++ b/packages/runtime/src/packaging.ts
@@ -140,6 +140,28 @@ export function assertWindowsNsisScript(script: string): void {
   if (/deletion-capability\.json|delete-plan|\$\{USERDATA\}/.test(script)) {
     throw new Error("NSIS uninstaller must never receive or execute a user-data deletion plan");
   }
+  assertWindowsUpgradeStaging(script);
+}
+
+/** Old 0.5.10 pattern deleted the live app tree then copied. Upgrade must stage first. */
+export function assertWindowsUpgradeStaging(script: string): void {
+  if (!/\$INSTDIR\.pending/.test(script)) {
+    throw new Error("Windows upgrade must stage into INSTDIR.pending before touching the live app");
+  }
+  if (!/upgrade_copy_failed/.test(script) || !/previous install was left in place/.test(script)) {
+    throw new Error("Windows upgrade must keep the previous program when the copy fails");
+  }
+  if (!/upgrade_activate_failed/.test(script) || !/\$INSTDIR\.previous/.test(script)) {
+    throw new Error("Windows upgrade must restore INSTDIR.previous when activation fails");
+  }
+  const pendingOut = script.search(/SetOutPath\s+"\$R2"/);
+  const liveRename = script.search(/Rename\s+"\$INSTDIR"\s+"\$INSTDIR\.previous"/);
+  if (pendingOut < 0 || liveRename < 0 || pendingOut > liveRename) {
+    throw new Error("Windows upgrade must copy the payload before renaming the live app directory");
+  }
+  if (/RMDir\s+\/r\s+"\$LOCALAPPDATA\\Penglai\\app\\0\.5"/.test(script)) {
+    throw new Error("Windows upgrade must not delete the live app tree before the new payload exists");
+  }
 }
 
 export const CROSS_BUILD_TARGETS = [

--- a/packages/runtime/src/plugin-host.ts
+++ b/packages/runtime/src/plugin-host.ts
@@ -1,5 +1,6 @@
 /** Plugin-safe runtime surface. Packed plugins must not import the host barrel. */
 export * from "./plugin-catalog.js";
+export * from "./plugin-resolution.js";
 export * from "./inventory-proof.js";
 export * from "./safe-tar.js";
 export * from "./plugin-owner.js";

--- a/packages/runtime/src/plugin-resolution.test.ts
+++ b/packages/runtime/src/plugin-resolution.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { PenglaiError } from "@penglai/contracts";
+import { FIRST_PARTY_PLUGIN_METADATA, PINNED_PLUGIN_DSH, type PluginCatalogEntry } from "./plugin-catalog.js";
+import {
+  assertActivationDigest,
+  comparePluginVersion,
+  overlayIdentityPath,
+  readInstalledOverlay,
+  resolvePluginCatalogEntry,
+  shouldPreserveInstalledPlugin,
+  writeInstalledOverlay,
+} from "./plugin-resolution.js";
+
+const bundled: PluginCatalogEntry = {
+  ...FIRST_PARTY_PLUGIN_METADATA.find((entry) => entry.id === "@penglai/office")!,
+  sha256: "a".repeat(64),
+  target: "darwin-arm64",
+  hasClient: true,
+};
+
+test("newer signed remote wins; older, equal, or DSH-mismatched remote keeps bundled", () => {
+  const newer = resolvePluginCatalogEntry({
+    bundled,
+    remote: {
+      id: bundled.id,
+      version: "0.5.11",
+      sha256: "b".repeat(64),
+      dshExact: PINNED_PLUGIN_DSH,
+    },
+  });
+  assert.deepEqual(newer, {
+    source: "remote",
+    version: "0.5.11",
+    sha256: "b".repeat(64),
+    id: bundled.id,
+  });
+
+  const older = resolvePluginCatalogEntry({
+    bundled,
+    remote: {
+      id: bundled.id,
+      version: "0.5.9",
+      sha256: "c".repeat(64),
+      dshExact: PINNED_PLUGIN_DSH,
+    },
+  });
+  assert.equal(older.source, "bundled");
+  assert.equal(older.version, bundled.version);
+  assert.equal(older.sha256, bundled.sha256);
+
+  const equal = resolvePluginCatalogEntry({
+    bundled,
+    remote: {
+      id: bundled.id,
+      version: bundled.version,
+      sha256: "d".repeat(64),
+      dshExact: PINNED_PLUGIN_DSH,
+    },
+  });
+  assert.equal(equal.source, "bundled");
+
+  const mismatchedDsh = resolvePluginCatalogEntry({
+    bundled,
+    remote: {
+      id: bundled.id,
+      version: "0.5.11",
+      sha256: "e".repeat(64),
+      dshExact: "0.1.3-alpha.1",
+    },
+  });
+  assert.equal(mismatchedDsh.source, "bundled");
+  assert.equal(mismatchedDsh.version, bundled.version);
+
+  assert.throws(
+    () =>
+      resolvePluginCatalogEntry({
+        remote: {
+          id: "@penglai/office",
+          version: "0.5.11",
+          sha256: "f".repeat(64),
+          dshExact: "0.1.3-alpha.1",
+        },
+      }),
+    (error: unknown) => error instanceof PenglaiError && /DSH pin/.test(error.message),
+  );
+  assert.throws(
+    () =>
+      resolvePluginCatalogEntry({
+        bundled,
+        remote: {
+          id: bundled.id,
+          version: "0.5.11",
+          sha256: "not-a-digest",
+          dshExact: PINNED_PLUGIN_DSH,
+        },
+      }),
+    /digest required/,
+  );
+  assert.equal(comparePluginVersion("0.5.11", "0.5.10"), 1);
+  assert.equal(comparePluginVersion("0.5.10", "0.5.10.1"), -1);
+});
+
+test("boot reseeding preserves a newer overlay and refreshes same-version first-party tarballs", () => {
+  assert.equal(
+    shouldPreserveInstalledPlugin({
+      installedVersion: "0.5.11",
+      installedSha256: "b".repeat(64),
+      bundledVersion: "0.5.10",
+      bundledSha256: "a".repeat(64),
+    }),
+    true,
+  );
+  assert.equal(
+    shouldPreserveInstalledPlugin({
+      installedVersion: "0.5.10",
+      installedSha256: "c".repeat(64),
+      bundledVersion: "0.5.10",
+      bundledSha256: "a".repeat(64),
+    }),
+    false,
+  );
+  assert.equal(
+    shouldPreserveInstalledPlugin({
+      installedVersion: "0.5.10",
+      installedSha256: "a".repeat(64),
+      bundledVersion: "0.5.10",
+      bundledSha256: "a".repeat(64),
+    }),
+    false,
+  );
+  assert.equal(
+    shouldPreserveInstalledPlugin({
+      installedVersion: "0.5.9",
+      installedSha256: "a".repeat(64),
+      bundledVersion: "0.5.10",
+      bundledSha256: "a".repeat(64),
+    }),
+    false,
+  );
+  assert.equal(shouldPreserveInstalledPlugin({ bundledVersion: "0.5.10" }), false);
+});
+
+test("activation digest must match the staged bytes, not a declared identity", () => {
+  const expected = "a".repeat(64);
+  assertActivationDigest(expected, expected);
+  assert.throws(() => assertActivationDigest("b".repeat(64), expected), /activation digest mismatch/);
+  assert.throws(() => assertActivationDigest("short", expected), /activation digest mismatch/);
+  const dest = mkdtempSync(join(tmpdir(), "penglai-overlay-"));
+  writeInstalledOverlay(dest, { version: "0.5.11", sha256: expected });
+  assert.deepEqual(readInstalledOverlay(dest), { version: "0.5.11", sha256: expected });
+  assert.match(readFileSync(overlayIdentityPath(dest), "utf8"), /"schema":1/);
+  assert.throws(() => writeInstalledOverlay(dest, { version: "0.5.11", sha256: "nope" }), /overlay digest required/);
+});
+
+test("first-party install path records overlay identity and skips a newer overlay", () => {
+  const src = readFileSync(new URL("./index.ts", import.meta.url), "utf8");
+  assert.match(src, /shouldPreserveInstalledPlugin\(/);
+  assert.match(src, /writeInstalledOverlay\(dest, \{ version: entry\.version, sha256: entry\.sha256 \}\)/);
+  const remotes = readFileSync(new URL("../../plugin-center/src/remotes.ts", import.meta.url), "utf8");
+  assert.match(remotes, /resolvePluginCatalogEntry\(/);
+  assert.match(remotes, /assertActivationDigest\(/);
+});

--- a/packages/runtime/src/plugin-resolution.ts
+++ b/packages/runtime/src/plugin-resolution.ts
@@ -1,0 +1,80 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { PenglaiError } from "@penglai/contracts";
+import { PINNED_PLUGIN_DSH, type PluginCatalogEntry } from "./plugin-catalog.js";
+
+export function comparePluginVersion(a: string, b: string): number {
+  const left = a.split(".").map((part) => Number.parseInt(part, 10));
+  const right = b.split(".").map((part) => Number.parseInt(part, 10));
+  for (let i = 0; i < Math.max(left.length, right.length); i += 1) {
+    const l = Number.isFinite(left[i]) ? left[i]! : 0;
+    const r = Number.isFinite(right[i]) ? right[i]! : 0;
+    if (l > r) return 1;
+    if (l < r) return -1;
+  }
+  return 0;
+}
+
+export interface RemotePluginIdentity {
+  id: string;
+  version: string;
+  sha256: string;
+  dshExact: string;
+}
+
+export function resolvePluginCatalogEntry(input: {
+  bundled?: PluginCatalogEntry;
+  remote?: RemotePluginIdentity;
+}): { source: "remote" | "bundled"; version: string; sha256?: string; id: string } {
+  const bundled = input.bundled;
+  const remote = input.remote;
+  if (remote) {
+    if (!/^[0-9a-f]{64}$/.test(remote.sha256)) {
+      throw new PenglaiError("SECURITY_POLICY", "remote plugin digest required");
+    }
+    if (remote.dshExact !== PINNED_PLUGIN_DSH) {
+      if (!bundled) throw new PenglaiError("SECURITY_POLICY", `${remote.id} DSH pin is not ${PINNED_PLUGIN_DSH}`);
+    } else if (!bundled || comparePluginVersion(remote.version, bundled.version) > 0) {
+      return { source: "remote", version: remote.version, sha256: remote.sha256, id: remote.id };
+    }
+  }
+  if (!bundled) throw new PenglaiError("INVALID_INPUT", "unlisted package");
+  return { source: "bundled", version: bundled.version, sha256: bundled.sha256, id: bundled.id };
+}
+
+export function shouldPreserveInstalledPlugin(input: {
+  installedVersion?: string;
+  installedSha256?: string;
+  bundledVersion: string;
+  bundledSha256?: string;
+}): boolean {
+  if (!input.installedVersion) return false;
+  return comparePluginVersion(input.installedVersion, input.bundledVersion) > 0;
+}
+
+export function overlayIdentityPath(dest: string): string {
+  return join(dest, ".penglai-overlay.json");
+}
+
+export function readInstalledOverlay(dest: string): { version: string; sha256: string } | undefined {
+  const path = overlayIdentityPath(dest);
+  if (!existsSync(path)) return undefined;
+  try {
+    const raw = JSON.parse(readFileSync(path, "utf8")) as { version?: unknown; sha256?: unknown };
+    if (typeof raw.version !== "string" || !/^[0-9a-f]{64}$/.test(String(raw.sha256))) return undefined;
+    return { version: raw.version, sha256: String(raw.sha256) };
+  } catch {
+    return undefined;
+  }
+}
+
+export function writeInstalledOverlay(dest: string, identity: { version: string; sha256: string }): void {
+  if (!/^[0-9a-f]{64}$/.test(identity.sha256)) throw new PenglaiError("SECURITY_POLICY", "overlay digest required");
+  writeFileSync(overlayIdentityPath(dest), `${JSON.stringify({ schema: 1, ...identity })}\n`, { mode: 0o600 });
+}
+
+export function assertActivationDigest(actual: string, expected: string): void {
+  if (!/^[0-9a-f]{64}$/.test(actual) || actual !== expected) {
+    throw new PenglaiError("SECURITY_POLICY", "plugin activation digest mismatch");
+  }
+}

--- a/packages/runtime/src/process-isolation.test.ts
+++ b/packages/runtime/src/process-isolation.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { once } from "node:events";
+import { reapDshOrphans } from "./process.js";
+import type { RuntimeLayout, UserLayout } from "./index.js";
+
+test("orphan cleanup preserves another data root using the same executable and entry", { skip: process.platform !== "darwin" }, async () => {
+  const root = mkdtempSync(join(tmpdir(), "penglai-process-scope-"));
+  const entry = join(root, "owned-test-entry.mjs");
+  const own = join(root, "own");
+  const other = join(root, "other");
+  mkdirSync(own); mkdirSync(other);
+  writeFileSync(entry, 'process.stdout.write("ready"); setInterval(() => {}, 1000);');
+  const children = [own, other].map((cwd) => spawn(process.execPath, [entry], { cwd, stdio: ["ignore", "pipe", "ignore"] }));
+  try {
+    await Promise.all(children.map((child) => once(child.stdout!, "data")));
+    const layout = { nodeBin: process.execPath, dshEntry: entry } as RuntimeLayout;
+    assert.deepEqual(reapDshOrphans(layout), []);
+    const killed = reapDshOrphans(layout, undefined, { dshHome: own } as UserLayout);
+    assert.deepEqual(killed.map((row) => row.pid), [children[0]!.pid]);
+    assert.doesNotThrow(() => process.kill(children[1]!.pid!, 0));
+  } finally {
+    for (const child of children) child.kill("SIGKILL");
+  }
+});

--- a/packages/runtime/src/process.ts
+++ b/packages/runtime/src/process.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { join, win32 } from "node:path";
 import type { RuntimeLayout, UserLayout } from "./index.js";
 import { writeFileAtomic } from "./permissions.js";
 import { invokeWindowsHost, windowsNativeHostStatus, type WindowsHostReport } from "./windows-host.js";
@@ -20,6 +20,8 @@ export interface ProcessIdentity {
   owner?: string;
   jobAssigned?: boolean;
   supervisorPid?: number;
+  supervisorStartMs?: number;
+  supervisorExecutable?: string;
 }
 
 export function identityPath(user: UserLayout): string {
@@ -85,15 +87,13 @@ export function processStillMatches(id: ProcessIdentity): boolean {
   if (platform === "win32") {
     const report = windowsIdentityReport(id.pid, id.appRoot);
     if (!report || !report.startMs) return false;
-    if (Math.abs(report.startMs - id.startMs) > 2000) return false;
-    if (report.executable && !report.executable.toLowerCase().includes(id.executable.replace(/\//g, "\\").toLowerCase().split("\\").pop() ?? "node.exe")) {
-      return false;
-    }
-    if (id.owner && report.owner && id.owner !== report.owner) return false;
+    if (report.startMs !== id.startMs) return false;
+    if (!report.executable || win32.normalize(report.executable).toLowerCase() !== win32.normalize(id.executable).toLowerCase()) return false;
+    if (id.owner && report.owner !== id.owner) return false;
     return true;
   }
   const start = readProcessStartMs(id.pid, "darwin");
-  if (!start || Math.abs(start - id.startMs) > 2000) return false;
+  if (!start || start !== id.startMs) return false;
   try {
     const cmd = execFileSync("/bin/ps", ["-p", String(id.pid), "-o", "command="], { encoding: "utf8" });
     return cmd.includes(id.executable) && cmd.includes(id.dshEntry);
@@ -150,12 +150,11 @@ function signalProcess(pid: number, signal: NodeJS.Signals): boolean {
 export function killIdentity(id: ProcessIdentity, signal: NodeJS.Signals): boolean {
   const platform = hostPlatform(id);
   if (platform === "win32") {
-    let acted = false;
-    if (id.supervisorPid && id.supervisorPid > 0) {
-      acted = signalProcess(id.supervisorPid, signal) || acted;
-    }
-    if (!processStillMatches(id)) return acted;
-    return signalProcess(id.pid, signal) || acted;
+    if (id.supervisorPid && id.supervisorStartMs && id.supervisorExecutable && processStillMatches({
+      ...id, pid: id.supervisorPid, startMs: id.supervisorStartMs, executable: id.supervisorExecutable,
+    })) return signalProcess(id.supervisorPid, signal);
+    if (!processStillMatches(id)) return false;
+    return signalProcess(id.pid, signal);
   }
   if (!processStillMatches(id)) return false;
   try {
@@ -166,35 +165,22 @@ export function killIdentity(id: ProcessIdentity, signal: NodeJS.Signals): boole
   }
 }
 
-export function reapDshOrphans(layout: RuntimeLayout, keep?: ProcessIdentity): Array<{ pid: number; ppid: number }> {
-  const platform = keep?.platform ?? process.platform;
-  if (platform === "win32") {
-    const status = windowsNativeHostStatus("win32", layout.appRoot);
-    if (!status.available || !status.executable) return [];
-    try {
-      const report = invokeWindowsHost(
-        [
-          "process-reap-supervisors",
-          "--exe",
-          status.executable,
-          ...(keep?.supervisorPid ? ["--keep-pid", String(keep.supervisorPid)] : []),
-        ],
-        { platform: "win32", appRoot: layout.appRoot },
-      );
-      return (report.pids ?? []).map((pid) => ({ pid, ppid: 0 }));
-    } catch {
-      return [];
-    }
-  }
+export function reapDshOrphans(layout: RuntimeLayout, keep?: ProcessIdentity, user?: UserLayout): Array<{ pid: number; ppid: number }> {
+  // Executable identity alone cannot distinguish two Penglai data roots.
+  // Windows children are owned through their recorded Job supervisor identity.
+  if ((keep?.platform ?? process.platform) === "win32" || !user) return [];
+  let expectedCwd: string;
+  try { expectedCwd = realpathSync(user.dshHome); } catch { return []; }
   const killed: Array<{ pid: number; ppid: number }> = [];
   for (const row of listDshCandidates(layout, "darwin")) {
     if (keep && row.pid === keep.pid) continue;
     try {
+      const cwd = execFileSync("/usr/sbin/lsof", ["-a", "-p", String(row.pid), "-d", "cwd", "-Fn"], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] })
+        .split("\n").find((line) => line.startsWith("n"))?.slice(1);
+      if (!cwd || realpathSync(cwd) !== expectedCwd) continue;
       process.kill(row.pid, "SIGKILL");
       killed.push({ pid: row.pid, ppid: row.ppid });
-    } catch {
-      /* gone */
-    }
+    } catch { /* unverified or already gone: never signal another instance */ }
   }
   return killed;
 }

--- a/packages/runtime/src/runtime.test.ts
+++ b/packages/runtime/src/runtime.test.ts
@@ -789,7 +789,7 @@ test("interrupted atomic activation restores the pre-activation directory", () =
   assert.equal(existsSync(staging), false);
 });
 
-test("Center transaction is restored before DSH profile activation", () => {
+for (const schema of [2, 3]) for (const phase of ["staging", "activating", "verifying"]) test(`Center schema ${schema} ${phase} is restored before DSH profile activation`, () => {
   const user = resolveUserLayout(mkdtempSync(join(tmpdir(), "penglai-center-preboot-")));
   const txDir = join(user.root, "profiles", "center-tx");
   mkdirSync(user.profileWeb, { recursive: true });
@@ -803,9 +803,9 @@ test("Center transaction is restored before DSH profile activation", () => {
   writeFileSync(
     join(txDir, "journal.json"),
     JSON.stringify({
-      schema: 2,
+      schema,
       operationId: "24e69732-d08b-4f05-a628-ddf0bcf99a50",
-      phase: "verifying",
+      phase,
       id: "@penglai/im",
       action: "disable",
       previousEnabled: true,

--- a/packages/runtime/src/scanner.test.ts
+++ b/packages/runtime/src/scanner.test.ts
@@ -98,7 +98,7 @@ test("R50-SEC: production scanner rejects transcript, voice reference, and grant
     /voice reference/,
   );
   assert.throws(
-    () => assertProductionBundleClean({ "grant.json": 'grantedPath: "/Users/owner/Documents"' }),
+    () => assertProductionBundleClean({ "grant.json": 'grantedPath: "/Users/owner/Documents"' }), // penglai-test-fixture
     /context grant path|owner path/,
   );
   assert.throws(

--- a/packages/runtime/src/uninstall.ts
+++ b/packages/runtime/src/uninstall.ts
@@ -5,13 +5,14 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   renameSync,
   rmSync,
   statSync,
   writeFileSync,
   type Stats,
 } from "node:fs";
-import { isAbsolute, relative, resolve } from "node:path";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { PenglaiError, readExactRegularFile } from "@penglai/contracts";
 
 export const DATA_CATEGORIES = [
@@ -188,6 +189,21 @@ function pathsOverlap(a: string, b: string): boolean {
   return pathInsideOrEqual(a, b) || pathInsideOrEqual(b, a);
 }
 
+function canonicalDeleteBoundary(path: string): string {
+  let existing = resolve(path);
+  for (;;) {
+    try {
+      const canonical = realpathSync(existing);
+      return resolve(canonical, relative(existing, resolve(path)));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      const parent = dirname(existing);
+      if (parent === existing) throw error;
+      existing = parent;
+    }
+  }
+}
+
 export function assertSafeDeletePath(
   path: string,
   userDataRoot: string,
@@ -201,18 +217,33 @@ export function assertSafeDeletePath(
   if (resolved === "/" || resolved === resolve(process.env.HOME ?? "/no-home")) {
     throw new PenglaiError("SECURITY_POLICY", "refuses home");
   }
+  const canonical = canonicalDeleteBoundary(resolved);
   for (const ws of workspaceRoots) {
-    if (pathsOverlap(resolved, ws)) {
+    if (pathsOverlap(resolved, ws) || pathsOverlap(canonical, canonicalDeleteBoundary(ws))) {
       throw new PenglaiError("SECURITY_POLICY", "workspace never deleted");
     }
   }
   for (const legacy of legacyRoots) {
-    if (pathsOverlap(resolved, legacy)) {
+    if (pathsOverlap(resolved, legacy) || pathsOverlap(canonical, canonicalDeleteBoundary(legacy))) {
       throw new PenglaiError("SECURITY_POLICY", "legacy never deleted");
     }
   }
   if (!managedRoots.some((root) => pathInsideOrEqual(resolved, root))) {
     throw new PenglaiError("SECURITY_POLICY", "path outside managed data roots");
+  }
+  const managed = managedRoots.find((root) => pathInsideOrEqual(resolved, root));
+  if (!managed || !pathInsideOrEqual(canonical, canonicalDeleteBoundary(managed))) {
+    throw new PenglaiError("SECURITY_POLICY", "canonical path outside managed data roots");
+  }
+  let ancestor = resolve(managed);
+  for (const part of ["", ...relative(ancestor, resolved).split(sep).filter(Boolean)]) {
+    ancestor = resolve(ancestor, part);
+    try {
+      if (lstatSync(ancestor).isSymbolicLink()) throw new PenglaiError("SECURITY_POLICY", "symlink ancestor refused");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") break;
+      throw error;
+    }
   }
   try {
     const st = lstatSync(resolved);

--- a/packages/runtime/src/update-coordinator.test.ts
+++ b/packages/runtime/src/update-coordinator.test.ts
@@ -498,3 +498,19 @@ test("R50-UPD-004/009/010 ledger and every crash state fail closed", async () =>
   assert.equal(reconciled.version, "0.5.3");
   assert.equal(reconciled.errorClass, undefined);
 });
+
+test("completed updates resume normal discovery after launch and reject version regression", async () => {
+  const fixture = signedFixture(CURRENT);
+  for (const currentVersion of [CURRENT, "0.4.9"]) {
+    const root = mkdtempSync(join(tmpdir(), "penglai-update-committed-"));
+    writeUpdateJournal(join(root, "journal"), {
+      operationId: "completed-upgrade", state: "COMMITTED", version: CURRENT,
+      previousVersion: CURRENT, target: TARGET, drained: true,
+    });
+    const coordinator = new AssistedUpdateCoordinator(coordinatorConfig(root, fixture, { currentVersion }));
+    const recovered = coordinator.recoverOnLaunch();
+    assert.equal(recovered.state, currentVersion === CURRENT ? "CURRENT" : "RECOVERY_REQUIRED");
+    if (currentVersion === CURRENT) assert.equal((await coordinator.check()).state, "CURRENT");
+    else await assert.rejects(coordinator.check(), /cannot check update/);
+  }
+});

--- a/packages/runtime/src/update-coordinator.ts
+++ b/packages/runtime/src/update-coordinator.ts
@@ -194,6 +194,18 @@ export class AssistedUpdateCoordinator {
   }
 
   recoverOnLaunch(): UpdateCoordinatorStatus {
+    if (this.#journal.state === "COMMITTED") {
+      const matchesInstalled = this.#journal.version !== undefined &&
+        compareSemver(this.#config.currentVersion, this.#journal.version) >= 0;
+      this.#journal = {
+        ...this.#journal,
+        state: matchesInstalled ? "CURRENT" : "RECOVERY_REQUIRED",
+        drained: false,
+        ...(matchesInstalled ? { version: this.#config.currentVersion } : { errorClass: "POST_VERIFY_FAILED" }),
+      };
+      this.#persist();
+      return this.status();
+    }
     if (
       this.#journal.state === "RECOVERY_REQUIRED" &&
       this.#journal.version &&

--- a/packages/runtime/src/windows-host.test.ts
+++ b/packages/runtime/src/windows-host.test.ts
@@ -73,7 +73,7 @@ test("native Windows host source encodes Job Object, ACL, and reparse facts", ()
   assert.equal(facts.jobSupervise, true);
   assert.equal(facts.deletePlan, false);
   assert.equal(facts.processSuspendResume, true);
-  assert.equal(facts.processReapSupervisors, true);
+  assert.equal(facts.processReapSupervisors, false);
   assert.equal(facts.pathBatchProbe, true);
   assert.equal(facts.childExitMonitoring, true);
   assert.equal(facts.ownerStopMonitoring, true);
@@ -298,6 +298,8 @@ test("NSIS script always preserves user data after in-app exact deletion", () =>
   assert.match(script, /Delete\s+"\$DESKTOP\\Penglai\.lnk"/);
   // The recursive app-tree delete must be guarded to the default install dir.
   assert.match(script, /RMDir\s+\/r\s+"\$INSTDIR"\s*\n\s*\$\{Else\}/);
+  assert.match(script, /\$INSTDIR\.pending/);
+  assert.match(script, /previous install was left in place/);
   const contract = windowsNativeHostContract();
   assert.equal(contract.posixModeImpersonation, false);
   const payload = readFileSync(new URL("../../../scripts/package-windows-payload.mjs", import.meta.url), "utf8");

--- a/scripts/lib/installed-boundary.mjs
+++ b/scripts/lib/installed-boundary.mjs
@@ -1,13 +1,23 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 function gate(value) {
   return value ? "PASS" : "FAIL";
 }
 
+const PRODUCT_VERSION = JSON.parse(
+  readFileSync(join(dirname(fileURLToPath(import.meta.url)), "../../package.json"), "utf8"),
+).version;
+
 export function credentialFreeInstalledChecks({ rec, first, identityOk }) {
   const walked = Array.isArray(first?.onboarding?.walked) ? first.onboarding.walked : [];
   const keyless = rec?.walk?.wizardKeyless ?? rec?.wizardKeyless ?? {};
+  const observedVersion = first?.identity?.version ?? rec?.version;
   return {
     exactInstaller: gate(rec?.fromExactDmg === true),
     identity: gate(first?.identity?.ok === true || identityOk === true),
+    currentVersion: gate(typeof observedVersion === "string" && observedVersion === PRODUCT_VERSION),
     proxyAuthenticationBoundary: gate(first?.nativeBoot?.authenticationBoundary === true),
     exactExecutableBoot: gate(first?.nativeBoot?.ok === true),
     ownedProcessTree: gate(first?.processTree?.ownedAbsolute === true && first.processTree?.dshPid > 0),

--- a/scripts/lib/installed-boundary.test.mjs
+++ b/scripts/lib/installed-boundary.test.mjs
@@ -22,7 +22,7 @@ function sample() {
       resume: { attempted: true, ok: true },
     },
     first: {
-      identity: { ok: true },
+      identity: { ok: true, version: "0.5.10" },
       nativeBoot: { ok: true, authenticationBoundary: true },
       processTree: { ownedAbsolute: true, dshPid: 42 },
       inventory: { ok: true, im: false },
@@ -50,6 +50,17 @@ test("credential-free installed boundary fails closed without auth, catalog, or 
   assert.equal(checks.officialProviderCatalog, "FAIL");
   assert.equal(checks.resume, "FAIL");
   assert.equal(credentialFreeInstalledPass(input), false);
+});
+
+test("credential-free installed checks fail a missing or legacy version instead of skipping", () => {
+  const missing = sample();
+  delete missing.first.identity.version;
+  assert.equal(credentialFreeInstalledChecks(missing).currentVersion, "FAIL");
+  assert.equal(credentialFreeInstalledPass(missing), false);
+  const legacy = sample();
+  legacy.first.identity.version = "0.5.0";
+  assert.equal(credentialFreeInstalledChecks(legacy).currentVersion, "FAIL");
+  assert.equal(credentialFreeInstalledPass(legacy), false);
 });
 
 test("credential-free evidence never claims a nonce or first Turn", () => {

--- a/scripts/lib/secret-scan.mjs
+++ b/scripts/lib/secret-scan.mjs
@@ -60,7 +60,7 @@ export const SECRET_RULES = Object.freeze([
 const SKIP_PATH =
   /^(?:node_modules\/|.*\/node_modules\/|dist\/|.*\/dist\/|\.git\/|pnpm-lock\.yaml$|package-lock\.json$|.*\.(?:png|jpg|jpeg|webp|gif|icns|ico|woff2?|dylib|node|wasm|tgz|zip)$)/;
 
-const DETECTOR_LINE = /\/.+\/[gimsuy]*|\.test\(|\.includes\(|lock\.includes\(|\.replace\(|INLINE_SECRET|FORBIDDEN/;
+const DETECTOR_LINE = /^\s*(?:re:\s*|if\s*\(\s*)?\/(?![/*])(?:\\.|[^/\n])+\/[gimsuy]*(?:\.test\([^;{}]*\)\)?\s*\{?|,|;)?\s*$/;
 
 export function isSkippedScanPath(rel) {
   return SKIP_PATH.test(rel.replaceAll("\\", "/"));
@@ -71,7 +71,7 @@ export function lineLooksLikeDetector(line) {
 }
 
 function hasConcreteApiKey(line) {
-  return /\bsk-[A-Za-z0-9]{24,}/.test(line);
+  return /\bsk-[A-Za-z0-9]{20,}/.test(line);
 }
 
 export function scanText(rel, text) {

--- a/scripts/lib/secret-scan.mjs
+++ b/scripts/lib/secret-scan.mjs
@@ -60,14 +60,39 @@ export const SECRET_RULES = Object.freeze([
 const SKIP_PATH =
   /^(?:node_modules\/|.*\/node_modules\/|dist\/|.*\/dist\/|\.git\/|pnpm-lock\.yaml$|package-lock\.json$|.*\.(?:png|jpg|jpeg|webp|gif|icns|ico|woff2?|dylib|node|wasm|tgz|zip)$)/;
 
-const DETECTOR_LINE = /^\s*(?:re:\s*|if\s*\(\s*)?\/(?![/*])(?:\\.|[^/\n])+\/[gimsuy]*(?:\.test\([^;{}]*\)\)?\s*\{?|,|;)?\s*$/;
-
 export function isSkippedScanPath(rel) {
   return SKIP_PATH.test(rel.replaceAll("\\", "/"));
 }
 
 export function lineLooksLikeDetector(line) {
-  return DETECTOR_LINE.test(line);
+  let s = String(line).trim();
+  if (s.startsWith("re:")) s = s.slice(3).trimStart();
+  else if (s.startsWith("if")) {
+    s = s.slice(2).trimStart();
+    if (s.startsWith("(")) s = s.slice(1).trimStart();
+  }
+  if (!s.startsWith("/") || s.startsWith("//") || s.startsWith("/*")) return false;
+  let i = 1;
+  while (i < s.length) {
+    const ch = s[i];
+    if (ch === "\\") {
+      i += 2;
+      continue;
+    }
+    if (ch === "/") break;
+    if (ch === "\n") return false;
+    i += 1;
+  }
+  if (i >= s.length || s[i] !== "/") return false;
+  i += 1;
+  while (i < s.length && "gimsuy".includes(s[i] ?? "")) i += 1;
+  const rest = s.slice(i).trim();
+  if (rest === "" || rest === "," || rest === ";") return true;
+  if (!rest.startsWith(".test(")) return false;
+  const close = rest.indexOf(")");
+  if (close < 0) return false;
+  const after = rest.slice(close + 1).replaceAll(")", "").trim();
+  return after === "" || after === "{";
 }
 
 function hasConcreteApiKey(line) {

--- a/scripts/lib/secret-scan.test.mjs
+++ b/scripts/lib/secret-scan.test.mjs
@@ -37,7 +37,17 @@ test("R56-SEC-008 scanner evidence never echoes the secret value", () => {
 test("R56-SEC-007 detector regex lines without a concrete key are not hits", () => {
   const hits = scanText(
     "packages/runtime/src/update.ts",
-    "if (/BEGIN OPENSSH PRIVATE KEY|minisign sk/.test(source)) {",
+    "if (/BEGIN OPENSSH PRIVATE KEY|minisign sk/.test(source)) {", // penglai-test-fixture
   );
   assert.deepEqual(hits, []);
+});
+
+test("URLs and unrelated detector calls cannot suppress concrete credentials", () => {
+  const examples = [
+    ["https://example.test/endpoint?bot_", "token=synthetic-token-value"].join(""),
+    ["Authorization: Bearer ", "synthetic-token-value https://example.test/"].join(""),
+    ['const x = {"client_', 'secret":"synthetic-value"}; other.test(x);'].join(""),
+    `const key = "sk-${"a".repeat(20)}"; other.includes(key);`,
+  ];
+  for (const example of examples) assert.ok(scanText("config.ts", example).length > 0);
 });

--- a/scripts/lib/secret-scan.test.mjs
+++ b/scripts/lib/secret-scan.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { formatSecretHits, FIXTURE_MARKER, scanText } from "./secret-scan.mjs";
+import { formatSecretHits, FIXTURE_MARKER, lineLooksLikeDetector, scanText } from "./secret-scan.mjs";
 
 const SAMPLE_KEY = `sk-${"abcdefghijklmnopqrstuvwxyz012345"}`;
 
@@ -40,6 +40,14 @@ test("R56-SEC-007 detector regex lines without a concrete key are not hits", () 
     "if (/BEGIN OPENSSH PRIVATE KEY|minisign sk/.test(source)) {", // penglai-test-fixture
   );
   assert.deepEqual(hits, []);
+});
+
+test("detector-line classification stays linear on backslash-dot noise", () => {
+  const noise = "\\.".repeat(20_000);
+  const started = Date.now();
+  assert.equal(lineLooksLikeDetector(`if (/${noise}/.test(source)) {`), true);
+  assert.equal(lineLooksLikeDetector("const live = true;"), false);
+  assert.ok(Date.now() - started < 250);
 });
 
 test("URLs and unrelated detector calls cannot suppress concrete credentials", () => {

--- a/scripts/nsis/Penglai.nsi
+++ b/scripts/nsis/Penglai.nsi
@@ -94,16 +94,40 @@ Section "Penglai" SecApp
       MessageBox MB_ICONSTOP "Penglai cannot safely upgrade a custom legacy install directory. Uninstall the old version first."
       Abort
     ${EndIf}
-    ; The product data lives outside this fixed app directory. Remove the old
-    ; immutable payload before copying so alpha.1-only packages cannot survive
-    ; an alpha.2 upgrade.
-    RMDir /r "$LOCALAPPDATA\Penglai\app\0.5"
-  ${EndIf}
-  SetOutPath "$INSTDIR"
+    ; Stage the new payload first. Only replace the live app directory after
+    ; the copy succeeds so a failed upgrade keeps the previous program.
+    StrCpy $R2 "$INSTDIR.pending"
+    RMDir /r "$R2"
+    CreateDirectory "$R2"
+    SetOutPath "$R2"
 !ifndef PENGLAI_PAYLOAD
   !define PENGLAI_PAYLOAD "..\..\dist\runtime-staging-win32-x86_64\payload"
 !endif
-  File /r "${PENGLAI_PAYLOAD}\*.*"
+    File /r "${PENGLAI_PAYLOAD}\*.*"
+    IfFileExists "$R2\Penglai.exe" 0 upgrade_copy_failed
+    RMDir /r "$INSTDIR.previous"
+    Rename "$INSTDIR" "$INSTDIR.previous"
+    Rename "$R2" "$INSTDIR"
+    IfFileExists "$INSTDIR\Penglai.exe" 0 upgrade_activate_failed
+    RMDir /r "$INSTDIR.previous"
+    Goto upgrade_done
+    upgrade_copy_failed:
+      RMDir /r "$R2"
+      MessageBox MB_ICONSTOP "Penglai could not copy the new version. The previous install was left in place."
+      Abort
+    upgrade_activate_failed:
+      RMDir /r "$INSTDIR"
+      Rename "$INSTDIR.previous" "$INSTDIR"
+      MessageBox MB_ICONSTOP "Penglai could not activate the new version and restored the previous install."
+      Abort
+    upgrade_done:
+  ${Else}
+    SetOutPath "$INSTDIR"
+!ifndef PENGLAI_PAYLOAD
+  !define PENGLAI_PAYLOAD "..\..\dist\runtime-staging-win32-x86_64\payload"
+!endif
+    File /r "${PENGLAI_PAYLOAD}\*.*"
+  ${EndIf}
   CreateDirectory "$SMPROGRAMS\Penglai"
   CreateShortCut "$SMPROGRAMS\Penglai\Penglai.lnk" "$INSTDIR\Penglai.exe"
   WriteRegStr HKCU "Software\Penglai\0.5" "InstallDir" "$INSTDIR"

--- a/scripts/sbom.mjs
+++ b/scripts/sbom.mjs
@@ -171,7 +171,7 @@ const sbom = {
   componentCount: components.length,
   components,
 };
-if (lock.includes("BEGIN OPENSSH PRIVATE KEY") || lock.includes("PENGLAI_FIXTURE_UPDATER_PRIVATE")) {
+if (/BEGIN OPENSSH PRIVATE KEY|PENGLAI_FIXTURE_UPDATER_PRIVATE/.test(lock)) {
   throw new Error("sbom input contained a private key");
 }
 writeFileSync("evidence/generated/sbom.json", JSON.stringify(sbom, null, 2));

--- a/website/en/index.html
+++ b/website/en/index.html
@@ -18,7 +18,9 @@
     <nav aria-label="Main navigation">
       <a href="#new">0.5.10</a>
       <a href="#inside">What ships</a>
-      <a href="#story">Story</a>
+      <a href="#setup">Setup</a>
+      <a href="#privacy">Privacy</a>
+      <a href="#faq">FAQ</a>
       <a href="#download">Download</a>
       <a href="../" hreflang="zh-CN">中文</a>
       <a class="github" href="https://github.com/kevinchennewbee/PenglaiAgent">GitHub</a>
@@ -102,6 +104,36 @@
       </div>
     </section>
 
+    <section class="section first-run" id="setup">
+      <div class="copy">
+        <p class="eyebrow">Setup and recovery</p>
+        <h2>Install the matching artifact, then finish the wizard through the first official reply.</h2>
+        <p>Use the Apple Silicon DMG, Intel Mac DMG, or Windows x64 installer. Do not mix them. Choose language and appearance, confirm the data directory, pick a model from the official list, test your API key, and select a real Workspace. Back, retry and restart resume are supported. Uninstall keeps user data by default.</p>
+      </div>
+      <img src="../shots/0.5.5/welcome.png" alt="Penglai first-run welcome page">
+    </section>
+
+    <section class="trust section" id="privacy">
+      <p class="eyebrow">Privacy</p>
+      <h2>No Penglai account. Data stays on this computer unless you send it.</h2>
+      <div class="trust-grid">
+        <p><strong>No Penglai cloud sync.</strong> Memory, Office drafts and IM bindings live in the local user-data directory. Model calls still send the current-task context to the provider you chose.</p>
+        <p><strong>Writes and outbound delivery need their own confirmation.</strong> Office save/return, personal Memory, and plugin install use product confirmation bound to that action, not a casual chat “ok”.</p>
+        <p><strong>Diagnostics are redacted.</strong> Plugin diagnostic export must not contain credentials, chat bodies, QR codes or private absolute paths.</p>
+      </div>
+    </section>
+
+    <section class="section" id="faq">
+      <p class="eyebrow">FAQ</p>
+      <h2>The limits, before the download buttons.</h2>
+      <div class="cards">
+        <article><h3>Is Penglai another agent?</h3><p>No. Official DeepSeek Harness is the only core. Penglai owns install, lifecycle and first-party plugins.</p></article>
+        <article><h3>Which version should I download?</h3><p>The public installers are still 0.5.10. Mentions of 0.5.11 describe in-development source, not a downloadable product.</p></article>
+        <article><h3>Why does Gatekeeper warn?</h3><p>macOS packages are ad-hoc signed and not notarized; Windows has no Authenticode. That is a stated limitation, not an OS endorsement.</p></article>
+        <article><h3>Are Office and Memory on by default?</h3><p>Yes. Messaging, ASR, TTS and Companion stay off until you enable them.</p></article>
+      </div>
+    </section>
+
     <section class="download section" id="download">
       <p class="eyebrow">Penglai 0.5.10</p>
       <h2>Choose your computer.</h2>
@@ -110,7 +142,7 @@
         <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_x64.dmg"><strong>macOS · Intel</strong><span>GitHub · 388.2 MiB · x86_64 Mac</span><code>6771901b5bf3b7e9e0c192125a866bf2e6c1c605655a8d07339ea37dc64ee9ea</code></a>
         <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_windows_x64_setup.exe"><strong>Windows · x64</strong><span>GitHub · 341.0 MiB · 64-bit installer</span><code>46b45bbb6a18859c7be03413b7983ad90dacc7710233130b2c81cb5a537bd484</code></a>
       </div>
-      <p class="quiet">The immutable GitHub Release is the sole authoritative public download source for 0.5.10; the Beijing mirror has not published 0.5.10. All three installers come from source <code>c5c0bcb022c5ae47cca242deb27fe1d30444c41d</code>. Full SHA256SUMS, the 1253-component SBOM, third-party notices, and signed update metadata are available on the same page. Updates are never silent.</p>
+      <p class="quiet">The current public download is still published 0.5.10. 0.5.11 is in development and has no installers or GitHub Release assets. The immutable GitHub Release is the sole authoritative public download source for 0.5.10; the Beijing mirror has not published 0.5.10. All three installers come from source <code>c5c0bcb022c5ae47cca242deb27fe1d30444c41d</code>. Full SHA256SUMS, SBOM, third-party notices, and signed update metadata are on the same page. Updates are never silent.</p>
       <div class="actions centered">
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.10">Bilingual release notes</a>
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">Security notes</a>

--- a/website/index.html
+++ b/website/index.html
@@ -18,7 +18,9 @@
     <nav aria-label="主导航">
       <a href="#new">0.5.10</a>
       <a href="#inside">内置能力</a>
-      <a href="#story">缘起</a>
+      <a href="#setup">安装</a>
+      <a href="#privacy">隐私</a>
+      <a href="#faq">问答</a>
       <a href="#download">下载</a>
       <a href="./en/" hreflang="en">EN</a>
       <a class="github" href="https://github.com/kevinchennewbee/PenglaiAgent">GitHub</a>
@@ -102,6 +104,36 @@
       </div>
     </section>
 
+    <section class="section first-run" id="setup">
+      <div class="copy">
+        <p class="eyebrow">安装与恢复</p>
+        <h2>下载对应芯片的安装包，走完引导，直到第一条官方回复。</h2>
+        <p>Apple 芯片用 aarch64 DMG，Intel Mac 用 x64 DMG，Windows 用 x64 安装器。不要混用。首次打开后选择语言和外观，确认数据目录，从官方列表选择模型和供应商，测试 API Key，选择真实 Workspace。可以返回、重试和重启续接。卸载默认保留用户数据。</p>
+      </div>
+      <img src="./shots/0.5.5/welcome.png" alt="蓬莱首次引导欢迎页">
+    </section>
+
+    <section class="trust section" id="privacy">
+      <p class="eyebrow">隐私</p>
+      <h2>没有蓬莱账号。数据默认留在这台电脑。</h2>
+      <div class="trust-grid">
+        <p><strong>没有蓬莱云同步。</strong>记忆、办公草稿和消息绑定都在本机用户数据目录。模型调用仍会把当前任务需要的内容发给你选择的供应商。</p>
+        <p><strong>写入和外发要单独确认。</strong>办公保存、回传、记忆个人化、插件安装都走产品内与动作绑定的确认，而不是一句聊天里的“好的”。</p>
+        <p><strong>诊断会去掉私密内容。</strong>插件诊断导出不得包含凭据、聊天正文、二维码或私人绝对路径。</p>
+      </div>
+    </section>
+
+    <section class="section" id="faq">
+      <p class="eyebrow">常见问题</p>
+      <h2>先把限制说清楚。</h2>
+      <div class="cards">
+        <article><h3>蓬莱是另一个 Agent 吗？</h3><p>不是。官方 DeepSeek Harness 是唯一核心。蓬莱负责安装、生命周期和第一方插件。</p></article>
+        <article><h3>现在该下载哪个版本？</h3><p>公开安装包仍是 0.5.10。页面上的 0.5.11 只描述正在开发的源码，不是可下载产品。</p></article>
+        <article><h3>为什么 Gatekeeper 会提示？</h3><p>macOS 安装包是 ad-hoc 签名、未公证；Windows 没有 Authenticode。这是已知限制，不是系统背书。</p></article>
+        <article><h3>办公和记忆默认开着吗？</h3><p>是。手机消息、语音识别、语音生成和主动陪伴默认关闭，需要时再开。</p></article>
+      </div>
+    </section>
+
     <section class="download section" id="download">
       <p class="eyebrow">Penglai 0.5.10</p>
       <h2>选择你的电脑。</h2>
@@ -110,7 +142,7 @@
         <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_x64.dmg"><strong>macOS · Intel</strong><span>GitHub · 388.2 MiB · x86_64 Mac</span><code>6771901b5bf3b7e9e0c192125a866bf2e6c1c605655a8d07339ea37dc64ee9ea</code></a>
         <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_windows_x64_setup.exe"><strong>Windows · x64</strong><span>GitHub · 341.0 MiB · 64 位安装器</span><code>46b45bbb6a18859c7be03413b7983ad90dacc7710233130b2c81cb5a537bd484</code></a>
       </div>
-      <p class="quiet">0.5.10 当前只以不可变 GitHub Release 为权威公开下载源；北京镜像尚未发布 0.5.10。三个安装包来自源码 <code>c5c0bcb022c5ae47cca242deb27fe1d30444c41d</code>。完整 SHA256SUMS、1253 组件 SBOM、第三方声明与签名元数据同页提供；更新不会静默执行。</p>
+      <p class="quiet">当前公开下载仍是已发布的 0.5.10。0.5.11 还在开发，没有安装包、也没有 GitHub Release 附件。0.5.10 只以不可变 GitHub Release 为权威公开下载源；北京镜像尚未发布 0.5.10。三个安装包来自源码 <code>c5c0bcb022c5ae47cca242deb27fe1d30444c41d</code>。完整 SHA256SUMS、SBOM、第三方声明与签名元数据同页提供；更新不会静默执行。</p>
       <div class="actions centered">
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.10">中英文发布说明</a>
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">安全说明</a>

--- a/website/styles/main.css
+++ b/website/styles/main.css
@@ -18,8 +18,12 @@ body {
   background:
     radial-gradient(circle at 12% 12%, rgba(13, 118, 93, .08), transparent 25rem),
     var(--paper);
+  font-family: "Iowan Old Style", "Palatino Linotype", Palatino, "Noto Serif SC", "Songti SC", serif;
+  font-size: 18px;
+  line-height: 1.7;
+}
+h1, h2, h3, .brand, .button, nav, .eyebrow, .state {
   font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", "PingFang SC", sans-serif;
-  line-height: 1.65;
 }
 a { color: inherit; }
 img { display: block; max-width: 100%; }


### PR DESCRIPTION
Land the 0.5.11 development source on the frozen official DSH `0.1.2-rc.1` cohort. Public product identity, `package.json`, `RELEASE`, and `release-contract.json` stay **0.5.10**. This PR does not retitle 0.5.11, does not rewrite tag `v0.5.10`, and does not publish installers.

## What landed

- Isolation and recovery: Owner-peer IM gating, Office job Workspace/Session ownership, Memory policy-before-write, Center journal schema 3 / last-good, Windows NSIS pending-then-previous staging (source), plugin catalog prefer-newer-signed-remote with digest activation, onboarding snapshot resume.
- First-party workflows through official DSH slots: scoped Memory library query, Weixin/Feishu official request identity, bounded text-PDF inspect plus digest-bound page preview, read-only usage projection, redacted Plugin Center diagnostics.
- Bilingual README and `website/` redesign. Download links still point at verified 0.5.10 assets.
- Development freeze records in `docs/0.5.11/`. `dsh-v0.1.3-alpha.1` is rejected until a complete npm cohort exists. Mnemon remains `0.2.4`.

Owner-authored `AGENTS.md` and `docs/0.5.7/RELEASE_RUNBOOK.md` are **not** in this PR.

## Local evidence (Apple Silicon, SHA `d7f20c7eeadf6722ab832f5cc3374cb7c5e6f77a`)

Official PASS on a clean worktree of that SHA:

- `verify:office-real`, `verify:memory-real` (Mnemon 0.2.4, isolation, 100k query)
- `verify:closure`, `verify:profile` (fresh: Office+Memory loaded, leftovers 0)
- `verify:clean-clone` (frozen-install, typecheck, build, `test:unit`)
- `verify:bundled-runtime` against an ad-hoc local DMG (`Penglai_0.5.10_macos_aarch64.dmg`, sha256 `01973f61a511cf4b6480622c94be6d170e889092e66e08a5ab7a94ec2c16a142`)

That DMG is a local candidate, not notarized, and not a public 0.5.11 asset.

## Still open

- Intel Mac and Windows x64 matching-native builds (native workflow requires clean `main`)
- Installed fresh/restart/Back/retry/upgrade/uninstall
- Live model/IM observations
- Publication of `v0.5.11`

## 中文

这是 0.5.11 开发源码合入，公开身份仍是 0.5.10。不改写已发布附件。Owner 的 `AGENTS.md` 与 0.5.7 手册未纳入。Apple Silicon 上 Office/Memory/profile/closure/clean-clone 已官方 PASS；Intel/Windows 安装包、已安装生命周期和发布仍待后续。