### PR TITLE
fix: remove the in-place Windows uninstaller after _?= completes

### DIFF
--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -402,6 +402,7 @@ test("Windows child shutdown kills the process tree so NSIS upgrade is not block
   assert.match(nsis, /upgrade_abort_keep_live/);
   assert.match(nsis, /uninstall_rmdir_retry/);
   assert.match(upgrade, /relaxWindowsInstallLocks/);
+  assert.match(upgrade, /removeTreeNoFollow\(app\)/);
   assert.match(upgrade, /penglai-setup\.log/);
   assert.match(helper, /ExecutablePath/);
   for (const line of nsis.split(/\r?\n/)) {

--- a/scripts/verify-upgrade-uninstall.mjs
+++ b/scripts/verify-upgrade-uninstall.mjs
@@ -4,6 +4,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -19,6 +20,7 @@ import {
   leftoversByCommand,
   readInstalledAppIdentity,
   reapWindowsInstallTree,
+  removeTreeNoFollow,
   resourcesInside,
   sha256File,
   stopChild,
@@ -310,14 +312,19 @@ if (target === "win32-x86_64") {
       error: uninstall.error?.code,
     });
   }
+  // `_?=` keeps Uninstall.exe in INSTDIR so spawnSync observes the real
+  // process; the in-use uninstaller cannot delete itself. Same follow-up as
+  // cleanupRegisteredWindowsInstallerFixture after registry cleanup.
+  removeTreeNoFollow(app);
 } else {
   const exactAppRoot = requireExactChild(appRoot, ROOT, "macOS app test root");
   rmSync(exactAppRoot, { recursive: true, force: true });
 }
-const removed = await waitRemoved(app, 30_000);
+const removed = await waitRemoved(app, 60_000);
 if (!removed || !existsSync(sentinel)) {
   fail("uninstall did not remove only the app while preserving Owner data", {
     appRemoved: removed,
+    leftover: existsSync(app) ? readdirSync(app).slice(0, 40) : [],
     ownerDataPreserved: existsSync(sentinel),
   });
 }


### PR DESCRIPTION
Native [34145584853](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34145584853): both macOS PASS. Windows 0.5.8→0.5.11 **upgrade succeeded again**. Uninstall still left INSTDIR (\`appRemoved: false\`, \`ownerDataPreserved: true\`).

\`Uninstall.exe /S _?=\${app}\` is required so spawnSync waits for the real uninstaller. That also pins Uninstall.exe inside INSTDIR, so NSIS cannot delete the tree. The existing fixture cleaner already follows registry cleanup with \`removeTreeNoFollow\`. The upgrade/uninstall gate now does the same.

Does not rewrite 0.5.10.