### PR TITLE
fix: make Windows silent upgrade fail closed without UI

### DIFF
--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -385,8 +385,12 @@ test("Windows child shutdown kills the process tree so NSIS upgrade is not block
   assert.ok(posixKill > taskkill, "POSIX SIGKILL remains the non-Windows fallback");
   assert.match(upgrade, /leftoversByCommand/);
   assert.match(upgrade, /taskkill\.exe/);
-  assert.match(upgrade, /timeout:\s*180_000/);
+  assert.match(upgrade, /\/IM", "Penglai\.exe"/);
+  assert.match(upgrade, /timeout:\s*20 \* 60_000/);
   assert.match(upgrade, /`_\?=\$\{app\}`/);
+  const nsis = readFileSync(join(root, "scripts/nsis/Penglai.nsi"), "utf8");
+  assert.match(nsis, /\/SD IDOK/);
+  assert.doesNotMatch(nsis, /MessageBox(?![^\n]*\/SD IDOK)/);
 });
 
 test("installed harness shutdown returns only after the child is gone", async (context) => {

--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -390,7 +390,9 @@ test("Windows child shutdown kills the process tree so NSIS upgrade is not block
   assert.match(upgrade, /`_\?=\$\{app\}`/);
   const nsis = readFileSync(join(root, "scripts/nsis/Penglai.nsi"), "utf8");
   assert.match(nsis, /\/SD IDOK/);
-  assert.doesNotMatch(nsis, /MessageBox(?![^\n]*\/SD IDOK)/);
+  for (const line of nsis.split(/\r?\n/)) {
+    if (line.includes("MessageBox")) assert.match(line, /\/SD IDOK/);
+  }
 });
 
 test("installed harness shutdown returns only after the child is gone", async (context) => {

--- a/packages/runtime/src/packaging.ts
+++ b/packages/runtime/src/packaging.ts
@@ -159,10 +159,19 @@ export function assertWindowsUpgradeStaging(script: string): void {
   if (pendingOut < 0 || liveRename < 0 || pendingOut > liveRename) {
     throw new Error("Windows upgrade must copy the payload before renaming the live app directory");
   }
-  if (!/ClearErrors[\s\S]*Rename\s+"\$INSTDIR"\s+"\$INSTDIR\.previous"[\s\S]*IfErrors\s+upgrade_activate_failed/.test(script)) {
+  const clearErrors = script.indexOf("ClearErrors");
+  const renameErrors = script.indexOf("IfErrors upgrade_activate_failed", liveRename);
+  if (clearErrors < 0 || renameErrors < 0 || clearErrors > liveRename || liveRename > renameErrors) {
     throw new Error("Windows upgrade must fail closed when renaming the live app directory");
   }
-  if (!/\/SD\s+IDOK/.test(script) || /MessageBox(?![^\n]*\/SD\s+IDOK)/.test(script)) {
+  let hasSilentDismiss = false;
+  for (const line of script.split(/\r?\n/)) {
+    if (line.includes("/SD IDOK")) hasSilentDismiss = true;
+    if (line.includes("MessageBox") && !line.includes("/SD IDOK")) {
+      throw new Error("Windows NSIS MessageBox must dismiss automatically during silent install");
+    }
+  }
+  if (!hasSilentDismiss) {
     throw new Error("Windows NSIS MessageBox must dismiss automatically during silent install");
   }
   if (/RMDir\s+\/r\s+"\$LOCALAPPDATA\\Penglai\\app\\0\.5"/.test(script)) {

--- a/packages/runtime/src/packaging.ts
+++ b/packages/runtime/src/packaging.ts
@@ -159,6 +159,12 @@ export function assertWindowsUpgradeStaging(script: string): void {
   if (pendingOut < 0 || liveRename < 0 || pendingOut > liveRename) {
     throw new Error("Windows upgrade must copy the payload before renaming the live app directory");
   }
+  if (!/ClearErrors[\s\S]*Rename\s+"\$INSTDIR"\s+"\$INSTDIR\.previous"[\s\S]*IfErrors\s+upgrade_activate_failed/.test(script)) {
+    throw new Error("Windows upgrade must fail closed when renaming the live app directory");
+  }
+  if (!/\/SD\s+IDOK/.test(script) || /MessageBox(?![^\n]*\/SD\s+IDOK)/.test(script)) {
+    throw new Error("Windows NSIS MessageBox must dismiss automatically during silent install");
+  }
   if (/RMDir\s+\/r\s+"\$LOCALAPPDATA\\Penglai\\app\\0\.5"/.test(script)) {
     throw new Error("Windows upgrade must not delete the live app tree before the new payload exists");
   }

--- a/scripts/nsis/Penglai.nsi
+++ b/scripts/nsis/Penglai.nsi
@@ -72,7 +72,7 @@ Function .onInit
     StrCpy $LANGUAGE $R8
   ${EndIf}
   ${IfNot} ${RunningX64}
-    MessageBox MB_ICONSTOP "Penglai ${PENGLAI_VERSION} requires 64-bit Windows."
+    MessageBox MB_ICONSTOP|MB_SETFOREGROUND "Penglai ${PENGLAI_VERSION} requires 64-bit Windows." /SD IDOK
     Abort
   ${EndIf}
   ReadRegStr $0 HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_ID}" "DisplayVersion"
@@ -81,7 +81,7 @@ Function .onInit
     ; string compare would treat "0.10.0" as older than "0.5.0".
     ${VersionCompare} "$0" "${PENGLAI_VERSION}" $R0
     ${If} $R0 == 1
-      MessageBox MB_ICONSTOP "Penglai refuses downgrade from $0 to ${PENGLAI_VERSION}."
+      MessageBox MB_ICONSTOP|MB_SETFOREGROUND "Penglai refuses downgrade from $0 to ${PENGLAI_VERSION}." /SD IDOK
       Abort
     ${EndIf}
     StrCpy $R1 "upgrade"
@@ -91,7 +91,7 @@ FunctionEnd
 Section "Penglai" SecApp
   ${If} $R1 == "upgrade"
     ${If} $INSTDIR != "$LOCALAPPDATA\Penglai\app\0.5"
-      MessageBox MB_ICONSTOP "Penglai cannot safely upgrade a custom legacy install directory. Uninstall the old version first."
+      MessageBox MB_ICONSTOP|MB_SETFOREGROUND "Penglai cannot safely upgrade a custom legacy install directory. Uninstall the old version first." /SD IDOK
       Abort
     ${EndIf}
     ; Stage the new payload first. Only replace the live app directory after
@@ -106,19 +106,23 @@ Section "Penglai" SecApp
     File /r "${PENGLAI_PAYLOAD}\*.*"
     IfFileExists "$R2\Penglai.exe" 0 upgrade_copy_failed
     RMDir /r "$INSTDIR.previous"
+    ClearErrors
     Rename "$INSTDIR" "$INSTDIR.previous"
+    IfErrors upgrade_activate_failed
+    ClearErrors
     Rename "$R2" "$INSTDIR"
+    IfErrors upgrade_activate_failed
     IfFileExists "$INSTDIR\Penglai.exe" 0 upgrade_activate_failed
     RMDir /r "$INSTDIR.previous"
     Goto upgrade_done
     upgrade_copy_failed:
       RMDir /r "$R2"
-      MessageBox MB_ICONSTOP "Penglai could not copy the new version. The previous install was left in place."
+      MessageBox MB_ICONSTOP|MB_SETFOREGROUND "Penglai could not copy the new version. The previous install was left in place." /SD IDOK
       Abort
     upgrade_activate_failed:
       RMDir /r "$INSTDIR"
       Rename "$INSTDIR.previous" "$INSTDIR"
-      MessageBox MB_ICONSTOP "Penglai could not activate the new version and restored the previous install."
+      MessageBox MB_ICONSTOP|MB_SETFOREGROUND "Penglai could not activate the new version and restored the previous install." /SD IDOK
       Abort
     upgrade_done:
   ${Else}

--- a/scripts/verify-upgrade-uninstall.mjs
+++ b/scripts/verify-upgrade-uninstall.mjs
@@ -84,6 +84,10 @@ async function boot(app, userData, label) {
     const leftover = leftoverNeedles.flatMap((needle) => leftoversByCommand(needle));
     if (leftover.length === 0) break;
     if (process.platform === "win32") {
+      spawnSync("taskkill.exe", ["/IM", "Penglai.exe", "/T", "/F"], {
+        windowsHide: true,
+        timeout: 15_000,
+      });
       for (const line of leftover) {
         const pid = Number(String(line).split(/\s+/)[0]);
         if (Number.isSafeInteger(pid) && pid > 0) {
@@ -110,7 +114,7 @@ async function boot(app, userData, label) {
 }
 
 function installWindows(installer, label) {
-  const run = spawnSync(installer, ["/S"], { encoding: "utf8", windowsHide: true, timeout: 180_000 });
+  const run = spawnSync(installer, ["/S"], { encoding: "utf8", windowsHide: true, timeout: 20 * 60_000 });
   if (run.error || run.status !== 0) {
     fail(`${label} NSIS install failed`, {
       status: run.status,
@@ -239,7 +243,7 @@ if (target === "win32-x86_64") {
   const uninstall = spawnSync(uninstaller, ["/S", `_?=${app}`], {
     encoding: "utf8",
     windowsHide: true,
-    timeout: 180_000,
+    timeout: 20 * 60_000,
   });
   if (uninstall.error || uninstall.status !== 0) {
     fail("Windows uninstaller returned failure", {


### PR DESCRIPTION
Windows native upgrade from 0.5.8 timed out at 180s (`ETIMEDOUT` on the 0.5.11 NSIS `/S` install). Silent install cannot block on MessageBox, live-directory rename must IfErrors-fail, and NSIS spawn uses the same 20-minute bound as `installFromExactInstaller`. After boot, `Penglai.exe` is reaped so the next installer is not waiting on a live tree.

Apple Silicon and Intel already PASS on `e52a5f15`. This is required before another three-target native run.