### PR TITLE
fix: Windows fs-ext rebuild via npm-cli.js

### DIFF
--- a/packages/runtime/src/windows-host.test.ts
+++ b/packages/runtime/src/windows-host.test.ts
@@ -347,6 +347,11 @@ test("NSIS script always preserves user data after in-app exact deletion", () =>
   assert.match(payload, /stagingForTarget\(ROOT, "win32-x86_64"\)/);
   assert.match(cleanClone, /process\.platform === "win32"[\s\S]*build:windows-host/);
   assert.match(cleanClone, /rebuild:fs-ext/);
+  const rebuildFsExt = readFileSync(new URL("../../../scripts/rebuild-fs-ext.mjs", import.meta.url), "utf8");
+  assert.match(rebuildFsExt, /npm-cli\.js/);
+  assert.match(rebuildFsExt, /shell: process\.platform === "win32"/);
+  assert.match(rebuildFsExt, /tmpdir\(\)/);
+  assert.doesNotMatch(rebuildFsExt, /\/tmp\/node-gyp-dev/);
   assert.match(packager, /stagingForTarget\(ROOT, "win32-x86_64"\)/);
   assert.doesNotMatch(payload, /const staging = join\(ROOT, "dist", "runtime-staging-win32-x86_64"\)/);
   assert.doesNotMatch(packager, /const staging = join\(ROOT, "dist", "runtime-staging-win32-x86_64"\)/);

--- a/scripts/rebuild-fs-ext.mjs
+++ b/scripts/rebuild-fs-ext.mjs
@@ -13,20 +13,27 @@ if (!existsSync(join(dir, "binding.gyp"))) {
   console.error("fs-ext binding.gyp missing");
   process.exit(1);
 }
-const npm = join(dirname(process.execPath), process.platform === "win32" ? "npm.cmd" : "npm");
+const npmJs = join(dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js");
 const devdir = process.env.npm_config_devdir || join(tmpdir(), "node-gyp-dev");
 const env = {
   ...process.env,
   npm_config_devdir: devdir,
   npm_config_ignore_scripts: "false",
 };
-const rebuilt = spawnSync(npm, ["rebuild", "fs-ext", "--ignore-scripts=false"], {
-  cwd: ROOT,
-  stdio: "inherit",
-  env,
-});
+const rebuilt = existsSync(npmJs)
+  ? spawnSync(process.execPath, [npmJs, "rebuild", "fs-ext", "--ignore-scripts=false"], {
+      cwd: ROOT,
+      stdio: "inherit",
+      env,
+    })
+  : spawnSync(process.platform === "win32" ? "npm.cmd" : "npm", ["rebuild", "fs-ext", "--ignore-scripts=false"], {
+      cwd: ROOT,
+      stdio: "inherit",
+      env,
+      shell: process.platform === "win32",
+    });
 if ((rebuilt.status ?? 1) !== 0 || !existsSync(built)) {
-  console.error("fs-ext rebuild failed");
+  console.error("fs-ext rebuild failed", rebuilt.error?.message ?? "", "status", rebuilt.status);
   process.exit(rebuilt.status ?? 1);
 }
 console.log("fs-ext rebuilt", built);


### PR DESCRIPTION
Native Windows install pinned dependencies failed because spawnSync of npm.cmd without shell produced no rebuild. Run npm-cli.js with the same Node, with a Windows shell fallback.

I05 Poppler remains deferred.