### PR TITLE
fix: require every pinned upgrade source in the native evidence set

### DIFF
--- a/scripts/lib/native-upgrade-set.mjs
+++ b/scripts/lib/native-upgrade-set.mjs
@@ -1,0 +1,21 @@
+export function expectedUpgradeSourceVersions(upgradeSources) {
+  if (!Array.isArray(upgradeSources?.sources)) return [];
+  return upgradeSources.sources.map((row) => String(row.version ?? "")).filter(Boolean).sort();
+}
+
+export function upgradeUninstallEvidenceMatches(record, { sourceSha, installerSha256, expectedVersions }) {
+  const versions = [...(record?.previousVersions ?? [])].sort();
+  if (JSON.stringify(versions) !== JSON.stringify(expectedVersions)) return false;
+  if (!Array.isArray(record.upgradePaths) || record.upgradePaths.length !== expectedVersions.length) return false;
+  return record.upgradePaths.every(
+    (row) =>
+      row?.verdict === "PASS" &&
+      row.previous?.boot?.freshReadiness === true &&
+      row.current?.boot?.freshReadiness === true &&
+      row.sourceSha === sourceSha &&
+      row.current?.installerSha256 === installerSha256 &&
+      row.upgradePreservedOwnerData === true &&
+      row.uninstallPreservedOwnerData === true &&
+      row.uninstallRemovedApp === true,
+  );
+}

--- a/scripts/lib/native-upgrade-set.test.mjs
+++ b/scripts/lib/native-upgrade-set.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { ROOT } from "./repo.mjs";
+import { expectedUpgradeSourceVersions, upgradeUninstallEvidenceMatches } from "./native-upgrade-set.mjs";
+
+const sources = JSON.parse(readFileSync(join(ROOT, "docs/0.5.11/UPGRADE_SOURCES.json"), "utf8"));
+
+function passingPath(version, sourceSha, installerSha256) {
+  return {
+    verdict: "PASS",
+    sourceSha,
+    previous: { version, boot: { freshReadiness: true } },
+    current: { installerSha256, boot: { freshReadiness: true } },
+    upgradePreservedOwnerData: true,
+    uninstallPreservedOwnerData: true,
+    uninstallRemovedApp: true,
+  };
+}
+
+test("native upgrade set follows every pinned previous version, not a hardcoded pair", () => {
+  const expected = expectedUpgradeSourceVersions(sources);
+  assert.deepEqual(expected, ["0.5.10", "0.5.8", "0.5.9"]);
+  const sourceSha = "a".repeat(40);
+  const installerSha256 = "b".repeat(64);
+  const twoPaths = {
+    previousVersions: ["0.5.8", "0.5.9"],
+    upgradePaths: [
+      passingPath("0.5.8", sourceSha, installerSha256),
+      passingPath("0.5.9", sourceSha, installerSha256),
+    ],
+  };
+  assert.equal(
+    upgradeUninstallEvidenceMatches(twoPaths, { sourceSha, installerSha256, expectedVersions: expected }),
+    false,
+  );
+  const threePaths = {
+    previousVersions: ["0.5.8", "0.5.9", "0.5.10"],
+    upgradePaths: expected.map((version) => passingPath(version, sourceSha, installerSha256)),
+  };
+  assert.equal(
+    upgradeUninstallEvidenceMatches(threePaths, { sourceSha, installerSha256, expectedVersions: expected }),
+    true,
+  );
+});

--- a/scripts/verify-native-set.mjs
+++ b/scripts/verify-native-set.mjs
@@ -4,6 +4,7 @@ import { ROOT } from "./lib/repo.mjs";
 import { requireCleanCandidateSource } from "./lib/candidate-source.mjs";
 import { finish } from "./lib/exit-contract.mjs";
 import { evidenceName, installerForTarget, RELEASE_TARGETS } from "./lib/release-targets.mjs";
+import { expectedUpgradeSourceVersions, upgradeUninstallEvidenceMatches } from "./lib/native-upgrade-set.mjs";
 
 const allowed = new Set([
   "verify:artifact",
@@ -69,9 +70,22 @@ for (const target of RELEASE_TARGETS) {
     });
   }
   if (command === "verify:upgrade-uninstall") {
-    const versions = [...(record.previousVersions ?? [])].sort();
-    if (JSON.stringify(versions) !== JSON.stringify(["0.5.8", "0.5.9"]) || record.upgradePaths?.length !== 2 || record.upgradePaths.some((row) => row.verdict !== "PASS" || row.previous?.boot?.freshReadiness !== true || row.current?.boot?.freshReadiness !== true || row.sourceSha !== source.git.head || row.current?.installerSha256 !== installerEvidence.sha256 || !row.upgradePreservedOwnerData || !row.uninstallPreservedOwnerData || !row.uninstallRemovedApp)) {
-      finish("INCOMPLETE", { command: "verify:native-set", gate: command, reason: "both native upgrade paths must pass on these installer bytes", target });
+    const upgradeSources = JSON.parse(readFileSync(join(ROOT, "docs/0.5.11/UPGRADE_SOURCES.json"), "utf8"));
+    const expectedVersions = expectedUpgradeSourceVersions(upgradeSources);
+    if (
+      !upgradeUninstallEvidenceMatches(record, {
+        sourceSha: source.git.head,
+        installerSha256: installerEvidence.sha256,
+        expectedVersions,
+      })
+    ) {
+      finish("INCOMPLETE", {
+        command: "verify:native-set",
+        gate: command,
+        reason: "every pinned native upgrade path must pass on these installer bytes",
+        target,
+        expectedVersions,
+      });
     }
   }
   if (command === "verify:profile") {


### PR DESCRIPTION
Native [34148252739](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34148252739) on \`5a057611\`:

- macOS darwin-aarch64 **SUCCESS**
- macOS darwin-x86_64 **SUCCESS**
- Windows win32-x86_64 **SUCCESS**
- Exact three-target evidence aggregate **INCOMPLETE**: \`both native upgrade paths must pass on these installer bytes\` for darwin-aarch64

Per-target upgrade/uninstall already ran 0.5.8+0.5.9+0.5.10. The aggregator still hardcoded the old pair. It now reads \`docs/0.5.11/UPGRADE_SOURCES.json\`.

Does not rewrite 0.5.10.