### PR TITLE
docs: publish verified 0.5.11 downloads and bilingual release records

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center"><strong>DeepSeek Harness, ready to live on a personal computer.</strong></p>
 
 <p align="center">
-  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.10"><img src="https://img.shields.io/badge/release-0.5.10-0f766e?style=flat-square" alt="Penglai 0.5.10 release"></a>
+  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.11"><img src="https://img.shields.io/badge/release-0.5.11-0f766e?style=flat-square" alt="Penglai 0.5.11 release"></a>
   <a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://img.shields.io/badge/DSH-0.1.2--rc.1-7c3aed?style=flat-square" alt="DeepSeek Harness 0.1.2-rc.1"></a>
   <img src="https://img.shields.io/badge/targets-Apple%20Silicon%20%7C%20Intel%20Mac%20%7C%20Windows%20x64-0f766e?style=flat-square" alt="Apple Silicon, Intel Mac, and Windows x64">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-16a34a?style=flat-square" alt="MIT License"></a>
@@ -19,29 +19,28 @@
   <a href="#english">English</a> ·
   <a href="#中文">中文</a> ·
   <a href="https://penglai.pages.dev">Website</a> ·
-  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.10">Download 0.5.10</a> ·
-  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.10">0.5.10 notes</a> ·
+  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.11">Download 0.5.11</a> ·
+  <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.11">0.5.11 notes</a> ·
   <a href="AGENTS.md">For AI contributors</a> ·
   <a href="SECURITY.md">Security</a>
 </p>
 
-> The current public product is Penglai 0.5.10, an immutable release built from
-> `c5c0bcb022c5ae47cca242deb27fe1d30444c41d`. It consumes official DSH `0.1.2-rc.1` npm packages,
+> The current public product is Penglai 0.5.11, an immutable release built from
+> `77e7105773b4d43abb7315ea6e83abe17e646cb4`. It consumes official DSH `0.1.2-rc.1` npm packages,
 > reconciled to tag `dsh-v0.1.2-rc.1` at
 > `a66e4702047846cdaa10c66c9d3df3951f5ea70d`. All 254 package archives,
 > registry signatures and pinned source manifests were verified.
 > The release includes three native installers and all seven integrity and license files.
 > macOS is ad-hoc signed and not notarized; Windows has no Authenticode.
-> [Release notes](docs/RELEASE_NOTES_0.5.10.md) · [Verified publication](docs/PUBLICATION_MANIFEST_0.5.10.md)
+> [Release notes](docs/RELEASE_NOTES_0.5.11.md) · [Verified publication](docs/PUBLICATION_MANIFEST_0.5.11.md)
 >
-> 0.5.11 is in development on this branch. It is not a published installer set.
-> Do not treat source tests as native, live-account or public-release evidence.
+> Published v0.5.10 tags and assets remain immutable. Source tests are not live-account evidence.
 
 <p align="center">
   <img src=".github/assets/0.5.5/plugin-center.png" width="49%" alt="Penglai 0.5.5 Plugin Center in the installed DSH settings">
   <img src=".github/assets/0.5.5/memory.png" width="49%" alt="Penglai Memory in the installed DSH settings">
 </p>
-<p align="center"><sub>Installed 0.5.5 screenshots are retained only as UI references. The 0.5.10 native-install evidence is recorded in its successful native run; these older images are not presented as 0.5.10 screenshots.</sub></p>
+<p align="center"><sub>Installed 0.5.5 screenshots are retained only as UI references. The 0.5.11 native-install evidence is recorded in its successful native run; these older images are not presented as 0.5.11 screenshots.</sub></p>
 
 <a id="english"></a>
 
@@ -62,23 +61,21 @@ actually usable: packaging, process supervision, onboarding, local paths,
 upgrades, uninstall, product identity, and plugin distribution. There is no
 second Penglai agent hiding beside DSH and no replacement chat page.
 
-Version 0.5.10 adapts message recovery, budget reconciliation and Companion
-replay to the official Session snapshot API. Upgrades from 0.5.8 and 0.5.9 use
-an isolated rc.1 DSH Home and preserve the previous generation for rollback.
-All three native installers pass credential-free onboarding and plugin checks,
-both upgrade paths, and default uninstall with user data preserved.
+Version 0.5.11 keeps that official Session snapshot path and adds isolation,
+recovery, Memory library, official IM question/approval identity, bounded PDF
+inspect, and redacted Plugin Center diagnostics. Upgrades from 0.5.8, 0.5.9
+and 0.5.10 use an isolated rc.1 DSH Home and preserve the previous generation
+for rollback. All three native installers pass credential-free onboarding and
+plugin checks, the three pinned upgrade paths, and default uninstall with user
+data preserved.
 
-The public download is still 0.5.10. 0.5.11 is in development on this branch
-and has no published installers. Source tests are not native, live-account or
-public-release evidence.
-
-## What ships in 0.5.10
+## What ships in 0.5.11
 
 | Product surface | Fresh install | What it does |
 | --- | --- | --- |
 | Penglai Office | On | Inspect, create, edit, preview, and save DOCX, XLSX, PPTX, and PDF |
 | Penglai Memory | On | Automatic current-Workspace memory, explicit personal memory, authorised sources, provenance, and a knowledge graph |
-| Mobile Messaging | Off | Eight platform connectors under one IM control plane; WhatsApp is not exposed or supported in 0.5.10 |
+| Mobile Messaging | Off | Eight platform connectors under one IM control plane; WhatsApp is not exposed or supported in 0.5.11 |
 | Speech Recognition | Off | Local SenseVoice transcription; enabling it adds the conversation microphone entry |
 | Voice Generation | Off | Local MOSS-TTS-Nano preview, desktop playback, and supported channel audio |
 | Companion | Off | Opt-in scheduled contact with quiet hours, daily limits, and a bound IM route |
@@ -205,17 +202,17 @@ go Back, retry a failed credential, resume after restart, and reject the app's
 own data or installation directory as a Workspace. Finishing the wizard means a
 real model reply was received, not merely that a health endpoint answered.
 
-The immutable [0.5.10 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.10)
+The immutable [0.5.11 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.11)
 contains exactly ten files: three native installers and seven integrity and license
 files. All installers were built from the same source SHA
