### PR TITLE
fix: reap the Windows install tree before NSIS upgrade

### DIFF
--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -384,9 +384,12 @@ test("Windows child shutdown kills the process tree so NSIS upgrade is not block
   assert.ok(stop >= 0 && taskkill > stop, "stopChild must tree-kill Windows descendants");
   assert.ok(posixKill > taskkill, "POSIX SIGKILL remains the non-Windows fallback");
   assert.match(upgrade, /leftoversByCommand/);
+  assert.match(upgrade, /reapWindowsInstallTree/);
   assert.match(upgrade, /taskkill\.exe/);
   assert.match(upgrade, /\/IM", "Penglai\.exe"/);
   assert.match(upgrade, /timeout:\s*20 \* 60_000/);
+  assert.match(helper, /export async function reapWindowsInstallTree/);
+  assert.match(helper, /Penglai Helper/);
   assert.match(upgrade, /`_\?=\$\{app\}`/);
   const nsis = readFileSync(join(root, "scripts/nsis/Penglai.nsi"), "utf8");
   assert.match(nsis, /\/SD IDOK/);

--- a/scripts/lib/installed-app.mjs
+++ b/scripts/lib/installed-app.mjs
@@ -21,6 +21,29 @@ import { installerForTarget } from "./release-targets.mjs";
 export const ARM64_DMG = join(ROOT, "dist/Penglai_0.5.11_macos_aarch64.dmg");
 export const ARM64_INSTALLER = "Penglai_0.5.11_macos_aarch64.dmg";
 
+export async function reapWindowsInstallTree(appDir, timeoutMs = 30_000) {
+  if (process.platform !== "win32") return { ok: true, leftover: [] };
+  const needles = [resolve(appDir), "Penglai.exe", "Penglai Helper"];
+  const deadline = Date.now() + timeoutMs;
+  const collect = () => [...new Set(needles.flatMap((needle) => leftoversByCommand(needle)))];
+  let leftover = collect();
+  while (Date.now() < deadline) {
+    leftover = collect();
+    if (leftover.length === 0) return { ok: true, leftover: [] };
+    spawnSync("taskkill.exe", ["/IM", "Penglai.exe", "/T", "/F"], { windowsHide: true, timeout: 15_000 });
+    spawnSync("taskkill.exe", ["/IM", "Penglai Helper.exe", "/T", "/F"], { windowsHide: true, timeout: 15_000 });
+    for (const line of leftover) {
+      const pid = Number(String(line).split(/\s+/)[0]);
+      if (Number.isSafeInteger(pid) && pid > 0) {
+        spawnSync("taskkill.exe", ["/PID", String(pid), "/T", "/F"], { windowsHide: true, timeout: 15_000 });
+      }
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
+  }
+  leftover = collect();
+  return { ok: leftover.length === 0, leftover };
+}
+
 export function leftoversByCommand(needle) {
   if (process.platform === "win32") {
     const r = spawnSync(

--- a/scripts/verify-upgrade-uninstall.mjs
+++ b/scripts/verify-upgrade-uninstall.mjs
@@ -18,6 +18,7 @@ import {
   launchPackaged,
   leftoversByCommand,
   readInstalledAppIdentity,
+  reapWindowsInstallTree,
   resourcesInside,
   sha256File,
   stopChild,
@@ -78,7 +79,7 @@ async function boot(app, userData, label) {
     userData, () => launchPackaged(executable, resources, userData),
   );
   const [code, signal] = await stopChild(launched.child);
-  const leftoverNeedles = [executable, join(resources, "runtime/dsh/lib/bin.js")].filter(Boolean);
+  const leftoverNeedles = [executable, join(resources, "runtime/dsh/lib/bin.js"), app].filter(Boolean);
   const leftoverDeadline = Date.now() + 30_000;
   while (Date.now() < leftoverDeadline) {
     const leftover = leftoverNeedles.flatMap((needle) => leftoversByCommand(needle));
@@ -100,6 +101,14 @@ async function boot(app, userData, label) {
     }
     await new Promise((resolveDelay) => setTimeout(resolveDelay, 250));
   }
+  if (process.platform === "win32") {
+    const reaped = await reapWindowsInstallTree(app);
+    if (!reaped.ok) {
+      fail(`${label} left Windows processes in the install tree`, {
+        leftover: reaped.leftover.slice(0, 20),
+      });
+    }
+  }
   if (!freshReadiness || !gateway || !inventory || (code !== 0 && signal === null)) {
     fail(`${label} did not boot and exit through the installed runtime`, {
       gateway,
@@ -120,6 +129,8 @@ function installWindows(installer, label) {
       status: run.status,
       timedOut: run.error?.code === "ETIMEDOUT",
       error: run.error?.code,
+      stdout: sanitizeEvidenceText(String(run.stdout ?? ""), 1_000),
+      stderr: sanitizeEvidenceText(String(run.stderr ?? ""), 1_000),
     });
   }
   const localAppData = process.env.LOCALAPPDATA;


### PR DESCRIPTION
Windows native upgrade from 0.5.8 now fails in ~2.5 minutes with NSIS exit 2 instead of hanging. That is the silent Abort after rename/copy failure, almost certainly because the live INSTDIR is still locked.

\`reapWindowsInstallTree\` kills Penglai.exe, helper processes, and anything whose command line contains the install directory before the next NSIS \`/S\`. Failed NSIS runs now include stdout/stderr.

Includes the PDF inspect page-part fix already on main.