### PR TITLE
fix: retry Windows NSIS live-dir rename after stopping Penglai

### DIFF
--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -393,6 +393,11 @@ test("Windows child shutdown kills the process tree so NSIS upgrade is not block
   assert.match(upgrade, /`_\?=\$\{app\}`/);
   const nsis = readFileSync(join(root, "scripts/nsis/Penglai.nsi"), "utf8");
   assert.match(nsis, /\/SD IDOK/);
+  assert.match(nsis, /upgrade_rename_live/);
+  assert.match(nsis, /taskkill\.exe/);
+  assert.match(nsis, /penglai-setup\.log/);
+  assert.match(upgrade, /penglai-setup\.log/);
+  assert.match(helper, /ExecutablePath/);
   for (const line of nsis.split(/\r?\n/)) {
     if (line.includes("MessageBox")) assert.match(line, /\/SD IDOK/);
   }

--- a/packages/runtime/src/leftover.test.ts
+++ b/packages/runtime/src/leftover.test.ts
@@ -233,6 +233,22 @@ test("Windows upgrade refuses the old live-tree delete-then-copy pattern", async
   const live = readFileSync(new URL("../../../scripts/nsis/Penglai.nsi", import.meta.url), "utf8");
   assertWindowsUpgradeStaging(live);
   assertWindowsNsisScript(live);
+  assert.match(live, /upgrade_rename_live/);
+  assert.match(live, /taskkill\.exe/);
+  assert.match(live, /\/IM Penglai\.exe/);
+  assert.match(live, /penglai-setup\.log/);
+  const noRetry = `
+    StrCpy $R2 "$INSTDIR.pending"
+    SetOutPath "$R2"
+    upgrade_copy_failed:
+    previous install was left in place
+    upgrade_activate_failed:
+    $INSTDIR.previous
+    ClearErrors
+    Rename "$INSTDIR" "$INSTDIR.previous"
+    IfErrors upgrade_activate_failed
+  `;
+  assert.throws(() => assertWindowsUpgradeStaging(noRetry), /stop Penglai\.exe and retry/);
   const oldLiveDeleteThenCopy = `
 RequestExecutionLevel user
 Section "Penglai"

--- a/packages/runtime/src/packaging.ts
+++ b/packages/runtime/src/packaging.ts
@@ -159,9 +159,25 @@ export function assertWindowsUpgradeStaging(script: string): void {
   if (pendingOut < 0 || liveRename < 0 || pendingOut > liveRename) {
     throw new Error("Windows upgrade must copy the payload before renaming the live app directory");
   }
-  const clearErrors = script.indexOf("ClearErrors");
-  const renameErrors = script.indexOf("IfErrors upgrade_activate_failed", liveRename);
-  if (clearErrors < 0 || renameErrors < 0 || clearErrors > liveRename || liveRename > renameErrors) {
+  const clearErrors = script.lastIndexOf("ClearErrors", liveRename);
+  if (clearErrors < 0) {
+    throw new Error("Windows upgrade must fail closed when renaming the live app directory");
+  }
+  const taskkill = script.indexOf("taskkill.exe");
+  const retryLabel = script.indexOf("upgrade_rename_live");
+  if (taskkill < 0 || retryLabel < 0 || taskkill > liveRename || retryLabel > liveRename) {
+    throw new Error("Windows upgrade must stop Penglai.exe and retry renaming the live app directory");
+  }
+  if (!script.includes("/IM Penglai.exe")) {
+    throw new Error("Windows upgrade must stop Penglai.exe before swapping the live app directory");
+  }
+  if (script.indexOf("Sleep ") < 0) {
+    throw new Error("Windows upgrade must wait between live-directory rename retries");
+  }
+  if (script.indexOf("penglai-setup.log") < 0) {
+    throw new Error("Windows upgrade must write a setup log when the live swap fails");
+  }
+  if (script.indexOf("upgrade_activate_failed", liveRename) < 0) {
     throw new Error("Windows upgrade must fail closed when renaming the live app directory");
   }
   let hasSilentDismiss = false;

--- a/packages/runtime/src/windows-host.test.ts
+++ b/packages/runtime/src/windows-host.test.ts
@@ -300,6 +300,9 @@ test("NSIS script always preserves user data after in-app exact deletion", () =>
   assert.match(script, /RMDir\s+\/r\s+"\$INSTDIR"\s*\n\s*\$\{Else\}/);
   assert.match(script, /\$INSTDIR\.pending/);
   assert.match(script, /previous install was left in place/);
+  assert.match(script, /upgrade_rename_live/);
+  assert.match(script, /taskkill\.exe/);
+  assert.match(script, /penglai-setup\.log/);
   const contract = windowsNativeHostContract();
   assert.equal(contract.posixModeImpersonation, false);
   const payload = readFileSync(new URL("../../../scripts/package-windows-payload.mjs", import.meta.url), "utf8");

--- a/scripts/lib/installed-app.mjs
+++ b/scripts/lib/installed-app.mjs
@@ -51,7 +51,7 @@ export function leftoversByCommand(needle) {
       [
         "-NoProfile",
         "-Command",
-        "Get-CimInstance Win32_Process | ForEach-Object { '{0} {1} {2}' -f $_.ProcessId, $_.ParentProcessId, $_.CommandLine }",
+        "Get-CimInstance Win32_Process | ForEach-Object { '{0} {1} {2} {3} {4}' -f $_.ProcessId, $_.ParentProcessId, $_.Name, $_.ExecutablePath, $_.CommandLine }",
       ],
       { encoding: "utf8" },
     );

--- a/scripts/nsis/Penglai.nsi
+++ b/scripts/nsis/Penglai.nsi
@@ -106,20 +106,42 @@ Section "Penglai" SecApp
     File /r "${PENGLAI_PAYLOAD}\*.*"
     IfFileExists "$R2\Penglai.exe" 0 upgrade_copy_failed
     RMDir /r "$INSTDIR.previous"
-    ClearErrors
-    Rename "$INSTDIR" "$INSTDIR.previous"
-    IfErrors upgrade_activate_failed
-    ClearErrors
-    Rename "$R2" "$INSTDIR"
-    IfErrors upgrade_activate_failed
-    IfFileExists "$INSTDIR\Penglai.exe" 0 upgrade_activate_failed
-    RMDir /r "$INSTDIR.previous"
-    Goto upgrade_done
+    ; Stop the running app, then retry the live rename. Explorer, Defender, and
+    ; Chromium helpers can keep INSTDIR open after Penglai.exe has already exited.
+    StrCpy $R3 "0"
+    upgrade_rename_live:
+      ExecWait '"$SYSDIR\taskkill.exe" /F /T /IM Penglai.exe' $R4
+      ExecWait '"$SYSDIR\taskkill.exe" /F /T /IM "Penglai Helper.exe"' $R4
+      Sleep 1000
+      ClearErrors
+      Rename "$INSTDIR" "$INSTDIR.previous"
+      IfErrors 0 upgrade_rename_pending
+      IntOp $R3 $R3 + 1
+      IntCmp $R3 90 upgrade_activate_failed upgrade_rename_live upgrade_activate_failed
+    upgrade_rename_pending:
+      StrCpy $R3 "0"
+    upgrade_rename_pending_retry:
+      ClearErrors
+      Rename "$R2" "$INSTDIR"
+      IfErrors 0 upgrade_rename_ok
+      Sleep 1000
+      IntOp $R3 $R3 + 1
+      IntCmp $R3 90 upgrade_activate_failed upgrade_rename_pending_retry upgrade_activate_failed
+    upgrade_rename_ok:
+      IfFileExists "$INSTDIR\Penglai.exe" 0 upgrade_activate_failed
+      RMDir /r "$INSTDIR.previous"
+      Goto upgrade_done
     upgrade_copy_failed:
       RMDir /r "$R2"
+      FileOpen $R8 "$TEMP\penglai-setup.log" w
+      FileWrite $R8 "phase=copy-failed$\r$\n"
+      FileClose $R8
       MessageBox MB_ICONSTOP|MB_SETFOREGROUND "Penglai could not copy the new version. The previous install was left in place." /SD IDOK
       Abort
     upgrade_activate_failed:
+      FileOpen $R8 "$TEMP\penglai-setup.log" w
+      FileWrite $R8 "phase=activate-failed r3=$R3$\r$\n"
+      FileClose $R8
       RMDir /r "$INSTDIR"
       Rename "$INSTDIR.previous" "$INSTDIR"
       MessageBox MB_ICONSTOP|MB_SETFOREGROUND "Penglai could not activate the new version and restored the previous install." /SD IDOK

--- a/scripts/verify-upgrade-uninstall.mjs
+++ b/scripts/verify-upgrade-uninstall.mjs
@@ -122,6 +122,20 @@ async function boot(app, userData, label) {
   return { gateway, inventory, freshReadiness, exitCode: code, signal };
 }
 
+function readWindowsSetupLog() {
+  const temp = process.env.TEMP || process.env.TMP || "";
+  const log = temp ? join(temp, "penglai-setup.log") : "";
+  if (!log || !existsSync(log)) return "";
+  const bytes = readFileSync(log);
+  const text =
+    bytes.length >= 2 && bytes[0] === 0xff && bytes[1] === 0xfe
+      ? bytes.subarray(2).toString("utf16le")
+      : bytes.includes(0)
+        ? bytes.toString("utf16le")
+        : bytes.toString("utf8");
+  return sanitizeEvidenceText(text, 2_000);
+}
+
 function installWindows(installer, label) {
   const run = spawnSync(installer, ["/S"], { encoding: "utf8", windowsHide: true, timeout: 20 * 60_000 });
   if (run.error || run.status !== 0) {
@@ -131,6 +145,7 @@ function installWindows(installer, label) {
       error: run.error?.code,
       stdout: sanitizeEvidenceText(String(run.stdout ?? ""), 1_000),
       stderr: sanitizeEvidenceText(String(run.stderr ?? ""), 1_000),
+      setupLog: readWindowsSetupLog(),
     });
   }
   const localAppData = process.env.LOCALAPPDATA;


### PR DESCRIPTION
## Summary
Native run [34129022887](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34129022887) on `6dbba19a`:
- macOS darwin-aarch64 **PASS** (including upgrade/uninstall)
- macOS darwin-x86_64 **PASS** (including upgrade/uninstall)
- Windows win32-x86_64 source, installer, u3, and `verify:installed` **PASS**
- Windows `verify:upgrade-uninstall` **FAIL** after a successful 0.5.8 boot: `0.5.11 upgrade NSIS install failed`, `status: 2`, `timedOut: false`, empty stdout/stderr

`reapWindowsInstallTree` already reported no leftovers. NSIS still `Abort`s when `Rename $INSTDIR $INSTDIR.previous` hits a remaining file lock (Defender / Explorer / Chromium helpers). That is a product upgrade path, not only CI.

## Change
- NSIS upgrade: `taskkill /IM Penglai.exe` (and Helper), retry live and pending `Rename` up to 90s, write `%TEMP%\penglai-setup.log` on copy/activate failure
- Staging contract tests require stop + retry + setup log
- `verify:upgrade-uninstall` includes the setup log in the FAIL record
- Windows leftover scan also matches `ExecutablePath` / `Name`

Does not rewrite 0.5.10. Owner `AGENTS.md` / 0.5.7 runbook are not in this PR.

## Test
- `packages/runtime/src/leftover.test.ts` 16 pass
- `packages/runtime/src/windows-host.test.ts` 12 pass
- `apps/desktop/src/installed-walk.test.ts` 21 pass