### PR TITLE
fix: attach installed app version to credential-free e2e identity

### DIFF
--- a/scripts/e2e-installed.mjs
+++ b/scripts/e2e-installed.mjs
@@ -387,32 +387,35 @@ const first = {
   http,
   websocket: official.websocket ?? { opened: false },
   live,
-  identity: evaluateLiveSample({
-    now: Date.now(),
-    health: {
-      at: new Date().toISOString(),
-      pid: launched.child.pid,
-      dshPid: processTree.dshPid,
-      sourceSha: candidateSourceSha,
-      installerSha256: installed.installerSha256,
-      target: declaredTarget,
-    },
-    observed,
-    expectedIdentity,
-    expected: {
-      sourceSha: candidateSourceSha,
-      artifactSha: installed.installerSha256,
-      target: declaredTarget,
-    },
-    liveHttpWs: {
-      httpOfficial: Boolean(live.httpOfficial || http.official),
-      wsOpened: Boolean(live.wsOpened || official.websocket?.opened),
-    },
-    requireOfficialLive: !walk?.wizardKeyless?.ok,
-    declaredSourceSha: candidateSourceSha,
-    declaredArtifactSha: installed.installerSha256,
-    declaredTarget,
-  }),
+  identity: {
+    ...evaluateLiveSample({
+      now: Date.now(),
+      health: {
+        at: new Date().toISOString(),
+        pid: launched.child.pid,
+        dshPid: processTree.dshPid,
+        sourceSha: candidateSourceSha,
+        installerSha256: installed.installerSha256,
+        target: declaredTarget,
+      },
+      observed,
+      expectedIdentity,
+      expected: {
+        sourceSha: candidateSourceSha,
+        artifactSha: installed.installerSha256,
+        target: declaredTarget,
+      },
+      liveHttpWs: {
+        httpOfficial: Boolean(live.httpOfficial || http.official),
+        wsOpened: Boolean(live.wsOpened || official.websocket?.opened),
+      },
+      requireOfficialLive: !walk?.wizardKeyless?.ok,
+      declaredSourceSha: candidateSourceSha,
+      declaredArtifactSha: installed.installerSha256,
+      declaredTarget,
+    }),
+    version: identity.facts.version,
+  },
   dom: {
     hasRoot: Boolean(walk?.last?.hasRoot || official.snap?.hasRoot),
     hasDshBoot: Boolean(walk?.last?.hasDshBoot || official.snap?.hasDshBoot),
@@ -472,6 +475,7 @@ if (resume.attempted && resume.ok === false) fail("wizard did not resume from le
 const keylessOk = Boolean(walk?.wizardKeyless?.ok && resume.ok);
 const candidateRecord = {
   fromExactDmg: true,
+  version: identity.facts.version,
   walk: walk ? { wizardKeyless: walk.wizardKeyless } : null,
   resume,
 };

--- a/scripts/lib/installed-boundary.test.mjs
+++ b/scripts/lib/installed-boundary.test.mjs
@@ -63,6 +63,18 @@ test("credential-free installed checks fail a missing or legacy version instead 
   assert.equal(credentialFreeInstalledPass(legacy), false);
 });
 
+test("currentVersion accepts installed facts.version on a live-sample identity object", () => {
+  const input = sample();
+  delete input.first.identity.version;
+  input.first.identity = { ok: true, verdict: "PASS", reasons: [], reason: "", version: "0.5.10" };
+  assert.equal(credentialFreeInstalledChecks(input).currentVersion, "PASS");
+  assert.equal(credentialFreeInstalledPass(input), true);
+  const viaRec = sample();
+  delete viaRec.first.identity.version;
+  viaRec.rec.version = "0.5.10";
+  assert.equal(credentialFreeInstalledChecks(viaRec).currentVersion, "PASS");
+});
+
 test("credential-free evidence never claims a nonce or first Turn", () => {
   const checks = credentialFreeInstalledChecks(sample());
   assert.equal(Object.hasOwn(checks, "officialNonceTurn"), false);


### PR DESCRIPTION
Native `test:e2e:installed` on `cabb686a` built the installer and completed the keyless wizard through `keytest`, then returned INCOMPLETE: `currentVersion` required `first.identity.version` (V02) but the live-sample identity object omitted it.

This records the installed app identity facts.version (`0.5.10` while public identity remains 0.5.10) on both `first.identity` and `rec.version`. It does not skip the check and does not rewrite 0.5.10.

Focused tests: `scripts/lib/installed-boundary.test.mjs` 12 pass / 1 skip.