### PR TITLE
fix: pin official JSONL testdata to LF on Windows checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,3 +25,9 @@ docs/*/DSH_NPM_COHORT.json text eol=lf
 docs/*/DSH_ALPHA_PACKAGED_BYTES.json text eol=lf
 pnpm-lock.yaml text eol=lf
 pnpm-workspace.yaml text eol=lf
+
+# Official session JSONL and other digest-bound testdata must stay LF on every
+# checkout. Git for Windows otherwise rewrites them to CRLF and invalidates
+# the committed provenance hash (U02 rc.1 v0 log 7dc9ca08… vs CRLF c2a03bce…).
+packages/runtime/testdata/** text eol=lf
+**/*.jsonl text eol=lf

--- a/packages/runtime/src/dsh-home-upgrade.test.ts
+++ b/packages/runtime/src/dsh-home-upgrade.test.ts
@@ -680,7 +680,23 @@ const OFFICIAL_RC1_ASSISTANT = "restored-from-rc1";
 function officialRc1Provenance() {
   return JSON.parse(
     readFileSync(join(OFFICIAL_RC1_V0_DIR, "provenance.json"), "utf8"),
-  ) as { sha256: string; writer: { session: string; formatVersion: number } };
+  ) as {
+    sha256: string;
+    bytes: number;
+    writer: { session: string; formatVersion: number };
+  };
+}
+
+function officialRc1FixtureLog(): Buffer {
+  return readFileSync(
+    join(
+      OFFICIAL_RC1_V0_DIR,
+      "sessions",
+      "--privacy-safe-workspace--",
+      OFFICIAL_RC1_SESSION_ID,
+      "session.jsonl",
+    ),
+  );
 }
 
 function officialRc1V0Home(): string {
@@ -780,6 +796,24 @@ async function restoreOfficialRc1(
   }
 }
 
+test("U02 official rc.1 v0 JSONL checkout bytes match provenance and stay LF", () => {
+  const provenance = officialRc1Provenance();
+  const fixture = officialRc1FixtureLog();
+  assert.equal(fixture.includes(0x0d), false);
+  assert.equal(fixture.byteLength, provenance.bytes);
+  assert.equal(
+    createHash("sha256").update(fixture).digest("hex"),
+    provenance.sha256,
+  );
+  const crlf = Buffer.from(
+    [...fixture].flatMap((byte) => (byte === 0x0a ? [0x0d, 0x0a] : [byte])),
+  );
+  assert.notEqual(
+    createHash("sha256").update(crlf).digest("hex"),
+    provenance.sha256,
+  );
+});
+
 test("U02 official rc.1 v0 JSONL migrates through Home and restores with 0.1.3-alpha.2", async () => {
   const provenance = officialRc1Provenance();
   assert.equal(provenance.writer.session, "0.1.2-rc.1");
@@ -795,6 +829,7 @@ test("U02 official rc.1 v0 JSONL migrates through Home and restores with 0.1.3-a
     createHash("sha256").update(original).digest("hex"),
     provenance.sha256,
   );
+  assert.deepEqual(original, officialRc1FixtureLog());
   assert.match(original.toString("utf8"), /"version":0/);
   assert.equal(original.includes("isSeeded"), false);
 

--- a/scripts/lib/dsh-local-dependency-map.test.mjs
+++ b/scripts/lib/dsh-local-dependency-map.test.mjs
@@ -31,6 +31,12 @@ test("fixed DSH closure manifest keeps release-identity bytes on Windows", () =>
   );
 });
 
+test("digest-bound runtime testdata and JSONL stay LF on Windows checkout", () => {
+  const attributes = readFileSync(`${ROOT}/.gitattributes`, "utf8");
+  assert.match(attributes, /^packages\/runtime\/testdata\/\*\* text eol=lf$/m);
+  assert.match(attributes, /^\*\*\/\*\.jsonl text eol=lf$/m);
+});
+
 test("same-version DSH tarballs reseal lock identities without resolving unrelated packages", () => {
   const row = {
     name: "@deepseek-ai/dsh-example",


### PR DESCRIPTION
## Why

Native 0.5.12 candidate `19c5d078` failed Windows source gates on U02. The official rc.1 v0 JSONL fixture hashed to `c2a03bce…` instead of provenance `7dc9ca08…`. That actual digest is the same file with LF converted to CRLF (1627 → 1638 bytes). ARM already passed the same tests, so this is checkout line-ending mutation, not Home migration.

## Change

- Pin `packages/runtime/testdata/**` and `**/*.jsonl` to `text eol=lf` in `.gitattributes`, matching the existing digest-bound text rule.
- Assert the checkout bytes match provenance, contain no CR, and that a CRLF rewrite cannot satisfy the official digest.
- Do not skip Windows, change the official hash, or introduce a substitute session log.

## Verification

- Local: `node --import tsx --test packages/runtime/src/dsh-home-upgrade.test.ts scripts/lib/dsh-local-dependency-map.test.mjs` → 26 pass / 0 fail.
- Native run `34253171694` Windows failure is this class; ARM/Intel of that run are left running for independent evidence.

Owner-staged `AGENTS.md` / `docs/0.5.7/RELEASE_RUNBOOK.md` are not in this PR.