### PR TITLE
fix: do not treat the installer UI proof host as a leftover

### DIFF
--- a/packages/runtime/src/windows-host.test.ts
+++ b/packages/runtime/src/windows-host.test.ts
@@ -323,6 +323,9 @@ test("NSIS script always preserves user data after in-app exact deletion", () =>
   assert.match(uiProof, /UIAutomationClient/);
   assert.match(uiProof, /PrintWindow/);
   assert.doesNotMatch(uiProof, /CopyFromScreen/);
+  assert.match(uiProof, /windows-installer-ui-proof\.ps1/);
+  assert.match(uiProof, /\$ids\.Remove\(\$PID\)/);
+  assert.match(uiProof, /for \(\$attempt = 0; \$attempt -lt 10; \$attempt \+= 1\)/);
   assert.match(payload, /public-export\.json/);
   assert.match(payload, /release-info\.json/);
   assert.match(payload, /stamp-windows-exe\.mjs/);

--- a/scripts/windows-installer-ui-proof.ps1
+++ b/scripts/windows-installer-ui-proof.ps1
@@ -126,7 +126,8 @@ function Get-PenglaiInstallerProcessIds([int]$RootProcessId, [string]$InstallerP
     $changed = $false
     foreach ($row in $rows) {
       $commandLine = [string]$row.CommandLine
-      $isBoundInstaller = (-not [string]::IsNullOrWhiteSpace($commandLine)) -and
+      $isProofHost = $commandLine.IndexOf('windows-installer-ui-proof.ps1', [System.StringComparison]::OrdinalIgnoreCase) -ge 0
+      $isBoundInstaller = (-not $isProofHost) -and (-not [string]::IsNullOrWhiteSpace($commandLine)) -and
         ($commandLine.IndexOf($InstallerPath, [System.StringComparison]::OrdinalIgnoreCase) -ge 0 -or
          $commandLine.IndexOf($InstallTarget, [System.StringComparison]::OrdinalIgnoreCase) -ge 0)
       if (($ids.Contains([int]$row.ParentProcessId) -or $isBoundInstaller) -and $ids.Add([int]$row.ProcessId)) {
@@ -134,19 +135,30 @@ function Get-PenglaiInstallerProcessIds([int]$RootProcessId, [string]$InstallerP
       }
     }
   } while ($changed)
+  [void]$ids.Remove($PID)
   return @($ids)
 }
 
 function Stop-PenglaiInstallerProcessTree([int]$RootProcessId, [string]$InstallerPath, [string]$InstallTarget) {
-  $ids = @(Get-PenglaiInstallerProcessIds $RootProcessId $InstallerPath $InstallTarget | Sort-Object -Descending)
-  foreach ($processId in $ids) {
-    Stop-Process -Id $processId -Force -ErrorAction SilentlyContinue
+  $leftovers = @()
+  for ($attempt = 0; $attempt -lt 10; $attempt += 1) {
+    $ids = @(Get-PenglaiInstallerProcessIds $RootProcessId $InstallerPath $InstallTarget | Sort-Object -Descending)
+    foreach ($processId in $ids) {
+      Stop-Process -Id $processId -Force -ErrorAction SilentlyContinue
+    }
+    Start-Sleep -Milliseconds 500
+    $leftovers = @(Get-PenglaiInstallerProcessIds $RootProcessId $InstallerPath $InstallTarget | Where-Object {
+      ($_ -ne $PID) -and (Get-Process -Id $_ -ErrorAction SilentlyContinue)
+    })
+    if ($leftovers.Count -eq 0) { return }
   }
-  Start-Sleep -Milliseconds 800
-  $leftovers = @(Get-PenglaiInstallerProcessIds $RootProcessId $InstallerPath $InstallTarget | Where-Object {
-    Get-Process -Id $_ -ErrorAction SilentlyContinue
-  })
-  if ($leftovers.Count -gt 0) { throw "installer UI proof left a bound process tree running" }
+  $detail = @(
+    foreach ($processId in $leftovers) {
+      $row = Get-CimInstance Win32_Process -Filter "ProcessId=$processId" -ErrorAction SilentlyContinue
+      "pid=$processId name=$($row.Name) cmd=$($row.CommandLine)"
+    }
+  ) -join '; '
+  throw "installer UI proof left a bound process tree running: $detail"
 }
 
 $installerPath = [System.IO.Path]::GetFullPath($Installer)


### PR DESCRIPTION
Native [34137261412](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34137261412) Windows failed at **Prove Simplified Chinese installer UI**. The UI proof JSON was already `PASS`; shutdown then threw `installer UI proof left a bound process tree running`.

The process collector treated any command line containing the installer path as in-tree, which can include the proof host, and only waited 800ms. Exclude `windows-installer-ui-proof.ps1` and `\$PID`, retry stop, and quote leftover pid/name/cmd on failure.

Does not rewrite 0.5.10.