### PR TITLE
fix: retry Windows uninstall after upgrade staging leftovers

### DIFF
--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -400,6 +400,7 @@ test("Windows child shutdown kills the process tree so NSIS upgrade is not block
   assert.match(nsis, /upgrade_pending_fallback/);
   assert.match(nsis, /robocopy\.exe/);
   assert.match(nsis, /upgrade_abort_keep_live/);
+  assert.match(nsis, /uninstall_rmdir_retry/);
   assert.match(upgrade, /relaxWindowsInstallLocks/);
   assert.match(upgrade, /penglai-setup\.log/);
   assert.match(helper, /ExecutablePath/);

--- a/packages/runtime/src/leftover.test.ts
+++ b/packages/runtime/src/leftover.test.ts
@@ -242,6 +242,9 @@ test("Windows upgrade refuses the old live-tree delete-then-copy pattern", async
   assert.match(live, /pending-copy-fallback/);
   assert.match(live, /robocopy\.exe/);
   assert.match(live, /upgrade_abort_keep_live/);
+  assert.match(live, /uninstall_rmdir_retry/);
+  assert.match(live, /RMDir \/r "\$INSTDIR\.pending"/);
+  assert.match(live, /RMDir \/r "\$INSTDIR\.previous"/);
   const noRetry = `
     StrCpy $R2 "$INSTDIR.pending"
     SetOutPath "$R2"

--- a/packages/runtime/src/packaging.ts
+++ b/packages/runtime/src/packaging.ts
@@ -202,6 +202,9 @@ export function assertWindowsUpgradeStaging(script: string): void {
   if (/RMDir\s+\/r\s+"\$LOCALAPPDATA\\Penglai\\app\\0\.5"/.test(script)) {
     throw new Error("Windows upgrade must not delete the live app tree before the new payload exists");
   }
+  if (script.indexOf("uninstall_rmdir_retry") < 0 || script.indexOf('RMDir /r "$INSTDIR.pending"') < 0) {
+    throw new Error("Windows uninstall must retry removing INSTDIR and drop upgrade staging directories");
+  }
 }
 
 export const CROSS_BUILD_TARGETS = [

--- a/packages/runtime/src/windows-host.test.ts
+++ b/packages/runtime/src/windows-host.test.ts
@@ -297,7 +297,9 @@ test("NSIS script always preserves user data after in-app exact deletion", () =>
   assert.match(script, /CreateShortCut\s+"\$DESKTOP\\Penglai\.lnk"/);
   assert.match(script, /Delete\s+"\$DESKTOP\\Penglai\.lnk"/);
   // The recursive app-tree delete must be guarded to the default install dir.
-  assert.match(script, /RMDir\s+\/r\s+"\$INSTDIR"\s*\n\s*\$\{Else\}/);
+  assert.match(script, /\$R0 S== \$R1/);
+  assert.match(script, /uninstall_rmdir_retry/);
+  assert.match(script, /Keeping custom install directory/);
   assert.match(script, /\$INSTDIR\.pending/);
   assert.match(script, /previous install was left in place/);
   assert.match(script, /upgrade_rename_live/);

--- a/scripts/nsis/Penglai.nsi
+++ b/scripts/nsis/Penglai.nsi
@@ -219,7 +219,19 @@ Section "un.Penglai" SectionUninstall
   StrCpy $R0 "$INSTDIR"
   StrCpy $R1 "$LOCALAPPDATA\Penglai\app\0.5"
   ${If} $R0 S== $R1
-    RMDir /r "$INSTDIR"
+    ExecWait '"$SYSDIR\taskkill.exe" /F /T /IM Penglai.exe' $R4
+    ExecWait '"$SYSDIR\taskkill.exe" /F /T /IM "Penglai Helper.exe"' $R4
+    Sleep 1000
+    RMDir /r "$INSTDIR.pending"
+    RMDir /r "$INSTDIR.previous"
+    StrCpy $R3 "0"
+    uninstall_rmdir_retry:
+      RMDir /r "$INSTDIR"
+      IfFileExists "$INSTDIR\Penglai.exe" 0 uninstall_rmdir_done
+      Sleep 1000
+      IntOp $R3 $R3 + 1
+      IntCmp $R3 30 uninstall_rmdir_done uninstall_rmdir_retry uninstall_rmdir_done
+    uninstall_rmdir_done:
   ${Else}
     DetailPrint "Keeping custom install directory $INSTDIR (not the default app tree)."
   ${EndIf}

--- a/scripts/verify-upgrade-uninstall.mjs
+++ b/scripts/verify-upgrade-uninstall.mjs
@@ -294,6 +294,8 @@ const currentBoot = await boot(app, userData, "upgraded install");
 if (!existsSync(sentinel)) fail("upgrade did not preserve isolated Owner data");
 
 if (target === "win32-x86_64") {
+  await reapWindowsInstallTree(app);
+  relaxWindowsInstallLocks(app);
   const uninstaller = join(app, "Uninstall.exe");
   if (!existsSync(uninstaller)) fail("Windows uninstaller missing after upgrade");
   const uninstall = spawnSync(uninstaller, ["/S", `_?=${app}`], {


### PR DESCRIPTION
Native [34142562461](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34142562461): both macOS PASS. Windows **0.5.11 upgrade from 0.5.8 succeeded**, then:

\`uninstall did not remove only the app while preserving Owner data\` (\`appRemoved: false\`, \`ownerDataPreserved: true\`).

Uninstaller now taskkills Penglai, deletes \`$INSTDIR.pending\` / \`$INSTDIR.previous\`, and retries \`RMDir /r \$INSTDIR\`. Harness reaps and excludes Defender before \`Uninstall.exe\`.

Does not rewrite 0.5.10.