### PR TITLE
fix: public-export owner-path scan and Windows fs-ext tmpdir

### DIFF
--- a/packages/release-identity/src/public-export.test.ts
+++ b/packages/release-identity/src/public-export.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -175,6 +176,20 @@ test("every required public doc is export-allowed", () => {
   }
   assert.equal(pathAllowed("docs/PUBLICATION_MANIFEST_0.5.11.md"), true);
   assert.equal(pathAllowed("docs/0.5.12/pdf-page-preview.png"), false);
+  assert.equal(pathAllowed("docs/0.5.12/REVIEW_PRODUCTION.md"), false);
+  assert.equal(pathAllowed("docs/0.5.12/REVIEW_SESSION_API.md"), false);
+});
+
+test("allowed tracked non-test text files pass the export scan", () => {
+  const names = execFileSync("git", ["ls-files", "-z"], { cwd: root, encoding: "utf8" })
+    .split("\0")
+    .filter(Boolean);
+  for (const rel of names) {
+    if (!pathAllowed(rel)) continue;
+    if (/\.(png|jpg|jpeg|webp|gif|ico|icns|wasm|ttf|woff2?|tgz|zip|node)$/i.test(rel)) continue;
+    if (/\.test\.(ts|mjs|js)$/.test(rel)) continue;
+    scanExportText(rel, readFileSync(join(root, rel), "utf8"));
+  }
 });
 
 test("R50-PREP-005 required public docs are enumerated", () => {

--- a/packages/release-identity/src/public-export.ts
+++ b/packages/release-identity/src/public-export.ts
@@ -114,6 +114,8 @@ export const PUBLIC_EXPORT_DENY = [
   "packages/release-identity/src/leftover-gates.test.ts",
   "packages/release-identity/src/remaining-gates.test.ts",
   "docs/0.5.12/pdf-page-preview.png",
+  "docs/0.5.12/REVIEW_PRODUCTION.md",
+  "docs/0.5.12/REVIEW_SESSION_API.md",
 ] as const;
 
 export const REQUIRED_PUBLIC_DOCS = [

--- a/scripts/rebuild-fs-ext.mjs
+++ b/scripts/rebuild-fs-ext.mjs
@@ -2,6 +2,7 @@
 /** Rebuild fs-ext after ignore-scripts installs. Required by official JSONL session persistence. */
 
 import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { ROOT } from "./lib/repo.mjs";
@@ -13,7 +14,7 @@ if (!existsSync(join(dir, "binding.gyp"))) {
   process.exit(1);
 }
 const npm = join(dirname(process.execPath), process.platform === "win32" ? "npm.cmd" : "npm");
-const devdir = process.env.npm_config_devdir || "/tmp/node-gyp-dev";
+const devdir = process.env.npm_config_devdir || join(tmpdir(), "node-gyp-dev");
 const env = {
   ...process.env,
   npm_config_devdir: devdir,


### PR DESCRIPTION
Native 34249736988 on 699c805b failed:

- public-export: REVIEW_PRODUCTION.md / REVIEW_SESSION_API.md contain /Users/agent paths and were under docs/0.5.12 allow.
- Windows: rebuild-fs-ext used /tmp/node-gyp-dev.

Deny those internal review notes, add a class scan of allowed tracked text, and use os.tmpdir() for node-gyp. I05 Poppler remains deferred.