### PR TITLE
fix: robocopy INSTDIR.pending when Windows cannot rename it

### DIFF
--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -397,8 +397,10 @@ test("Windows child shutdown kills the process tree so NSIS upgrade is not block
   assert.match(nsis, /taskkill\.exe/);
   assert.match(nsis, /penglai-setup\.log/);
   assert.match(nsis, /upgrade_rename_fallback/);
+  assert.match(nsis, /upgrade_pending_fallback/);
   assert.match(nsis, /robocopy\.exe/);
   assert.match(nsis, /upgrade_abort_keep_live/);
+  assert.match(upgrade, /relaxWindowsInstallLocks/);
   assert.match(upgrade, /penglai-setup\.log/);
   assert.match(helper, /ExecutablePath/);
   for (const line of nsis.split(/\r?\n/)) {

--- a/packages/runtime/src/leftover.test.ts
+++ b/packages/runtime/src/leftover.test.ts
@@ -238,6 +238,8 @@ test("Windows upgrade refuses the old live-tree delete-then-copy pattern", async
   assert.match(live, /\/IM Penglai\.exe/);
   assert.match(live, /penglai-setup\.log/);
   assert.match(live, /upgrade_rename_fallback/);
+  assert.match(live, /upgrade_pending_fallback/);
+  assert.match(live, /pending-copy-fallback/);
   assert.match(live, /robocopy\.exe/);
   assert.match(live, /upgrade_abort_keep_live/);
   const noRetry = `

--- a/packages/runtime/src/packaging.ts
+++ b/packages/runtime/src/packaging.ts
@@ -180,6 +180,9 @@ export function assertWindowsUpgradeStaging(script: string): void {
   if (script.indexOf("upgrade_rename_fallback") < 0 || script.indexOf("robocopy.exe") < 0) {
     throw new Error("Windows upgrade must copy the staged payload over a live tree that cannot be renamed");
   }
+  if (script.indexOf("upgrade_pending_fallback") < 0 || script.indexOf("pending-copy-fallback") < 0) {
+    throw new Error("Windows upgrade must copy the staged payload when INSTDIR.pending cannot be renamed");
+  }
   if (script.indexOf("upgrade_abort_keep_live") < 0) {
     throw new Error("Windows upgrade must not delete INSTDIR when INSTDIR.previous was never created");
   }

--- a/packages/runtime/src/windows-host.test.ts
+++ b/packages/runtime/src/windows-host.test.ts
@@ -304,6 +304,7 @@ test("NSIS script always preserves user data after in-app exact deletion", () =>
   assert.match(script, /taskkill\.exe/);
   assert.match(script, /penglai-setup\.log/);
   assert.match(script, /upgrade_rename_fallback/);
+  assert.match(script, /upgrade_pending_fallback/);
   assert.match(script, /robocopy\.exe/);
   assert.match(script, /upgrade_abort_keep_live/);
   const contract = windowsNativeHostContract();

--- a/scripts/nsis/Penglai.nsi
+++ b/scripts/nsis/Penglai.nsi
@@ -126,7 +126,17 @@ Section "Penglai" SecApp
       IfErrors 0 upgrade_rename_ok
       Sleep 1000
       IntOp $R3 $R3 + 1
-      IntCmp $R3 90 upgrade_activate_failed upgrade_rename_pending_retry upgrade_activate_failed
+      IntCmp $R3 90 upgrade_pending_fallback upgrade_rename_pending_retry upgrade_pending_fallback
+    upgrade_pending_fallback:
+      CreateDirectory "$INSTDIR"
+      ExecWait '"$SYSDIR\robocopy.exe" "$R2" "$INSTDIR" /E /IS /IT /R:5 /W:2 /NFL /NDL /NJH /NJS' $R4
+      IntCmp $R4 8 upgrade_activate_failed 0 upgrade_activate_failed
+      IfFileExists "$INSTDIR\Penglai.exe" 0 upgrade_activate_failed
+      RMDir /r "$R2"
+      FileOpen $R8 "$TEMP\penglai-setup.log" w
+      FileWrite $R8 "phase=pending-copy-fallback r3=$R3 robocopy=$R4$\r$\n"
+      FileClose $R8
+      Goto upgrade_done
     upgrade_rename_ok:
       IfFileExists "$INSTDIR\Penglai.exe" 0 upgrade_activate_failed
       RMDir /r "$INSTDIR.previous"

--- a/scripts/verify-upgrade-uninstall.mjs
+++ b/scripts/verify-upgrade-uninstall.mjs
@@ -136,6 +136,33 @@ function readWindowsSetupLog() {
   return sanitizeEvidenceText(text, 2_000);
 }
 
+let lastWindowsDefender = { attempted: false };
+
+function relaxWindowsInstallLocks(app) {
+  if (process.platform !== "win32") return { attempted: false };
+  const root = resolve(String(process.env.LOCALAPPDATA ?? ""), "Penglai");
+  const script = [
+    "Set-MpPreference -DisableRealtimeMonitoring $true",
+    `Add-MpPreference -ExclusionPath '${root.replace(/'/g, "''")}'`,
+    "Get-MpPreference | Select-Object -ExpandProperty DisableRealtimeMonitoring",
+  ].join("; ");
+  const defender = spawnSync("powershell.exe", ["-NoProfile", "-Command", script], {
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: 30_000,
+  });
+  if (app) {
+    spawnSync("taskkill.exe", ["/F", "/T", "/IM", "Penglai.exe"], { windowsHide: true, timeout: 15_000 });
+  }
+  lastWindowsDefender = {
+    attempted: true,
+    status: defender.status,
+    stdout: sanitizeEvidenceText(String(defender.stdout ?? ""), 200),
+    stderr: sanitizeEvidenceText(String(defender.stderr ?? ""), 200),
+  };
+  return lastWindowsDefender;
+}
+
 function installWindows(installer, label) {
   const run = spawnSync(installer, ["/S"], { encoding: "utf8", windowsHide: true, timeout: 20 * 60_000 });
   if (run.error || run.status !== 0) {
@@ -147,6 +174,7 @@ function installWindows(installer, label) {
       stderr: sanitizeEvidenceText(String(run.stderr ?? ""), 1_000),
       setupLog: readWindowsSetupLog(),
       lockers: leftoversByCommand(join(String(process.env.LOCALAPPDATA ?? ""), "Penglai", "app", "0.5")).slice(0, 20),
+      defender: lastWindowsDefender,
     });
   }
   const localAppData = process.env.LOCALAPPDATA;
@@ -246,6 +274,7 @@ if (target === "win32-x86_64") {
 
 const previousIdentity = assertVersion(app, previousVersion, "previous install");
 const previousBoot = await boot(app, userData, "previous install");
+if (target === "win32-x86_64") relaxWindowsInstallLocks(app);
 
 if (target === "win32-x86_64") {
   app = installWindows(currentInstaller, "0.5.11 upgrade");
@@ -311,4 +340,5 @@ finish("PASS", {
   upgradePreservedOwnerData: true,
   uninstallRemovedApp: true,
   uninstallPreservedOwnerData: true,
+  defender: lastWindowsDefender,
 });


### PR DESCRIPTION
Native [34139541073](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34139541073) both macOS PASS; Windows upgrade still `phase=activate-failed r3=90` with \`lockers: []\`.

That pattern is live-dir rename succeeding, then **pending** (the just-copied 0.5.11 payload) staying locked for 90s. The previous fallback only covered live-dir rename.

- NSIS: \`upgrade_pending_fallback\` robocopies \`$INSTDIR.pending\` onto \`$INSTDIR\`
- Upgrade harness: disable Defender realtime + exclusion for \`%LOCALAPPDATA%\\Penglai\` before the 0.5.11 installer

Does not rewrite 0.5.10.