### PR TITLE
fix: use 0.5.12 DSH packaged-byte policy

### DIFF
--- a/packages/runtime/src/windows-host.test.ts
+++ b/packages/runtime/src/windows-host.test.ts
@@ -347,6 +347,11 @@ test("NSIS script always preserves user data after in-app exact deletion", () =>
   assert.match(payload, /stagingForTarget\(ROOT, "win32-x86_64"\)/);
   assert.match(cleanClone, /process\.platform === "win32"[\s\S]*build:windows-host/);
   assert.match(cleanClone, /rebuild:fs-ext/);
+  const artifact = readFileSync(new URL("../../../scripts/verify-artifact.mjs", import.meta.url), "utf8");
+  const bundleDesktop = readFileSync(new URL("../../../scripts/bundle-desktop.mjs", import.meta.url), "utf8");
+  assert.match(artifact, /docs\/0\.5\.12\/DSH_ALPHA_PACKAGED_BYTES\.json/);
+  assert.doesNotMatch(artifact, /docs\/0\.5\.10\/DSH_ALPHA_PACKAGED_BYTES\.json/);
+  assert.match(bundleDesktop, /docs\/0\.5\.12\/DSH_ALPHA_PACKAGED_BYTES\.json/);
   const rebuildFsExt = readFileSync(new URL("../../../scripts/rebuild-fs-ext.mjs", import.meta.url), "utf8");
   assert.match(rebuildFsExt, /npm-cli\.js/);
   assert.match(rebuildFsExt, /shell: process\.platform === "win32"/);

--- a/scripts/bundle-desktop.mjs
+++ b/scripts/bundle-desktop.mjs
@@ -39,7 +39,7 @@ await build({
 const staticSrc = join(ROOT, "apps/desktop/static");
 if (existsSync(staticSrc)) cpSync(staticSrc, join(outDir, "static"), { recursive: true });
 const packagedBytes = JSON.parse(
-  readFileSync(join(ROOT, "docs/0.5.10/DSH_ALPHA_PACKAGED_BYTES.json"), "utf8"),
+  readFileSync(join(ROOT, "docs/0.5.12/DSH_ALPHA_PACKAGED_BYTES.json"), "utf8"),
 );
 const brandDest = join(outDir, "static", "penglai-brand");
 mkdirSync(brandDest, { recursive: true });

--- a/scripts/verify-artifact.mjs
+++ b/scripts/verify-artifact.mjs
@@ -54,7 +54,7 @@ if (blocked) {
 
 const sha256 = (path) => createHash("sha256").update(readFileSync(path)).digest("hex");
 const packagedBytes = JSON.parse(
-  readFileSync(join(ROOT, "docs/0.5.10/DSH_ALPHA_PACKAGED_BYTES.json"), "utf8"),
+  readFileSync(join(ROOT, "docs/0.5.12/DSH_ALPHA_PACKAGED_BYTES.json"), "utf8"),
 );
 if (packagedBytes.dsh !== packaged.release.dsh || packagedBytes.mode !== "official-npm-cohort-no-source-patch") {
   finish("FAIL", { command: "verify:artifact", reason: "DSH alpha packaged-byte policy identity drift" });


### PR DESCRIPTION
Native ARM failed verify:artifact with DSH alpha packaged-byte policy identity drift because verify-artifact.mjs and bundle-desktop.mjs still read the 0.5.10 rc.1 policy. Point both at docs/0.5.12/DSH_ALPHA_PACKAGED_BYTES.json.

I05 Poppler remains deferred.