### PR TITLE
fix: retry transient Mnemon archive downloads

### DIFF
--- a/scripts/lib/mnemon-fetch.mjs
+++ b/scripts/lib/mnemon-fetch.mjs
@@ -94,14 +94,46 @@ export function assertNoSpecialFiles(root) {
   }
 }
 
-export async function downloadHttps(url, dest, { fetchImpl = fetch, maxBytes = 40 * 1024 * 1024 } = {}) {
+const TRANSIENT_DOWNLOAD_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+function delay(ms, sleepImpl) {
+  return sleepImpl(ms);
+}
+
+export function isTransientMnemonDownloadStatus(status) {
+  return TRANSIENT_DOWNLOAD_STATUS.has(Number(status));
+}
+
+export async function downloadHttps(
+  url,
+  dest,
+  {
+    fetchImpl = fetch,
+    maxBytes = 40 * 1024 * 1024,
+    maxAttempts = 5,
+    sleepImpl = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  } = {},
+) {
   let current = url;
+  let attempt = 1;
   for (let hop = 0; hop <= 5; hop += 1) {
     const parsed = new URL(current);
     if (parsed.protocol !== "https:" || parsed.username || parsed.password || !HOST_ALLOW.has(parsed.hostname)) {
       throw new Error(`mnemon download host rejected ${parsed.hostname}`);
     }
-    const response = await fetchImpl(current, { redirect: "manual", headers: { "User-Agent": "Penglai/0.5.11 mnemon-fetch" } });
+    let response;
+    try {
+      response = await fetchImpl(current, {
+        redirect: "manual",
+        headers: { "User-Agent": "Penglai/0.5.11 mnemon-fetch" },
+      });
+    } catch (error) {
+      if (attempt >= maxAttempts) throw error;
+      await delay(Math.min(1000 * 2 ** (attempt - 1), 8_000), sleepImpl);
+      attempt += 1;
+      hop -= 1;
+      continue;
+    }
     if ([301, 302, 303, 307, 308].includes(response.status)) {
       const location = response.headers.get("location");
       await response.body?.cancel?.().catch(() => undefined);
@@ -109,7 +141,16 @@ export async function downloadHttps(url, dest, { fetchImpl = fetch, maxBytes = 4
       current = new URL(location, current).toString();
       continue;
     }
-    if (!response.ok || !response.body) throw new Error(`download failed ${response.status}`);
+    if (!response.ok || !response.body) {
+      await response.body?.cancel?.().catch(() => undefined);
+      if (!isTransientMnemonDownloadStatus(response.status) || attempt >= maxAttempts) {
+        throw new Error(`download failed ${response.status}`);
+      }
+      await delay(Math.min(1000 * 2 ** (attempt - 1), 8_000), sleepImpl);
+      attempt += 1;
+      hop -= 1;
+      continue;
+    }
     const tmp = `${dest}.${randomBytes(6).toString("hex")}.part`;
     await pipeline(Readable.fromWeb(response.body), createWriteStream(tmp, { mode: 0o600, flags: "wx" }));
     const size = statSync(tmp).size;

--- a/scripts/lib/mnemon-fetch.test.mjs
+++ b/scripts/lib/mnemon-fetch.test.mjs
@@ -4,9 +4,12 @@ import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Readable } from "node:stream";
 import {
   assertSafeArchiveEntry,
+  downloadHttps,
   extractZipContents,
+  isTransientMnemonDownloadStatus,
   parseFetchArgs,
   publishArchive,
   selectAssets,
@@ -45,6 +48,59 @@ test("Windows zip extraction falls back to built-in tar before PowerShell", () =
   };
   extractZipContents("mnemon.zip", "out", "win32", run);
   assert.deepEqual(commands, ["unzip", "tar"]);
+});
+
+test("downloadHttps retries a transient 504 then writes the archive", async () => {
+  let calls = 0;
+  const sleeps = [];
+  const dest = join(mkdtempSync(join(tmpdir(), "mnemon-dl-")), "mnemon.tar.gz");
+  const payload = Buffer.from("mnemon-archive");
+  const out = await downloadHttps("https://github.com/mnemon-dev/mnemon/releases/download/x", dest, {
+    fetchImpl: async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          ok: false,
+          status: 504,
+          headers: { get: () => null },
+          body: { cancel: async () => undefined },
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        body: Readable.toWeb(Readable.from(payload)),
+      };
+    },
+    sleepImpl: async (ms) => {
+      sleeps.push(ms);
+    },
+  });
+  assert.equal(calls, 2);
+  assert.deepEqual(sleeps, [1000]);
+  assert.equal(readFileSync(out).toString(), "mnemon-archive");
+  assert.equal(isTransientMnemonDownloadStatus(504), true);
+});
+
+test("downloadHttps does not retry a 404", async () => {
+  let calls = 0;
+  const dest = join(mkdtempSync(join(tmpdir(), "mnemon-404-")), "x");
+  await assert.rejects(
+    () =>
+      downloadHttps("https://github.com/mnemon-dev/mnemon/releases/download/x", dest, {
+        fetchImpl: async () => {
+          calls += 1;
+          return { ok: false, status: 404, headers: { get: () => null }, body: { cancel: async () => undefined } };
+        },
+        sleepImpl: async () => {
+          throw new Error("404 must not sleep-retry");
+        },
+      }),
+    /download failed 404/,
+  );
+  assert.equal(calls, 1);
+  assert.equal(isTransientMnemonDownloadStatus(404), false);
 });
 
 test("verified archives publish through a destination-local atomic rename", () => {


### PR DESCRIPTION
Ready but **not for merge until native 34133527954 is known**.

Native [34132858284](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34132858284) on `a71303f3` failed at `pnpm fetch:mnemon-assets` with `download failed 504`. Same SHA previously fetched Mnemon on [34129022887](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34129022887).

`downloadHttps` now retries 408/425/429/500/502/503/504 and fetch throws, up to 5 attempts. 404 does not retry.

A three-target native PASS must come from one main SHA. If the in-flight native re-dispatch [34133527954](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34133527954) PASSes, keep this PR unmerged until after `v0.5.11` publication. If Windows 504s again, squash-merge this first and re-dispatch native from the new SHA.