### PR TITLE
fix: reap Windows process trees before NSIS upgrade

### DIFF
--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -375,6 +375,20 @@ test("installed restart requests the product lifecycle before signal fallback", 
   );
 });
 
+test("Windows child shutdown kills the process tree so NSIS upgrade is not blocked", () => {
+  const helper = readFileSync(join(root, "scripts/lib/installed-app.mjs"), "utf8");
+  const upgrade = readFileSync(join(root, "scripts/verify-upgrade-uninstall.mjs"), "utf8");
+  const stop = helper.indexOf("export async function stopChild");
+  const taskkill = helper.indexOf('spawnSync("taskkill.exe", ["/PID", String(child.pid), "/T", "/F"]', stop);
+  const posixKill = helper.indexOf('child.kill("SIGKILL")', stop);
+  assert.ok(stop >= 0 && taskkill > stop, "stopChild must tree-kill Windows descendants");
+  assert.ok(posixKill > taskkill, "POSIX SIGKILL remains the non-Windows fallback");
+  assert.match(upgrade, /leftoversByCommand/);
+  assert.match(upgrade, /taskkill\.exe/);
+  assert.match(upgrade, /timeout:\s*180_000/);
+  assert.match(upgrade, /`_\?=\$\{app\}`/);
+});
+
 test("installed harness shutdown returns only after the child is gone", async (context) => {
   const { stopChild } = await import("../../../scripts/lib/installed-app.mjs");
   const child = spawn(

--- a/scripts/lib/installed-app.mjs
+++ b/scripts/lib/installed-app.mjs
@@ -544,10 +544,18 @@ export async function stopChild(child, timeoutMs = 8_000) {
     new Promise((resolveTimeout) => setTimeout(() => resolveTimeout({ exited: false }), timeoutMs)),
   ]);
   if (graceful.exited) return graceful.value;
-  try {
-    child.kill("SIGKILL");
-  } catch {
-    /* already gone */
+  if (process.platform === "win32" && Number.isSafeInteger(child.pid) && child.pid > 0) {
+    spawnSync("taskkill.exe", ["/PID", String(child.pid), "/T", "/F"], {
+      encoding: "utf8",
+      windowsHide: true,
+      timeout: 15_000,
+    });
+  } else {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      /* already gone */
+    }
   }
   const forced = await Promise.race([
     closed.then((value) => ({ exited: true, value })),

--- a/scripts/verify-upgrade-uninstall.mjs
+++ b/scripts/verify-upgrade-uninstall.mjs
@@ -16,6 +16,7 @@ import {
   cleanupRegisteredWindowsInstallerFixture,
   installFromExactDmg,
   launchPackaged,
+  leftoversByCommand,
   readInstalledAppIdentity,
   resourcesInside,
   sha256File,
@@ -77,6 +78,24 @@ async function boot(app, userData, label) {
     userData, () => launchPackaged(executable, resources, userData),
   );
   const [code, signal] = await stopChild(launched.child);
+  const leftoverNeedles = [executable, join(resources, "runtime/dsh/lib/bin.js")].filter(Boolean);
+  const leftoverDeadline = Date.now() + 30_000;
+  while (Date.now() < leftoverDeadline) {
+    const leftover = leftoverNeedles.flatMap((needle) => leftoversByCommand(needle));
+    if (leftover.length === 0) break;
+    if (process.platform === "win32") {
+      for (const line of leftover) {
+        const pid = Number(String(line).split(/\s+/)[0]);
+        if (Number.isSafeInteger(pid) && pid > 0) {
+          spawnSync("taskkill.exe", ["/PID", String(pid), "/T", "/F"], {
+            windowsHide: true,
+            timeout: 15_000,
+          });
+        }
+      }
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
+  }
   if (!freshReadiness || !gateway || !inventory || (code !== 0 && signal === null)) {
     fail(`${label} did not boot and exit through the installed runtime`, {
       gateway,
@@ -91,9 +110,13 @@ async function boot(app, userData, label) {
 }
 
 function installWindows(installer, label) {
-  const run = spawnSync(installer, ["/S"], { encoding: "utf8" });
-  if (run.status !== 0) {
-    fail(`${label} NSIS install failed`, { status: run.status });
+  const run = spawnSync(installer, ["/S"], { encoding: "utf8", windowsHide: true, timeout: 180_000 });
+  if (run.error || run.status !== 0) {
+    fail(`${label} NSIS install failed`, {
+      status: run.status,
+      timedOut: run.error?.code === "ETIMEDOUT",
+      error: run.error?.code,
+    });
   }
   const localAppData = process.env.LOCALAPPDATA;
   if (!localAppData) fail("LOCALAPPDATA is unavailable on the Windows native runner");
@@ -213,8 +236,18 @@ if (!existsSync(sentinel)) fail("upgrade did not preserve isolated Owner data");
 if (target === "win32-x86_64") {
   const uninstaller = join(app, "Uninstall.exe");
   if (!existsSync(uninstaller)) fail("Windows uninstaller missing after upgrade");
-  const uninstall = spawnSync(uninstaller, ["/S"], { encoding: "utf8" });
-  if (uninstall.status !== 0) fail("Windows uninstaller returned failure", { status: uninstall.status });
+  const uninstall = spawnSync(uninstaller, ["/S", `_?=${app}`], {
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: 180_000,
+  });
+  if (uninstall.error || uninstall.status !== 0) {
+    fail("Windows uninstaller returned failure", {
+      status: uninstall.status,
+      timedOut: uninstall.error?.code === "ETIMEDOUT",
+      error: uninstall.error?.code,
+    });
+  }
 } else {
   const exactAppRoot = requireExactChild(appRoot, ROOT, "macOS app test root");
   rmSync(exactAppRoot, { recursive: true, force: true });


### PR DESCRIPTION
Windows native upgrade/uninstall hung because `stopChild` did not kill descendant processes and NSIS `/S` waited on the live tree. `taskkill /T` after the graceful timeout, leftover reap after each boot, and bounded NSIS spawn close that gap.

Does not rewrite v0.5.10. Native run 34111506245 is still hung on Windows upgrade from `ec35eebc`; this needs a new three-target run after merge.