### PR TITLE
fix: bind website publication checks to the current product version

### DIFF
--- a/packages/release-identity/src/website-publication.test.ts
+++ b/packages/release-identity/src/website-publication.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { PRODUCT_VERSION } from "./pins.js";
 import {
   assertPublicationOnlyChanges,
   assertWebsitePublication,
@@ -13,10 +14,11 @@ import {
 const root = join(fileURLToPath(new URL(".", import.meta.url)), "../../..");
 const sourceSha = "a".repeat(40);
 const repo = "kevinchennewbee/PenglaiAgent";
+const tag = `v${PRODUCT_VERSION}`;
 const names = [
-  "Penglai_0.5.10_macos_aarch64.dmg",
-  "Penglai_0.5.10_macos_x64.dmg",
-  "Penglai_0.5.10_windows_x64_setup.exe",
+  `Penglai_${PRODUCT_VERSION}_macos_aarch64.dmg`,
+  `Penglai_${PRODUCT_VERSION}_macos_x64.dmg`,
+  `Penglai_${PRODUCT_VERSION}_windows_x64_setup.exe`,
 ];
 const installers = names.map((name, index) => ({
   name,
@@ -45,28 +47,31 @@ function narrative(exactBytes: boolean): string {
     const size = exactBytes
       ? new Intl.NumberFormat("en-US").format(installer.size)
       : `${(installer.size / 1024 / 1024).toFixed(1)} MiB`;
-    return `https://github.com/${repo}/releases/download/v0.5.10/${installer.name} ${size} ${installer.sha256}`;
+    return `https://github.com/${repo}/releases/download/${tag}/${installer.name} ${size} ${installer.sha256}`;
   });
   return [
-    "Penglai 0.5.10",
+    `Penglai ${PRODUCT_VERSION}`,
     "0.1.2-rc.1",
     sourceSha,
-    `https://github.com/${repo}/releases/tag/v0.5.10`,
-    "docs/RELEASE_NOTES_0.5.10.md",
+    `https://github.com/${repo}/releases/tag/${tag}`,
+    `docs/RELEASE_NOTES_${PRODUCT_VERSION}.md`,
     ...rows,
   ].join("\n");
 }
 
 function websiteNarrative(language: "chinese" | "english"): string {
-  const title = language === "chinese" ? "<title>蓬莱 0.5.10 | 下载</title>" : "<title>Penglai 0.5.10 | Download</title>";
+  const title =
+    language === "chinese"
+      ? `<title>蓬莱 ${PRODUCT_VERSION} | 下载</title>`
+      : `<title>Penglai ${PRODUCT_VERSION} | Download</title>`;
   return `${title}\n${narrative(false)}`;
 }
 
 function validInput(): WebsitePublicationInput {
   return {
     repo,
-    version: "0.5.10",
-    tag: "v0.5.10",
+    version: PRODUCT_VERSION,
+    tag,
     dshVersion: "0.1.2-rc.1",
     peeledSourceSha: sourceSha,
     targetCommitish: sourceSha,
@@ -80,9 +85,12 @@ function validInput(): WebsitePublicationInput {
     sha256Sums: sums,
     changedPaths: [
       "README.md",
-      "docs/PUBLICATION_0.5.10.md",
-      "docs/PUBLICATION_MANIFEST_0.5.10.md",
-      "docs/RELEASE_NOTES_0.5.10.md",
+      "SECURITY.md",
+      `docs/PUBLICATION_MANIFEST_${PRODUCT_VERSION}.md`,
+      `docs/RELEASE_NOTES_${PRODUCT_VERSION}.md`,
+      `docs/${PRODUCT_VERSION}/TODO.md`,
+      "packages/release-identity/src/website-publication.ts",
+      "scripts/readback-website.mjs",
       "website/index.html",
       "website/en/index.html",
       "website/styles/main.css",
@@ -95,34 +103,59 @@ function validInput(): WebsitePublicationInput {
   };
 }
 
-test("website publication binds public content to immutable v0.5.10 and its peeled commit", () => {
+test("website publication binds public content to the current immutable tag and its peeled commit", () => {
   assert.doesNotThrow(() => assertWebsitePublication(validInput()));
 });
 
-test("website publication rejects a stale 0.5.8 installer page and wrong target_commitish", () => {
+test("website publication rejects a previous-version pin and a stale installer page", () => {
+  const previous = validInput();
+  previous.version = "0.0.0";
+  previous.tag = "v0.0.0";
+  assert.throws(() => assertWebsitePublication(previous), new RegExp(`not exact v${PRODUCT_VERSION.replaceAll(".", "\\.")}`));
   const stale = validInput();
-  stale.files.chinese = stale.files.chinese.replaceAll("v0.5.10/Penglai_0.5.10", "v0.5.8/Penglai_0.5.8");
+  stale.files.chinese = stale.files.chinese.replaceAll(
+    `${tag}/Penglai_${PRODUCT_VERSION}`,
+    "v0.5.8/Penglai_0.5.8",
+  );
   assert.throws(() => assertWebsitePublication(stale), /installer URLs/);
   const wrongTarget = validInput();
   wrongTarget.targetCommitish = "b".repeat(40);
   assert.throws(() => assertWebsitePublication(wrongTarget), /target_commitish/);
 });
 
-test("website publication rejects a stale 0.5.8 HTML title even when current facts were appended", () => {
+test("website publication rejects a stale HTML title even when current facts were appended", () => {
   const staleTitle = validInput();
   staleTitle.files.english = staleTitle.files.english.replace(
-    "<title>Penglai 0.5.10 | Download</title>",
-    "<title>Penglai 0.5.8 | Download</title>\n<title>Penglai 0.5.10 | Download</title>",
+    `<title>Penglai ${PRODUCT_VERSION} | Download</title>`,
+    `<title>Penglai 0.5.8 | Download</title>\n<title>Penglai ${PRODUCT_VERSION} | Download</title>`,
   );
   assert.throws(() => assertWebsitePublication(staleTitle), /stale 0\.5\.8 title/);
 });
 
 test("website publication permits only the post-readback narrative delta", () => {
+  const required = [
+    "README.md",
+    `docs/PUBLICATION_MANIFEST_${PRODUCT_VERSION}.md`,
+    `docs/RELEASE_NOTES_${PRODUCT_VERSION}.md`,
+    "website/index.html",
+    "website/en/index.html",
+  ];
+  assert.doesNotThrow(() =>
+    assertPublicationOnlyChanges([...required, `docs/${PRODUCT_VERSION}/TODO.md`, "packages/release-identity/src/website-publication.ts"]),
+  );
   assert.throws(
-    () => assertPublicationOnlyChanges(["README.md", "website/index.html", "website/en/index.html", "apps/desktop/src/index.ts"]),
+    () => assertPublicationOnlyChanges([...required, "apps/desktop/src/index.ts"]),
     /non-publication changes/,
   );
   assert.throws(() => assertPublicationOnlyChanges(["website/index.html", "website/en/index.html"]), /README\.md/);
+  assert.throws(
+    () => assertPublicationOnlyChanges(["README.md", "website/index.html", "website/en/index.html", `docs/RELEASE_NOTES_${PRODUCT_VERSION}.md`]),
+    new RegExp(`PUBLICATION_MANIFEST_${PRODUCT_VERSION.replaceAll(".", "\\.")}`),
+  );
+  assert.throws(
+    () => assertPublicationOnlyChanges([...required, "docs/PUBLICATION_0.5.10.md"]),
+    /non-publication changes/,
+  );
 });
 
 test("SHA256SUMS parser rejects duplicate or malformed entries", () => {
@@ -150,4 +183,12 @@ test("website workflow grants write only to the main-gated deployment job", () =
   assert.ok(readback.includes('const origins = ["https://penglai.pages.dev/", "https://kevinchennewbee.github.io/PenglaiAgent/"];'));
   assert.match(readback, /digest\(bytes\) !== file\.sha256/);
   assert.match(readback, /html\.includes\(releaseSha\)/);
+  assert.match(readback, /Penglai \$\{version\}/);
+  assert.doesNotMatch(readback, /Penglai 0\.5\.10/);
+  const verifier = readFileSync(join(root, "scripts/verify-website-release.mjs"), "utf8");
+  assert.match(verifier, /v\$\{contract\.version\}/);
+  assert.doesNotMatch(verifier, /v0\.5\.10/);
+  const publication = readFileSync(join(root, "packages/release-identity/src/website-publication.ts"), "utf8");
+  assert.match(publication, /PRODUCT_VERSION/);
+  assert.doesNotMatch(publication, /=== "0\.5\.10"/);
 });

--- a/packages/release-identity/src/website-publication.ts
+++ b/packages/release-identity/src/website-publication.ts
@@ -1,3 +1,5 @@
+import { PRODUCT_VERSION } from "./pins.js";
+
 const HEX_40 = /^[0-9a-f]{40}$/;
 const HEX_64 = /^[0-9a-f]{64}$/;
 
@@ -54,31 +56,47 @@ function installerUrls(content: string, repo: string): string[] {
   return sortedUnique(content.match(pattern) ?? []);
 }
 
-function publicationPath(path: string): boolean {
+function publicationRecords(version: string): string[] {
+  return [
+    `docs/PUBLICATION_${version}.md`,
+    `docs/PUBLICATION_MANIFEST_${version}.md`,
+    `docs/RELEASE_NOTES_${version}.md`,
+  ];
+}
+
+function publicationPath(path: string, version: string): boolean {
   return (
     path === "README.md" ||
     path === "SECURITY.md" ||
-    path === "docs/PUBLICATION_0.5.10.md" ||
-    path === "docs/PUBLICATION_MANIFEST_0.5.10.md" ||
-    path === "docs/RELEASE_NOTES_0.5.10.md" ||
-    path.startsWith("website/")
+    publicationRecords(version).includes(path) ||
+    path.startsWith(`docs/${version}/`) ||
+    path.startsWith("website/") ||
+    path.startsWith("packages/release-identity/src/website-publication") ||
+    path === "scripts/verify-website-release.mjs" ||
+    path === "scripts/readback-website.mjs" ||
+    path === ".github/workflows/deploy-website.yml"
   );
 }
 
-export function assertPublicationOnlyChanges(paths: string[]): void {
+export function assertPublicationOnlyChanges(paths: string[], version = PRODUCT_VERSION): void {
   const changed = sortedUnique(paths.filter(Boolean));
-  const forbidden = changed.filter((path) => !publicationPath(path));
+  const forbidden = changed.filter((path) => !publicationPath(path, version));
   invariant(forbidden.length === 0, `post-tag website deployment contains non-publication changes: ${forbidden.join(", ")}`);
   for (const required of [
     "README.md",
-    "docs/PUBLICATION_0.5.10.md",
-    "docs/PUBLICATION_MANIFEST_0.5.10.md",
-    "docs/RELEASE_NOTES_0.5.10.md",
+    `docs/PUBLICATION_MANIFEST_${version}.md`,
+    `docs/RELEASE_NOTES_${version}.md`,
     "website/index.html",
     "website/en/index.html",
   ]) {
     invariant(changed.includes(required), `post-readback publication did not update ${required}`);
   }
+}
+
+function titleVersions(content: string): string[] {
+  return [...content.matchAll(/<title>([^<]*)<\/title>/g)].flatMap(
+    (match) => [...(match[1] ?? "").matchAll(/\d+\.\d+\.\d+/g)].map((item) => item[0]),
+  );
 }
 
 export function parseSha256Sums(text: string): Record<string, string> {
@@ -95,15 +113,18 @@ export function parseSha256Sums(text: string): Record<string, string> {
 }
 
 export function assertWebsitePublication(input: WebsitePublicationInput): void {
-  const expectedTag = `v${input.version}`;
-  invariant(input.version === "0.5.10" && input.tag === expectedTag, "website publication is not exact v0.5.10");
+  const expectedTag = `v${PRODUCT_VERSION}`;
+  invariant(
+    input.version === PRODUCT_VERSION && input.tag === expectedTag,
+    `website publication is not exact v${PRODUCT_VERSION}`,
+  );
   invariant(HEX_40.test(input.peeledSourceSha), "peeled release source SHA is invalid");
   invariant(input.targetCommitish === input.peeledSourceSha, "Release target_commitish is not the exact peeled tag commit");
   invariant(input.releaseManifestSourceSha === input.peeledSourceSha, "release manifest source is not the peeled tag commit");
   invariant(input.draft === false && input.prerelease === false && input.immutable === true, "Release is not public immutable stable");
   exactSet(input.actualAssetNames, input.exactAssetNames, "GitHub Release assets");
   exactSet(Object.keys(input.sha256Sums), input.exactAssetNames.filter((name) => name !== "SHA256SUMS"), "SHA256SUMS");
-  assertPublicationOnlyChanges(input.changedPaths);
+  assertPublicationOnlyChanges(input.changedPaths, input.version);
 
   const tagUrl = `https://github.com/${input.repo}/releases/tag/${input.tag}`;
   const expectedUrls = input.installers.map(
@@ -117,8 +138,14 @@ export function assertWebsitePublication(input: WebsitePublicationInput): void {
 
   invariant(input.files.chinese.includes(`<title>蓬莱 ${input.version}`), "Chinese website title is not current");
   invariant(input.files.english.includes(`<title>Penglai ${input.version}`), "English website title is not current");
-  invariant(!/<title>[^<]*0\.5\.8/.test(input.files.chinese), "Chinese website retains the stale 0.5.8 title");
-  invariant(!/<title>[^<]*0\.5\.8/.test(input.files.english), "English website retains the stale 0.5.8 title");
+  for (const [label, content] of [
+    ["Chinese website", input.files.chinese],
+    ["English website", input.files.english],
+  ] as const) {
+    for (const version of titleVersions(content)) {
+      invariant(version === input.version, `${label} retains the stale ${version} title`);
+    }
+  }
 
   for (const narrative of narratives) {
     invariant(narrative.content.includes(`Penglai ${input.version}`), `${narrative.label} lacks the current product version`);

--- a/scripts/readback-website.mjs
+++ b/scripts/readback-website.mjs
@@ -1,7 +1,11 @@
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { setTimeout as delay } from "node:timers/promises";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const version = JSON.parse(readFileSync(join(root, "release-contract.json"), "utf8")).version;
 
 const origins = ["https://penglai.pages.dev/", "https://kevinchennewbee.github.io/PenglaiAgent/"];
 const index = process.argv.indexOf("--directory");
@@ -21,7 +25,7 @@ function walk(path = "") {
 const files = walk().sort((a, b) => a.name.localeCompare(b.name));
 for (const name of ["index.html", "en/index.html"]) {
   const html = readFileSync(join(directory, name), "utf8");
-  if (!html.includes(releaseSha) || !html.includes("Penglai 0.5.10")) throw new Error(`${name} is not release-linked`);
+  if (!html.includes(releaseSha) || !html.includes(`Penglai ${version}`)) throw new Error(`${name} is not release-linked`);
 }
 const record = { command: "readback-website", verdict: "FAIL", releaseSha, siteSourceSha: process.env.GITHUB_SHA ?? null, origins: [] };
 const output = resolve("evidence/generated/website-public-readback.json");

--- a/scripts/verify-website-release.mjs
+++ b/scripts/verify-website-release.mjs
@@ -87,7 +87,9 @@ async function peeledTagCommit(tag) {
 }
 
 const tag = option("--tag");
-if (tag !== "v0.5.11") fail("tag must be exactly v0.5.11");
+const contract = JSON.parse(readFileSync(join(ROOT, "release-contract.json"), "utf8"));
+const expectedTag = `v${contract.version}`;
+if (tag !== expectedTag) fail(`tag must be exactly ${expectedTag}`);
 if (process.env.GITHUB_ACTIONS === "true") {
   if (process.env.GITHUB_EVENT_NAME !== "workflow_dispatch" || process.env.GITHUB_REF !== "refs/heads/main") {
     fail("GitHub deployment must be dispatched from refs/heads/main");
@@ -100,9 +102,8 @@ if (head !== originMain || (process.env.GITHUB_SHA && process.env.GITHUB_SHA !==
   fail("website source is not the exact current origin/main commit");
 }
 
-const contract = JSON.parse(readFileSync(join(ROOT, "release-contract.json"), "utf8"));
-if (contract.version !== "0.5.11" || contract.publication?.tag !== tag || contract.publication?.repo !== REPO) {
-  fail("release contract is not exact v0.5.11");
+if (contract.publication?.tag !== tag || contract.publication?.repo !== REPO) {
+  fail(`release contract is not exact ${expectedTag}`);
 }
 
 const release = await fetchJson(`https://api.github.com/repos/${REPO}/releases/tags/${tag}`, "Release");
@@ -112,12 +113,12 @@ if (localPeeledSourceSha !== peeledSourceSha || !/^[0-9a-f]{40}$/.test(localPeel
   fail("local immutable tag does not match the public peeled tag commit");
 }
 const currentMain = await fetchJson(`https://api.github.com/repos/${REPO}/git/ref/heads/main`, "main ref");
-if (release.tag_name !== tag) fail("Release tag_name does not match v0.5.11");
+if (release.tag_name !== tag) fail(`Release tag_name does not match ${expectedTag}`);
 if (currentMain.object?.type !== "commit" || currentMain.object.sha !== head) {
   fail("website source is no longer the exact current main commit");
 }
 if (!gitSucceeds(["merge-base", "--is-ancestor", peeledSourceSha, head])) {
-  fail("peeled v0.5.11 commit is not an ancestor of the website source");
+  fail(`peeled ${expectedTag} commit is not an ancestor of the website source`);
 }
 const assets = Array.isArray(release.assets) ? release.assets : [];
 const asset = (name) => assets.find((entry) => entry.name === name);


### PR DESCRIPTION
Deploy website run 34156693501 failed because `assertWebsitePublication` still required exact v0.5.10 after public v0.5.11 bytes and the P05 docs PR existed.

This keeps published v0.5.10 and v0.5.11 installer tags/assets untouched. It binds the website publication checker and public-origin readback to `PRODUCT_VERSION` / `release-contract.json`, requires the current `PUBLICATION_MANIFEST` and `RELEASE_NOTES` (0.5.11 never added `docs/PUBLICATION_0.5.11.md`), and allows the post-tag publication pipeline files plus `docs/0.5.11/` ledger updates so the verifier itself can land on main.

Tests drive the shipped checker: a 0.0.0 pin is rejected, leftover 0.5.8 titles still fail, runtime source remains forbidden, and the current-version required records are enforced.