### PR TITLE
fix: copy over a locked Windows install tree during upgrade

### DIFF
--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -396,6 +396,9 @@ test("Windows child shutdown kills the process tree so NSIS upgrade is not block
   assert.match(nsis, /upgrade_rename_live/);
   assert.match(nsis, /taskkill\.exe/);
   assert.match(nsis, /penglai-setup\.log/);
+  assert.match(nsis, /upgrade_rename_fallback/);
+  assert.match(nsis, /robocopy\.exe/);
+  assert.match(nsis, /upgrade_abort_keep_live/);
   assert.match(upgrade, /penglai-setup\.log/);
   assert.match(helper, /ExecutablePath/);
   for (const line of nsis.split(/\r?\n/)) {

--- a/packages/runtime/src/leftover.test.ts
+++ b/packages/runtime/src/leftover.test.ts
@@ -237,6 +237,9 @@ test("Windows upgrade refuses the old live-tree delete-then-copy pattern", async
   assert.match(live, /taskkill\.exe/);
   assert.match(live, /\/IM Penglai\.exe/);
   assert.match(live, /penglai-setup\.log/);
+  assert.match(live, /upgrade_rename_fallback/);
+  assert.match(live, /robocopy\.exe/);
+  assert.match(live, /upgrade_abort_keep_live/);
   const noRetry = `
     StrCpy $R2 "$INSTDIR.pending"
     SetOutPath "$R2"

--- a/packages/runtime/src/packaging.ts
+++ b/packages/runtime/src/packaging.ts
@@ -177,6 +177,12 @@ export function assertWindowsUpgradeStaging(script: string): void {
   if (script.indexOf("penglai-setup.log") < 0) {
     throw new Error("Windows upgrade must write a setup log when the live swap fails");
   }
+  if (script.indexOf("upgrade_rename_fallback") < 0 || script.indexOf("robocopy.exe") < 0) {
+    throw new Error("Windows upgrade must copy the staged payload over a live tree that cannot be renamed");
+  }
+  if (script.indexOf("upgrade_abort_keep_live") < 0) {
+    throw new Error("Windows upgrade must not delete INSTDIR when INSTDIR.previous was never created");
+  }
   if (script.indexOf("upgrade_activate_failed", liveRename) < 0) {
     throw new Error("Windows upgrade must fail closed when renaming the live app directory");
   }

--- a/packages/runtime/src/windows-host.test.ts
+++ b/packages/runtime/src/windows-host.test.ts
@@ -303,6 +303,9 @@ test("NSIS script always preserves user data after in-app exact deletion", () =>
   assert.match(script, /upgrade_rename_live/);
   assert.match(script, /taskkill\.exe/);
   assert.match(script, /penglai-setup\.log/);
+  assert.match(script, /upgrade_rename_fallback/);
+  assert.match(script, /robocopy\.exe/);
+  assert.match(script, /upgrade_abort_keep_live/);
   const contract = windowsNativeHostContract();
   assert.equal(contract.posixModeImpersonation, false);
   const payload = readFileSync(new URL("../../../scripts/package-windows-payload.mjs", import.meta.url), "utf8");

--- a/scripts/lib/mnemon-fetch.mjs
+++ b/scripts/lib/mnemon-fetch.mjs
@@ -94,14 +94,46 @@ export function assertNoSpecialFiles(root) {
   }
 }
 
-export async function downloadHttps(url, dest, { fetchImpl = fetch, maxBytes = 40 * 1024 * 1024 } = {}) {
+const TRANSIENT_DOWNLOAD_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+function delay(ms, sleepImpl) {
+  return sleepImpl(ms);
+}
+
+export function isTransientMnemonDownloadStatus(status) {
+  return TRANSIENT_DOWNLOAD_STATUS.has(Number(status));
+}
+
+export async function downloadHttps(
+  url,
+  dest,
+  {
+    fetchImpl = fetch,
+    maxBytes = 40 * 1024 * 1024,
+    maxAttempts = 5,
+    sleepImpl = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  } = {},
+) {
   let current = url;
+  let attempt = 1;
   for (let hop = 0; hop <= 5; hop += 1) {
     const parsed = new URL(current);
     if (parsed.protocol !== "https:" || parsed.username || parsed.password || !HOST_ALLOW.has(parsed.hostname)) {
       throw new Error(`mnemon download host rejected ${parsed.hostname}`);
     }
-    const response = await fetchImpl(current, { redirect: "manual", headers: { "User-Agent": "Penglai/0.5.11 mnemon-fetch" } });
+    let response;
+    try {
+      response = await fetchImpl(current, {
+        redirect: "manual",
+        headers: { "User-Agent": "Penglai/0.5.11 mnemon-fetch" },
+      });
+    } catch (error) {
+      if (attempt >= maxAttempts) throw error;
+      await delay(Math.min(1000 * 2 ** (attempt - 1), 8_000), sleepImpl);
+      attempt += 1;
+      hop -= 1;
+      continue;
+    }
     if ([301, 302, 303, 307, 308].includes(response.status)) {
       const location = response.headers.get("location");
       await response.body?.cancel?.().catch(() => undefined);
@@ -109,7 +141,16 @@ export async function downloadHttps(url, dest, { fetchImpl = fetch, maxBytes = 4
       current = new URL(location, current).toString();
       continue;
     }
-    if (!response.ok || !response.body) throw new Error(`download failed ${response.status}`);
+    if (!response.ok || !response.body) {
+      await response.body?.cancel?.().catch(() => undefined);
+      if (!isTransientMnemonDownloadStatus(response.status) || attempt >= maxAttempts) {
+        throw new Error(`download failed ${response.status}`);
+      }
+      await delay(Math.min(1000 * 2 ** (attempt - 1), 8_000), sleepImpl);
+      attempt += 1;
+      hop -= 1;
+      continue;
+    }
     const tmp = `${dest}.${randomBytes(6).toString("hex")}.part`;
     await pipeline(Readable.fromWeb(response.body), createWriteStream(tmp, { mode: 0o600, flags: "wx" }));
     const size = statSync(tmp).size;

--- a/scripts/lib/mnemon-fetch.test.mjs
+++ b/scripts/lib/mnemon-fetch.test.mjs
@@ -4,9 +4,12 @@ import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Readable } from "node:stream";
 import {
   assertSafeArchiveEntry,
+  downloadHttps,
   extractZipContents,
+  isTransientMnemonDownloadStatus,
   parseFetchArgs,
   publishArchive,
   selectAssets,
@@ -45,6 +48,59 @@ test("Windows zip extraction falls back to built-in tar before PowerShell", () =
   };
   extractZipContents("mnemon.zip", "out", "win32", run);
   assert.deepEqual(commands, ["unzip", "tar"]);
+});
+
+test("downloadHttps retries a transient 504 then writes the archive", async () => {
+  let calls = 0;
+  const sleeps = [];
+  const dest = join(mkdtempSync(join(tmpdir(), "mnemon-dl-")), "mnemon.tar.gz");
+  const payload = Buffer.from("mnemon-archive");
+  const out = await downloadHttps("https://github.com/mnemon-dev/mnemon/releases/download/x", dest, {
+    fetchImpl: async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          ok: false,
+          status: 504,
+          headers: { get: () => null },
+          body: { cancel: async () => undefined },
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        body: Readable.toWeb(Readable.from(payload)),
+      };
+    },
+    sleepImpl: async (ms) => {
+      sleeps.push(ms);
+    },
+  });
+  assert.equal(calls, 2);
+  assert.deepEqual(sleeps, [1000]);
+  assert.equal(readFileSync(out).toString(), "mnemon-archive");
+  assert.equal(isTransientMnemonDownloadStatus(504), true);
+});
+
+test("downloadHttps does not retry a 404", async () => {
+  let calls = 0;
+  const dest = join(mkdtempSync(join(tmpdir(), "mnemon-404-")), "x");
+  await assert.rejects(
+    () =>
+      downloadHttps("https://github.com/mnemon-dev/mnemon/releases/download/x", dest, {
+        fetchImpl: async () => {
+          calls += 1;
+          return { ok: false, status: 404, headers: { get: () => null }, body: { cancel: async () => undefined } };
+        },
+        sleepImpl: async () => {
+          throw new Error("404 must not sleep-retry");
+        },
+      }),
+    /download failed 404/,
+  );
+  assert.equal(calls, 1);
+  assert.equal(isTransientMnemonDownloadStatus(404), false);
 });
 
 test("verified archives publish through a destination-local atomic rename", () => {

--- a/scripts/nsis/Penglai.nsi
+++ b/scripts/nsis/Penglai.nsi
@@ -117,7 +117,7 @@ Section "Penglai" SecApp
       Rename "$INSTDIR" "$INSTDIR.previous"
       IfErrors 0 upgrade_rename_pending
       IntOp $R3 $R3 + 1
-      IntCmp $R3 90 upgrade_activate_failed upgrade_rename_live upgrade_activate_failed
+      IntCmp $R3 90 upgrade_rename_fallback upgrade_rename_live upgrade_rename_fallback
     upgrade_rename_pending:
       StrCpy $R3 "0"
     upgrade_rename_pending_retry:
@@ -131,6 +131,20 @@ Section "Penglai" SecApp
       IfFileExists "$INSTDIR\Penglai.exe" 0 upgrade_activate_failed
       RMDir /r "$INSTDIR.previous"
       Goto upgrade_done
+    upgrade_rename_fallback:
+      ; Directory MoveFile can stay blocked (Defender/Search) after Penglai.exe
+      ; has exited. Copy the staged payload over the live tree instead of
+      ; deleting INSTDIR, and only then drop the pending staging directory.
+      CreateDirectory "$INSTDIR.previous"
+      CopyFiles /SILENT "$INSTDIR\*.*" "$INSTDIR.previous"
+      ExecWait '"$SYSDIR\robocopy.exe" "$R2" "$INSTDIR" /E /IS /IT /R:5 /W:2 /NFL /NDL /NJH /NJS' $R4
+      IntCmp $R4 8 upgrade_activate_failed 0 upgrade_activate_failed
+      IfFileExists "$INSTDIR\Penglai.exe" 0 upgrade_activate_failed
+      RMDir /r "$R2"
+      FileOpen $R8 "$TEMP\penglai-setup.log" w
+      FileWrite $R8 "phase=activate-copy-fallback r3=$R3 robocopy=$R4$\r$\n"
+      FileClose $R8
+      Goto upgrade_done
     upgrade_copy_failed:
       RMDir /r "$R2"
       FileOpen $R8 "$TEMP\penglai-setup.log" w
@@ -142,9 +156,13 @@ Section "Penglai" SecApp
       FileOpen $R8 "$TEMP\penglai-setup.log" w
       FileWrite $R8 "phase=activate-failed r3=$R3$\r$\n"
       FileClose $R8
+      IfFileExists "$INSTDIR.previous\Penglai.exe" 0 upgrade_abort_keep_live
       RMDir /r "$INSTDIR"
       Rename "$INSTDIR.previous" "$INSTDIR"
       MessageBox MB_ICONSTOP|MB_SETFOREGROUND "Penglai could not activate the new version and restored the previous install." /SD IDOK
+      Abort
+    upgrade_abort_keep_live:
+      MessageBox MB_ICONSTOP|MB_SETFOREGROUND "Penglai could not activate the new version. The previous install was left in place." /SD IDOK
       Abort
     upgrade_done:
   ${Else}

--- a/scripts/verify-upgrade-uninstall.mjs
+++ b/scripts/verify-upgrade-uninstall.mjs
@@ -146,6 +146,7 @@ function installWindows(installer, label) {
       stdout: sanitizeEvidenceText(String(run.stdout ?? ""), 1_000),
       stderr: sanitizeEvidenceText(String(run.stderr ?? ""), 1_000),
       setupLog: readWindowsSetupLog(),
+      lockers: leftoversByCommand(join(String(process.env.LOCALAPPDATA ?? ""), "Penglai", "app", "0.5")).slice(0, 20),
     });
   }
   const localAppData = process.env.LOCALAPPDATA;


### PR DESCRIPTION
## Summary
Native [34133527954](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34133527954) on `a71303f3`:
- both macOS targets **PASS** including upgrade
- Windows u3 / installed **PASS**
- Windows 0.5.11 upgrade NSIS **FAIL** with `setupLog: phase=activate-failed r3=90`

The live `Rename $INSTDIR $INSTDIR.previous` stayed blocked for 90 seconds after `taskkill`. That is a directory-lock class (Defender/Search), not a still-running `Penglai.exe`.

## Change
- After 90 rename retries, **robocopy** the staged payload over the live tree (`upgrade_rename_fallback`) instead of Abort
- `upgrade_activate_failed` restores from `.previous` only when `Penglai.exe` is there; otherwise leave the live install
- Includes the Mnemon 504 retry from #141 (`downloadHttps` retries 408/429/5xx)

Supersedes #141 (same Mnemon commit is in this branch). Does not rewrite 0.5.10.

## Test
leftover 16, windows-host 12, installed-walk 21, mnemon-fetch 8, all pass.