-and passed [native installed-product gates](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33775824578)
+and passed [native installed-product gates](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34151469696)
 and public download readback:
 
 | Platform | Release asset | Bytes | SHA-256 |
 | --- | --- | ---: | --- |
-| Apple Silicon, macOS 13+ | [`Penglai_0.5.10_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_aarch64.dmg) | 471,410,669 | `0fdca1a2d64c536088b53ddd4910851e9876abed4ee114aecd7a1437ff9417e5` |
-| Intel Mac | [`Penglai_0.5.10_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_x64.dmg) | 407,030,741 | `6771901b5bf3b7e9e0c192125a866bf2e6c1c605655a8d07339ea37dc64ee9ea` |
-| Windows x64 | [`Penglai_0.5.10_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_windows_x64_setup.exe) | 357,546,167 | `46b45bbb6a18859c7be03413b7983ad90dacc7710233130b2c81cb5a537bd484` |
+| Apple Silicon, macOS 13+ | [`Penglai_0.5.11_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_aarch64.dmg) | 467,172,406 | `7a59833e32ae7cdcfc6dae6b1c2d744f251cb929cf251d758479c25fca41c536` |
+| Intel Mac | [`Penglai_0.5.11_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_x64.dmg) | 408,749,431 | `783fcf5c042998d1a550d7c48fe30879d78f996d5602f002dea411826e210798` |
+| Windows x64 | [`Penglai_0.5.11_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_windows_x64_setup.exe) | 357,628,547 | `5862cf0df14daf12ef223d5a825cad501ea56f78a40cdb54bef4fa8b7779c929` |
 
 Use the same-platform installer as a manual overlay when upgrading. There is no
 silent update. External Workspaces and the `Penglai/0.5` data generation are
@@ -337,21 +334,19 @@ Turn 和会话界面都归 DSH。蓬莱负责那些不太耀眼、却决定桌�
 事情：打包、进程监管、安装引导、本地目录、升级、卸载、产品身份和插件分发。这里
 没有藏着第二套蓬莱 Agent，也没有另做一张聊天页替代 DSH。
 
-0.5.10 使用未经修改的官方 DSH `0.1.2-rc.1` npm 包，并让消息恢复、预算结算和
-主动陪伴回放适配官方 Session 快照接口。从 0.5.8 和 0.5.9 升级时使用独立的
-rc.1 数据目录，保留旧代际用于回退。三端安装包均通过无需真实账号的引导和插件
-检查、两条升级路径，以及默认保留用户数据的卸载验证。
+0.5.11 继续使用未经修改的官方 DSH `0.1.2-rc.1` npm 包，并补上隔离、恢复、
+记忆库、官方 IM 提问/审批身份、有界 PDF 检查和脱敏插件诊断。从 0.5.8、0.5.9
+和 0.5.10 升级时使用独立的 rc.1 数据目录，保留旧代际用于回退。三端安装包均
+通过无需真实账号的引导和插件检查、三条升级路径，以及默认保留用户数据的卸载
+验证。
 
-当前公开下载仍是 0.5.10。0.5.11 还在开发，没有安装包，也没有公开发布附件。
-源码测试不能当作原生安装、真实账号或公开发布证据。
-
-## 0.5.10 带来了什么
+## 0.5.11 带来了什么
 
 | 产品功能 | 全新安装 | 能做什么 |
 | --- | --- | --- |
 | 蓬莱办公 | 默认启用 | 检查、创建、编辑、预览和保存 DOCX、XLSX、PPTX、PDF |
 | 蓬莱记忆 | 默认启用 | 当前 Workspace 自动记忆、明确个人记忆、授权资料、来源追溯和知识图谱 |
-| 消息连接 | 默认关闭 | 八个平台共用一个 IM 控制平面；0.5.10 不展示或支持 WhatsApp |
+| 消息连接 | 默认关闭 | 八个平台共用一个 IM 控制平面；0.5.11 不展示或支持 WhatsApp |
 | 蓬莱语音识别 | 默认关闭 | 本地 SenseVoice 转写；启用后为电脑会话提供麦克风入口 |
 | 蓬莱语音生成 | 默认关闭 | 本地 MOSS-TTS-Nano 试听、电脑播放和支持渠道的语音输出 |
 | 蓬莱主动陪伴 | 默认关闭 | 安静时段、每日上限、指定 IM 路由下的主动联系 |
@@ -456,17 +451,17 @@ SenseVoice 和 MOSS-TTS 默认关闭，是因为模型文件较大。语音识�
 真实 DSH Turn。它支持返回、密钥失败后重试、重启后续接，也会拒绝把应用数据目录
 或安装目录选作 Workspace。只有模型真的回复了，才算完成，不会拿健康接口冒充。
 
-不可变的 [0.5.10 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.10)
+不可变的 [0.5.11 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.11)
 固定十项附件：三个原生安装包和七项完整性、签名与许可证材料。
 三个安装包来自同一源码提交，并已通过
-[三端原生安装门禁](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/33775824578)
+[三端原生安装门禁](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34151469696)
 和公网下载回读：
 
 | 平台 | 正式文件 | 字节数 | SHA-256 |
 | --- | --- | ---: | --- |
-| Apple Silicon，macOS 13+ | [`Penglai_0.5.10_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_aarch64.dmg) | 471,410,669 | `0fdca1a2d64c536088b53ddd4910851e9876abed4ee114aecd7a1437ff9417e5` |
-| Intel Mac | [`Penglai_0.5.10_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_x64.dmg) | 407,030,741 | `6771901b5bf3b7e9e0c192125a866bf2e6c1c605655a8d07339ea37dc64ee9ea` |
-| Windows x64 | [`Penglai_0.5.10_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_windows_x64_setup.exe) | 357,546,167 | `46b45bbb6a18859c7be03413b7983ad90dacc7710233130b2c81cb5a537bd484` |
+| Apple Silicon，macOS 13+ | [`Penglai_0.5.11_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_aarch64.dmg) | 467,172,406 | `7a59833e32ae7cdcfc6dae6b1c2d744f251cb929cf251d758479c25fca41c536` |
+| Intel Mac | [`Penglai_0.5.11_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_x64.dmg) | 408,749,431 | `783fcf5c042998d1a550d7c48fe30879d78f996d5602f002dea411826e210798` |
+| Windows x64 | [`Penglai_0.5.11_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_windows_x64_setup.exe) | 357,628,547 | `5862cf0df14daf12ef223d5a825cad501ea56f78a40cdb54bef4fa8b7779c929` |
 
 升级时使用同平台安装包手动覆盖即可。它不会静默升级；外部 Workspace 与
 `Penglai/0.5` 数据代际会保留。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,17 +1,18 @@
 # Security Policy
 
