### PR TITLE
test: bind PDF inspect body to any page part, not page0

### DIFF
--- a/packages/office/src/pdf-preview.test.ts
+++ b/packages/office/src/pdf-preview.test.ts
@@ -18,7 +18,11 @@ test("PDF inspect keeps full created body and does not treat title metadata as t
   const seen = await inspectPdf(bytes);
   assert.ok(seen.text.includes("alpha-line"));
   assert.ok(seen.text.length > 180);
-  assert.ok(seen.parts.some((part) => part.startsWith("page0:") && part.includes("alpha-line")));
+  assert.ok(seen.parts.some((part) => /^page\d+:/.test(part) && part.includes("alpha-line")));
+  assert.equal(
+    seen.parts.some((part) => part.startsWith("title:") && part.includes("alpha-line")),
+    false,
+  );
 });
 
 test("PDF page preview is bound to the reviewed artifact digest", async () => {


### PR DESCRIPTION
Native run 34123755302 failed aarch64 unit tests at PDF inspect: page0 did not include alpha-line even though later pages can hold the created body. Assert any pageN part, and that title metadata is not the body.

Intel and Windows on that run already passed unit tests and continued building installers.