-Penglai 0.5.10 is a **community-verified** desktop distribution of official DeepSeek Harness (DSH). This file is the public security entry. The full product contract lives in [`docs/SECURITY.md`](docs/SECURITY.md).
+Penglai 0.5.11 is a **community-verified** desktop distribution of official DeepSeek Harness (DSH). This file is the public security entry. The full product contract lives in [`docs/SECURITY.md`](docs/SECURITY.md).
 
 ## Supported versions
 
 | Version | Status |
 | --- | --- |
-| 0.5.10 | Current immutable public release |
-| 0.5.8 and 0.5.9 | Historical releases; native upgrades to 0.5.10 verified on all three targets |
+| 0.5.11 | Current immutable public release |
+| 0.5.10 | Historical immutable release; native upgrades to 0.5.11 verified on all three targets |
+| 0.5.8 and 0.5.9 | Historical releases; native upgrades to 0.5.11 verified on all three targets |
 | Earlier 0.5.x | Historical releases; use the documented migration path |
 | 0.4.1 and earlier | Unsupported; 0.5 does not silently import or delete old secrets or databases |
 
-The 0.5.10 release contains all ten files in its release contract, including
+The 0.5.11 release contains all ten files in its release contract, including
 signed update metadata, SHA256SUMS, the three-target SBOM and third-party notices.
 The immutable 0.5.9 release contains only its three installers; its missing
 metadata is a historical publication defect. Do not infer signed updater
@@ -48,7 +49,7 @@ Adapters cannot call a parallel Agent. `docs/0.5.7/LIVE_IM_MATRIX.md` preserves
 historical account-test requirements; it does not establish current-version live
 results. Current account journeys are claimed only with current evidence. Slack,
 Telegram, and Discord do not fake QR.
-WhatsApp is not displayed, supported, planned, or bundled in 0.5.10.
+WhatsApp is not displayed, supported, planned, or bundled in 0.5.11.
 
 - Weixin: real QR login. The scanner is the only allowed identity unless the user expands the allowlist.
 - Feishu: the official application-registration QR flow is used where available, with manual App ID/Secret setup as a fallback. Penglai does not host the application or invent a login QR.
@@ -79,11 +80,11 @@ Penglai will not claim notarization, Authenticode, App Store trust, silent auto-
 
 ## 中文
 
-当前正式版本为 0.5.10，使用固定的官方 DSH `0.1.2-rc.1` npm 包。
-Apple Silicon、Intel Mac 和 Windows x64 均验证从 0.5.8、0.5.9 升级并在默认
+当前正式版本为 0.5.11，使用固定的官方 DSH `0.1.2-rc.1` npm 包。
+Apple Silicon、Intel Mac 和 Windows x64 均验证从 0.5.8、0.5.9、0.5.10 升级并在默认
 卸载后保留用户数据。旧版 DSH Home 保留，rc.1 在独立目录通过健康检查后启用。
 
-0.5.10 的正式发布包含十项完整附件，包括签名更新清单、校验和、三端 SBOM 与
+0.5.11 的正式发布包含十项完整附件，包括签名更新清单、校验和、三端 SBOM 与
 第三方声明。0.5.9 历史发布只有三个安装包，缺少元数据属于当时的发布缺陷；
 不能据此声称该版签名更新链路完整。原有不可变附件未被修改。
 

--- a/docs/0.5.11/TODO.md
+++ b/docs/0.5.11/TODO.md
@@ -78,8 +78,8 @@ relevant row; no row is closed by intent or a matching version string.
 - [x] V06 Run formatting/typecheck/unit/contract/integration/E2E/security/chaos/deterministic soak and relevant failure baselines; repair every in-scope failure.
 - [x] V07 Run versions/identity/contracts/dependencies/licenses/secrets/SBOM/notices/cohort/closure/profile/clean-clone gates.
 - [x] V08 Run real fixed-DSH plugin/Remote/connection disposal and profile-mode checks; execute Office-real and Memory-real.
-- [ ] V09 Build Apple Silicon/Intel Mac/Windows x64 from one clean main SHA; verify architecture, native helpers, packaged runtime and signatures.
-- [ ] V10 Run matching-native fresh/restart/Back/retry/invalid-path/credential-recovery/plugin/upgrade/uninstall checks; preserve user data and old Home generations.
+- [x] V09 Build Apple Silicon/Intel Mac/Windows x64 from one clean main SHA; verify architecture, native helpers, packaged runtime and signatures.
+- [x] V10 Run matching-native fresh/restart/Back/retry/invalid-path/credential-recovery/plugin/upgrade/uninstall checks; preserve user data and old Home generations.
 - [ ] V11 Record actual account/live observations when available; leave unavailable supplemental observations explicitly unrun, never promote fixtures to live PASS.
 - [x] V12 Confirm the two-hour installed soak is absent from the required execution path while deterministic `test:soak` remains required.
 
@@ -90,10 +90,10 @@ relevant row; no row is closed by intent or a matching version string.
 - [x] W03 Redesign existing English/Chinese website with responsive layout, accessible controls and professional typography; preserve official publication architecture and URLs.
 - [x] W04 Validate desktop/mobile layouts, keyboard/language navigation, downloads and source-vs-installer claims; show the resulting preview.
 - [x] P01 Complete 0.5.11 acceptance delta/release notes/security/upgrade documentation and final requirement-by-requirement review.
-- [ ] P02 Complete normal source review, commits, push/PR/merge workflow without including unrelated Owner changes.
-- [ ] P03 Assemble the exact contract asset set from the accepted native builds; validate draft download hashes, signatures and source identity.
-- [ ] P04 Complete the applicable immutable release/publication workflow and exact public-byte readback; keep 0.5.10 untouched.
-- [ ] P05 Publish README/website release claims only after public artifacts exist, verify live links/pages, and close this ledger with authoritative evidence.
+- [x] P02 Complete normal source review, commits, push/PR/merge workflow without including unrelated Owner changes.
+- [x] P03 Assemble the exact contract asset set from the accepted native builds; validate draft download hashes, signatures and source identity.
+- [x] P04 Complete the applicable immutable release/publication workflow and exact public-byte readback; keep 0.5.10 untouched.
+- [x] P05 Publish README/website release claims only after public artifacts exist, verify live links/pages, and close this ledger with authoritative evidence.
 
 ## 中文说明
 
@@ -271,3 +271,14 @@ F05 identity is now retitled on `release/0.5.11` from `origin/main` `24b7aa09`. 
 - Source gates on this dirty tree: `format:check` ok; `typecheck` ok; `test:unit` 908 pass / 2 skip; `test:contract` 134; `test:security` 15; `verify:versions` PASS 0.5.11; `verify:identity` PASS dirty=true UNFROZEN; `verify:contracts` ok 0.5.11.
 - Intel native u3 on 0.5.10-named run `34104666669` failed `sawGateway` after the last restart; this tree waits 180s for `gateway.port` and drains leftover DSH processes before the next phase. That run cannot publish as 0.5.11.
 - V09/V10/P03–P05 still require a new three-target native run from a clean main SHA after this identity lands. Do not publish 0.5.10-named artifacts as 0.5.11.
+
+## Incremental verification — 2026-09-08 (public v0.5.11)
+
+Public identity is **0.5.11**. Immutable release [`v0.5.11`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.11). Source SHA `77e7105773b4d43abb7315ea6e83abe17e646cb4`. Published v0.5.10 was not rewritten.
+
+- V09/V10: three-target native [PASS](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34151469696) including 0.5.8/0.5.9/0.5.10 upgrade and default uninstall.
+- P03: ten-file draft assembled; hashes match `SHA256SUMS`.
+- P04: publication and public-byte readback [PASS](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34155522316).
+- P05: README, `website/`, and SECURITY.md download tables updated to the public bytes in `docs/PUBLICATION_MANIFEST_0.5.11.md`.
+- V11: still unrun. No live model/IM credentials. Fixtures are not live PASS.
+- R511-02c: Mnemon remains `0.2.4`. Windows special-character paths / old database copies still unrun as a dedicated native Mnemon row.

--- a/docs/PUBLICATION_MANIFEST_0.5.11.md
+++ b/docs/PUBLICATION_MANIFEST_0.5.11.md
@@ -1,0 +1,39 @@
+# PUBLICATION_MANIFEST 0.5.11
+
+Status: `PUBLIC_READBACK_PASS`
+
+All ten immutable assets were downloaded after publication. Their exact sizes, SHA-256 digests, update signature and installer signatures passed verification. The table records observed public bytes; source templates remain `UNFROZEN` and are not substituted for generated release identities.
+
+| Field | Value |
+| --- | --- |
+| Product | `0.5.11` |
+| DSH | official unmodified npm `0.1.2-rc.1`; tag `dsh-v0.1.2-rc.1`; commit `a66e4702047846cdaa10c66c9d3df3951f5ea70d` |
+| Upstream cohort | 254 packages with registry archive, signature and fixed-source manifest verification |
+| Build source SHA | `77e7105773b4d43abb7315ea6e83abe17e646cb4` |
+| Public export tree | `9cb435dd9d1508c42c9314349476695ecbc60d9d776d89c403000e8ddfdcf585` |
+| Release | [`v0.5.11`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.11), immutable |
+| Three native targets | [PASS](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34151469696) |
+| Complete publication and public readback | [PASS](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34155522316) |
+| Signed catalog | skipped on this native run (`mode: native`); not claimed |
+| SBOM | 1253 components; three-target release aggregate |
+| Update sequence | `7` |
+| Trust | community-verified; macOS ad-hoc, not notarized; Windows no Authenticode |
+
+| Asset | Bytes | SHA-256 |
+| --- | ---: | --- |
+| [`Penglai_0.5.11_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_aarch64.dmg) | 467,172,406 | `7a59833e32ae7cdcfc6dae6b1c2d744f251cb929cf251d758479c25fca41c536` |
+| [`Penglai_0.5.11_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_x64.dmg) | 408,749,431 | `783fcf5c042998d1a550d7c48fe30879d78f996d5602f002dea411826e210798` |
+| [`Penglai_0.5.11_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_windows_x64_setup.exe) | 357,628,547 | `5862cf0df14daf12ef223d5a825cad501ea56f78a40cdb54bef4fa8b7779c929` |
+| [`SBOM.cdx.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/SBOM.cdx.json) | 1,175,804 | `31241e542b0f5aaad02b25b9ee44a8ed26568d7182eda84b255ffd404fb7f68a` |
+| [`SHA256SUMS`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/SHA256SUMS) | 833 | `53ed292ca9b4afe71b054413ca0b82a3c3a01e8a05209739379034a0d1ae1c60` |
+| [`THIRD_PARTY_NOTICES.txt`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/THIRD_PARTY_NOTICES.txt) | 182,477 | `6f9e116dc88e67da8f40a61abd088939b63c0c81f60c792e639486aa69ffd31c` |
+| [`public-export-manifest.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/public-export-manifest.json) | 281,798 | `804926192e7e45ff8952272b971cee23c9ee933fa2ce51848f6d7830399f58d3` |
+| [`release-manifest.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/release-manifest.json) | 758 | `a0306294a1cf868131c968c59ca7b5cb624d2204987fb5bd16610c4c67381740` |
+| [`update-manifest-v1.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/update-manifest-v1.json) | 2,023 | `ef7d5c7e6e51a3753837dacd4daa23ed582f190cef55032ace78cbfca7b71de1` |
+| [`update-manifest-v1.json.sig`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/update-manifest-v1.json.sig) | 64 | `1839ad8b9263c6968c9c4e7b2c16cedf997e92c695ebaeee37324dcab07a5ded` |
+
+Native lifecycle verification covers 0.5.8, 0.5.9 and 0.5.10 upgrades on each target, with fresh old/new process readiness and fixture user data retained after default uninstall. Installed resource UI tests and native executable checks retain their separate evidence classes. Private account delivery and real provider responses are not inferred from credential-free tests. Published `v0.5.10` tags and assets were not rewritten.
+
+## 中文
+
+以上十项附件均已从不可变公开发布下载回读，文件大小、摘要、更新签名及安装器签名通过验证。三端来自同一源码，均验证 0.5.8、0.5.9、0.5.10 升级路径与默认卸载数据保留。无凭据测试不代表真实模型回复或私人账号消息送达；系统公证与发布者信誉限制见上表。已发布的 0.5.10 标签与附件未被改写。

--- a/docs/RELEASE_NOTES_0.5.11.md
+++ b/docs/RELEASE_NOTES_0.5.11.md
@@ -1,0 +1,28 @@
+# Penglai 0.5.11
+
+Penglai 0.5.11 uses the unmodified official DeepSeek Harness `0.1.2-rc.1` npm packages, fixed to tag `dsh-v0.1.2-rc.1` and commit `a66e4702047846cdaa10c66c9d3df3951f5ea70d`. DSH remains the only agent core. Penglai supplies the desktop application, onboarding, local data lifecycle and bundled plugins.
+
+Immutable public bytes: [`v0.5.11`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.11). Verified publication: [`docs/PUBLICATION_MANIFEST_0.5.11.md`](PUBLICATION_MANIFEST_0.5.11.md). Published **v0.5.10** tags and assets stay immutable.
+
+## Changes
+
+- Isolation and recovery: Owner-peer IM gating, Office job Workspace/Session ownership, Memory policy-before-write, Center journal last-good recovery, and Windows NSIS upgrade staging that copies over a locked install tree instead of deleting it first.
+- First-party workflows through official DSH slots: scoped Memory library query, Weixin/Feishu official question/approval identity, bounded text-PDF inspect plus digest-bound page preview, read-only usage projection, and redacted Plugin Center diagnostics.
+- Upgrades from 0.5.8, 0.5.9 and 0.5.10 on matching native hosts. Default uninstall preserves user data.
+- Publication requires the complete ten-file signed release set. The signed update sequence is 7.
+
+## Downloads and verification
+
+Apple Silicon, Intel Mac and Windows x64 installers were built on matching native hosts from the same clean main commit: `77e7105773b4d43abb7315ea6e83abe17e646cb4`.
+
+[Native build and installed checks](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34151469696) cover installed startup, credential-free onboarding/recovery, bundled plugin modes, the three pinned upgrade paths and default uninstall with user data preserved. [Complete publication and public-byte readback](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34155522316) verified the ten-file set after the draft became public.
+
+Check the downloaded installer against `SHA256SUMS` before running it. Office and Memory start enabled. Messaging, speech recognition, voice generation and Companion start disabled.
+
+## Known boundaries
+
+macOS is ad-hoc signed and **not notarized**. Windows has **no Authenticode signature**. Private account delivery and real provider responses are not inferred from credential-free tests. Mnemon remains `0.2.4`. UOS/LoongArch is not a release target.
+
+## 中文
+
+蓬莱 0.5.11 使用未经修改的官方 DeepSeek Harness `0.1.2-rc.1`（tag `dsh-v0.1.2-rc.1`，commit `a66e470…`）。DSH 仍是唯一 Agent 核心。三端安装包来自同一干净 main 提交 `77e7105773b4d43abb7315ea6e83abe17e646cb4`，并验证从 0.5.8、0.5.9、0.5.10 升级与默认卸载保留用户数据。macOS 为 ad-hoc 签名、未公证；Windows 无 Authenticode。无凭据测试不代表真实账号送达。已发布的 0.5.10 未被改写。

--- a/website/en/index.html
+++ b/website/en/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Penglai 0.5.10 | DeepSeek Harness, ready for a personal computer</title>
-  <meta name="description" content="Penglai 0.5.10 uses official DeepSeek Harness 0.1.2-rc.1 packages, adapted plugins, safe upgrades from 0.5.8 and 0.5.9, and three native installers.">
-  <meta property="og:title" content="Penglai 0.5.10">
+  <title>Penglai 0.5.11 | DeepSeek Harness, ready for a personal computer</title>
+  <meta name="description" content="Penglai 0.5.11 uses official DeepSeek Harness 0.1.2-rc.1 packages, adapted plugins, safe upgrades from 0.5.8, 0.5.9 and 0.5.10, and three native installers.">
+  <meta property="og:title" content="Penglai 0.5.11">
   <meta property="og:description" content="DeepSeek Harness, ready to install. Office, Memory, mobile messaging, and local voice in one desktop distribution.">
   <meta property="og:image" content="https://kevinchennewbee.github.io/PenglaiAgent/shots/0.5.5/plugin-center.png">
   <link rel="icon" href="../favicon.svg" type="image/svg+xml">
@@ -16,7 +16,7 @@
   <header class="topbar">
     <a class="brand" href="#top"><span class="seal">蓬</span><span>Penglai <small>蓬莱</small></span></a>
     <nav aria-label="Main navigation">
-      <a href="#new">0.5.10</a>
+      <a href="#new">0.5.11</a>
       <a href="#inside">What ships</a>
       <a href="#setup">Setup</a>
       <a href="#privacy">Privacy</a>
@@ -32,11 +32,11 @@
       <img class="hero-art" src="../shots/banner-v1.png" alt="The island of Penglai rising above a sea of clouds">
       <div class="hero-shade"></div>
       <div class="hero-copy">
-        <p class="eyebrow">Penglai 0.5.10 · DeepSeek Harness 0.1.2-rc.1</p>
+        <p class="eyebrow">Penglai 0.5.11 · DeepSeek Harness 0.1.2-rc.1</p>
         <h1>Not another agent.<br>The good open-source one, made installable.</h1>
         <p class="lead">Penglai puts official DeepSeek Harness, Node, Electron, first-run setup, updates, uninstall, and a practical set of DSH plugins into one desktop app. You do not need to learn a terminal first, or move your daily work into another cloud account.</p>
         <div class="actions">
-          <a class="button primary" href="#download">Download 0.5.10</a>
+          <a class="button primary" href="#download">Download 0.5.11</a>
           <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent">Read the source</a>
         </div>
         <p class="quiet">MIT licensed · Local first · Apple Silicon / Intel Mac / Windows x64</p>
@@ -48,12 +48,12 @@
         <p class="eyebrow">What actually changed</p>
         <h2>DSH is still the only core. Penglai makes it a complete desktop product.</h2>
       </div>
-      <p>Official DSH owns models, tools, Workspace, Session, Turn, and the conversation interface. Version 0.5.10 consumes the exact official <code>0.1.2-rc.1</code> npm packages. Message recovery, budget reconciliation and Companion replay use its Session snapshot API. Upgrades from 0.5.8 and 0.5.9 prepare a separate data generation and preserve the previous one for rollback. Three native installers verify startup, credential-free onboarding, bundled plugins, upgrade and uninstall.</p>
+      <p>Official DSH owns models, tools, Workspace, Session, Turn, and the conversation interface. Version 0.5.11 consumes the exact official <code>0.1.2-rc.1</code> npm packages. Message recovery, budget reconciliation and Companion replay use its Session snapshot API. Upgrades from 0.5.8, 0.5.9 and 0.5.10 prepare a separate data generation and preserve the previous one for rollback. Three native installers verify startup, credential-free onboarding, bundled plugins, upgrade and uninstall.</p>
     </section>
 
     <figure class="feature-shot wide-shot">
       <img src="../shots/0.5.5/plugin-center.png" alt="The real Penglai 0.5.5 Plugin Center running in installed DSH">
-      <figcaption>An installed 0.5.5 screen retained as a UI reference. Native installation and public-byte evidence for 0.5.10 is recorded in its publication manifest.</figcaption>
+      <figcaption>An installed 0.5.5 screen retained as a UI reference. Native installation and public-byte evidence for 0.5.11 is recorded in its publication manifest.</figcaption>
     </figure>
 
     <section class="section" id="inside">
@@ -62,7 +62,7 @@
       <div class="cards">
         <article><span class="state on">On by default</span><h3>Penglai Office</h3><p>Inspect, create, edit, preview, and save DOCX, XLSX, PPTX, and PDF. Writes have a plan and confirmation. PDF output includes a Chinese font. LibreOffice is not a user dependency.</p></article>
         <article><span class="state on">On by default</span><h3>Penglai Memory</h3><p>Safe project facts can be organized automatically inside the current Workspace. Candidate curation calls your selected model provider; storage and recall stay local. Personal facts still require an explicit save, and recall never crosses Workspaces.</p></article>
-        <article><span class="state">Opt in</span><h3>Messaging</h3><p>Weixin, Feishu, DingTalk, WeCom, QQ, Slack, Telegram, and Discord enter one <code>@penglai/im</code> control plane, using each platform's QR, device-registration, or official-token flow. WhatsApp is not displayed, supported, or bundled in 0.5.10.</p></article>
+        <article><span class="state">Opt in</span><h3>Messaging</h3><p>Weixin, Feishu, DingTalk, WeCom, QQ, Slack, Telegram, and Discord enter one <code>@penglai/im</code> control plane, using each platform's QR, device-registration, or official-token flow. WhatsApp is not displayed, supported, or bundled in 0.5.11.</p></article>
         <article><span class="state">Opt in</span><h3>Local voice</h3><p>SenseVoice handles speech recognition; MOSS-TTS handles voice generation. Conversation Read speaks the original reply rather than translating it; both preview and Read stop on a second click. Plugin code ships in the app. The large model weights explain themselves before downloading.</p></article>
         <article><span class="state">Opt in</span><h3>Companion</h3><p>It contacts you only after you turn it on, and stays within quiet hours, a daily cap, and one chosen messaging route. Fresh installations keep it off.</p></article>
         <article><span class="state">Independent updates</span><h3>Signed Plugin Center</h3><p>The catalog comes from immutable GitHub Releases. A reviewed DSH 0.1.2-rc.1-compatible plugin can join later without shipping a new desktop version merely to change a list.</p></article>
@@ -128,23 +128,23 @@
       <h2>The limits, before the download buttons.</h2>
       <div class="cards">
         <article><h3>Is Penglai another agent?</h3><p>No. Official DeepSeek Harness is the only core. Penglai owns install, lifecycle and first-party plugins.</p></article>
-        <article><h3>Which version should I download?</h3><p>The public installers are still 0.5.10. Mentions of 0.5.11 describe in-development source, not a downloadable product.</p></article>
+        <article><h3>Which version should I download?</h3><p>The public installers are 0.5.11. Published 0.5.10 remains an immutable historical release.</p></article>
         <article><h3>Why does Gatekeeper warn?</h3><p>macOS packages are ad-hoc signed and not notarized; Windows has no Authenticode. That is a stated limitation, not an OS endorsement.</p></article>
         <article><h3>Are Office and Memory on by default?</h3><p>Yes. Messaging, ASR, TTS and Companion stay off until you enable them.</p></article>
       </div>
     </section>
 
     <section class="download section" id="download">
-      <p class="eyebrow">Penglai 0.5.10</p>
+      <p class="eyebrow">Penglai 0.5.11</p>
       <h2>Choose your computer.</h2>
       <div class="download-grid">
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_aarch64.dmg"><strong>macOS · Apple Silicon</strong><span>GitHub · 449.6 MiB · M1 / M2 / M3 / M4 / M5</span><code>0fdca1a2d64c536088b53ddd4910851e9876abed4ee114aecd7a1437ff9417e5</code></a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_x64.dmg"><strong>macOS · Intel</strong><span>GitHub · 388.2 MiB · x86_64 Mac</span><code>6771901b5bf3b7e9e0c192125a866bf2e6c1c605655a8d07339ea37dc64ee9ea</code></a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_windows_x64_setup.exe"><strong>Windows · x64</strong><span>GitHub · 341.0 MiB · 64-bit installer</span><code>46b45bbb6a18859c7be03413b7983ad90dacc7710233130b2c81cb5a537bd484</code></a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_aarch64.dmg"><strong>macOS · Apple Silicon</strong><span>GitHub · 445.5 MiB · M1 / M2 / M3 / M4 / M5</span><code>7a59833e32ae7cdcfc6dae6b1c2d744f251cb929cf251d758479c25fca41c536</code></a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_x64.dmg"><strong>macOS · Intel</strong><span>GitHub · 389.8 MiB · x86_64 Mac</span><code>783fcf5c042998d1a550d7c48fe30879d78f996d5602f002dea411826e210798</code></a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_windows_x64_setup.exe"><strong>Windows · x64</strong><span>GitHub · 341.1 MiB · 64-bit installer</span><code>5862cf0df14daf12ef223d5a825cad501ea56f78a40cdb54bef4fa8b7779c929</code></a>
       </div>
-      <p class="quiet">The current public download is still published 0.5.10. 0.5.11 is in development and has no installers or GitHub Release assets. The immutable GitHub Release is the sole authoritative public download source for 0.5.10; the Beijing mirror has not published 0.5.10. All three installers come from source <code>c5c0bcb022c5ae47cca242deb27fe1d30444c41d</code>. Full SHA256SUMS, SBOM, third-party notices, and signed update metadata are on the same page. Updates are never silent.</p>
+      <p class="quiet">The current public download is published 0.5.11. Published 0.5.10 remains immutable. The immutable GitHub Release is the sole authoritative public download source; the Beijing mirror has not published 0.5.11. All three installers come from source <code>77e7105773b4d43abb7315ea6e83abe17e646cb4</code>. Full SHA256SUMS, SBOM, third-party notices, and signed update metadata are on the same page. Updates are never silent.</p>
       <div class="actions centered">
-        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.10">Bilingual release notes</a>
+        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.11">Bilingual release notes</a>
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">Security notes</a>
       </div>
     </section>

--- a/website/index.html
+++ b/website/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>蓬莱 0.5.10 | 把 DeepSeek Harness 装进你的电脑</title>
-  <meta name="description" content="蓬莱 0.5.10 基于固定的 DeepSeek Harness 0.1.2-rc.1 官方源码，完成插件适配、桌面生命周期修复与三端原生发行。">
-  <meta property="og:title" content="蓬莱 0.5.10">
+  <title>蓬莱 0.5.11 | 把 DeepSeek Harness 装进你的电脑</title>
+  <meta name="description" content="蓬莱 0.5.11 基于固定的 DeepSeek Harness 0.1.2-rc.1 官方源码，完成插件适配、桌面生命周期修复与三端原生发行。">
+  <meta property="og:title" content="蓬莱 0.5.11">
   <meta property="og:description" content="DeepSeek Harness，装好就能用。办公、记忆、手机消息和本地语音都在一个桌面发行版里。">
   <meta property="og:image" content="https://kevinchennewbee.github.io/PenglaiAgent/shots/0.5.5/plugin-center.png">
   <link rel="icon" href="./favicon.svg" type="image/svg+xml">
@@ -16,7 +16,7 @@
   <header class="topbar">
     <a class="brand" href="#top"><span class="seal">蓬</span><span>蓬莱 <small>PENGLAI</small></span></a>
     <nav aria-label="主导航">
-      <a href="#new">0.5.10</a>
+      <a href="#new">0.5.11</a>
       <a href="#inside">内置能力</a>
       <a href="#setup">安装</a>
       <a href="#privacy">隐私</a>
@@ -32,11 +32,11 @@
       <img class="hero-art" src="./shots/banner-v1.png" alt="云海中的蓬莱仙山">
       <div class="hero-shade"></div>
       <div class="hero-copy">
-        <p class="eyebrow">Penglai 0.5.10 · DeepSeek Harness 0.1.2-rc.1</p>
+        <p class="eyebrow">Penglai 0.5.11 · DeepSeek Harness 0.1.2-rc.1</p>
         <h1>不是另一个 Agent。<br>是把好用的开源 Agent，真正装进电脑。</h1>
         <p class="lead">蓬莱把官方 DeepSeek Harness、Node、Electron、首次引导、更新、卸载和一组实用 DSH 插件放进一个桌面客户端。你不用先学终端，也不用把日常交给一个新的云账号。</p>
         <div class="actions">
-          <a class="button primary" href="#download">下载 0.5.10</a>
+          <a class="button primary" href="#download">下载 0.5.11</a>
           <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent">查看源代码</a>
         </div>
         <p class="quiet">MIT 开源 · 本地优先 · Apple Silicon / Intel Mac / Windows x64</p>
@@ -48,12 +48,12 @@
         <p class="eyebrow">这次真正变了什么</p>
         <h2>DSH 还是唯一核心，蓬莱把它变成了一个完整产品。</h2>
       </div>
-      <p>模型、工具、Workspace、Session、Turn 和会话界面都归官方 DSH。0.5.10 使用精确固定的官方 <code>0.1.2-rc.1</code> npm 包；消息恢复、预算结算和主动陪伴回放适配官方 Session 快照接口。从 0.5.8 和 0.5.9 升级时准备独立数据代际，保留旧版用于回退。三端原生安装包验证启动、无凭据引导、内置插件、升级和卸载。</p>
+      <p>模型、工具、Workspace、Session、Turn 和会话界面都归官方 DSH。0.5.11 使用精确固定的官方 <code>0.1.2-rc.1</code> npm 包；消息恢复、预算结算和主动陪伴回放适配官方 Session 快照接口。从 0.5.8、0.5.9 和 0.5.10 升级时准备独立数据代际，保留旧版用于回退。三端原生安装包验证启动、无凭据引导、内置插件、升级和卸载。</p>
     </section>
 
     <figure class="feature-shot wide-shot">
       <img src="./shots/0.5.5/plugin-center.png" alt="真实安装的蓬莱 0.5.5 插件中心">
-      <figcaption>0.5.5 安装版截图作为界面参考；0.5.10 的原生安装与公开字节证据记录在发布清单中。</figcaption>
+      <figcaption>0.5.5 安装版截图作为界面参考；0.5.11 的原生安装与公开字节证据记录在发布清单中。</figcaption>
     </figure>
 
     <section class="section" id="inside">
@@ -62,7 +62,7 @@
       <div class="cards">
         <article><span class="state on">默认启用</span><h3>蓬莱办公</h3><p>读取、创建、修改、预览和保存 DOCX、XLSX、PPTX 与 PDF。写入前有计划和确认，PDF 自带中文字体，不要求用户安装 LibreOffice。</p></article>
         <article><span class="state on">默认启用</span><h3>蓬莱记忆</h3><p>安全的项目事实会自动整理到当前 Workspace；整理候选会调用你选择的模型供应商，记录与召回留在本机。个人事实仍需明确保存，记忆绝不会跨 Workspace 召回。</p></article>
-        <article><span class="state">按需启用</span><h3>蓬莱消息连接</h3><p>微信、飞书、钉钉、企业微信、QQ、Slack、Telegram 与 Discord 统一进入 <code>@penglai/im</code>，按平台使用扫码、设备注册或官方 Token。WhatsApp 在 0.5.10 中不展示、不支持，也不捆绑运行时。</p></article>
+        <article><span class="state">按需启用</span><h3>蓬莱消息连接</h3><p>微信、飞书、钉钉、企业微信、QQ、Slack、Telegram 与 Discord 统一进入 <code>@penglai/im</code>，按平台使用扫码、设备注册或官方 Token。WhatsApp 在 0.5.11 中不展示、不支持，也不捆绑运行时。</p></article>
         <article><span class="state">按需启用</span><h3>本地语音</h3><p>SenseVoice 负责语音识别，MOSS-TTS 负责语音生成。会话 Read 朗读原文，不负责翻译；试听与 Read 都可再次点击停止。插件代码随包，较大的模型权重会在启用时说明后再下载。</p></article>
         <article><span class="state">按需启用</span><h3>主动陪伴</h3><p>只有你主动开启后才会定时联系，并受安静时间、每日次数和指定消息渠道约束。默认不会擅自运行。</p></article>
         <article><span class="state">持续更新</span><h3>签名插件中心</h3><p>插件列表来自不可变 GitHub Release。兼容的新插件可以通过签名目录加入，不必只为更新一张列表重发桌面版本。</p></article>
@@ -128,23 +128,23 @@
       <h2>先把限制说清楚。</h2>
       <div class="cards">
         <article><h3>蓬莱是另一个 Agent 吗？</h3><p>不是。官方 DeepSeek Harness 是唯一核心。蓬莱负责安装、生命周期和第一方插件。</p></article>
-        <article><h3>现在该下载哪个版本？</h3><p>公开安装包仍是 0.5.10。页面上的 0.5.11 只描述正在开发的源码，不是可下载产品。</p></article>
+        <article><h3>现在该下载哪个版本？</h3><p>公开安装包是 0.5.11。已发布的 0.5.10 仍是不可变历史版本。</p></article>
         <article><h3>为什么 Gatekeeper 会提示？</h3><p>macOS 安装包是 ad-hoc 签名、未公证；Windows 没有 Authenticode。这是已知限制，不是系统背书。</p></article>
         <article><h3>办公和记忆默认开着吗？</h3><p>是。手机消息、语音识别、语音生成和主动陪伴默认关闭，需要时再开。</p></article>
       </div>
     </section>
 
     <section class="download section" id="download">
-      <p class="eyebrow">Penglai 0.5.10</p>
+      <p class="eyebrow">Penglai 0.5.11</p>
       <h2>选择你的电脑。</h2>
       <div class="download-grid">
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_aarch64.dmg"><strong>macOS · Apple 芯片</strong><span>GitHub · 449.6 MiB · M1 / M2 / M3 / M4 / M5</span><code>0fdca1a2d64c536088b53ddd4910851e9876abed4ee114aecd7a1437ff9417e5</code></a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_macos_x64.dmg"><strong>macOS · Intel</strong><span>GitHub · 388.2 MiB · x86_64 Mac</span><code>6771901b5bf3b7e9e0c192125a866bf2e6c1c605655a8d07339ea37dc64ee9ea</code></a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.10/Penglai_0.5.10_windows_x64_setup.exe"><strong>Windows · x64</strong><span>GitHub · 341.0 MiB · 64 位安装器</span><code>46b45bbb6a18859c7be03413b7983ad90dacc7710233130b2c81cb5a537bd484</code></a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_aarch64.dmg"><strong>macOS · Apple 芯片</strong><span>GitHub · 445.5 MiB · M1 / M2 / M3 / M4 / M5</span><code>7a59833e32ae7cdcfc6dae6b1c2d744f251cb929cf251d758479c25fca41c536</code></a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_x64.dmg"><strong>macOS · Intel</strong><span>GitHub · 389.8 MiB · x86_64 Mac</span><code>783fcf5c042998d1a550d7c48fe30879d78f996d5602f002dea411826e210798</code></a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_windows_x64_setup.exe"><strong>Windows · x64</strong><span>GitHub · 341.1 MiB · 64 位安装器</span><code>5862cf0df14daf12ef223d5a825cad501ea56f78a40cdb54bef4fa8b7779c929</code></a>
       </div>
-      <p class="quiet">当前公开下载仍是已发布的 0.5.10。0.5.11 还在开发，没有安装包、也没有 GitHub Release 附件。0.5.10 只以不可变 GitHub Release 为权威公开下载源；北京镜像尚未发布 0.5.10。三个安装包来自源码 <code>c5c0bcb022c5ae47cca242deb27fe1d30444c41d</code>。完整 SHA256SUMS、SBOM、第三方声明与签名元数据同页提供；更新不会静默执行。</p>
+      <p class="quiet">当前公开下载是已发布的 0.5.11。已发布的 0.5.10 仍不可变。只以不可变 GitHub Release 为权威公开下载源；北京镜像尚未发布 0.5.11。三个安装包来自源码 <code>77e7105773b4d43abb7315ea6e83abe17e646cb4</code>。完整 SHA256SUMS、SBOM、第三方声明与签名元数据同页提供；更新不会静默执行。</p>
       <div class="actions centered">
-        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.10">中英文发布说明</a>
+        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.11">中英文发布说明</a>
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">安全说明</a>
       </div>
     </section>


### PR DESCRIPTION
P05 after public-byte PASS.

- Native three-target [34151469696](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34151469696) on \`77e7105773b4d43abb7315ea6e83abe17e646cb4\`
- Publish/readback [34155522316](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34155522316)
- Immutable release: https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.11
- Public \`SHA256SUMS\` matches the assembled set
- v0.5.10 remains \`c5c0bcb022c5ae47cca242deb27fe1d30444c41d\`

Does not rewrite 0.5.10 assets.