### PR TITLE
fix: detach the RW DMG before UDZO convert

### DIFF
--- a/scripts/build-local-dmg.mjs
+++ b/scripts/build-local-dmg.mjs
@@ -43,7 +43,7 @@ function waitSync(milliseconds) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
 }
 
-function createDmg(args, dmgPath) {
+function createDmg(args, dmgPath, { onRetry } = {}) {
   const attempts = 3;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     const result = spawnSync("hdiutil", args, {
@@ -62,6 +62,7 @@ function createDmg(args, dmgPath) {
       throw new Error(`hdiutil ${args[0]} failed: ${detail}`);
     }
 
+    onRetry?.();
     rmSync(dmgPath, { force: true });
     const delayMs = attempt * 2_000;
     process.stderr.write(
@@ -223,6 +224,7 @@ try {
       imageKey: "zlib-level=9",
     }),
     dmgPath,
+    { onRetry: () => detachDmgUntilReleased({ mount: volume, image: rwImage }) },
   );
   run("hdiutil", ["verify", dmgPath]);
 } finally {

--- a/scripts/build-local-dmg.mjs
+++ b/scripts/build-local-dmg.mjs
@@ -22,7 +22,12 @@ import { join } from "node:path";
 import { ROOT } from "./lib/repo.mjs";
 import { inspectPackagedCandidate } from "./lib/packaged-candidate.mjs";
 import { readReleaseIdentityPins } from "./lib/release-pins-source.mjs";
-import { hdiutilConvertArgs, hdiutilCreateArgs } from "./lib/hdiutil-image.mjs";
+import {
+  detachDmgUntilReleased,
+  hdiutilBusyRetryable,
+  hdiutilConvertArgs,
+  hdiutilCreateArgs,
+} from "./lib/hdiutil-image.mjs";
 
 const releasePins = readReleaseIdentityPins();
 
@@ -50,7 +55,7 @@ function createDmg(args, dmgPath) {
     if (result.status === 0) return;
 
     const diagnostic = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
-    const retryable = diagnostic.includes("Resource busy");
+    const retryable = hdiutilBusyRetryable(diagnostic);
     if (!retryable || attempt === attempts) {
       const detail =
         result.error?.message ?? `exit ${result.status ?? "unknown"}`;
@@ -60,7 +65,7 @@ function createDmg(args, dmgPath) {
     rmSync(dmgPath, { force: true });
     const delayMs = attempt * 2_000;
     process.stderr.write(
-      `hdiutil ${args[0]} reported Resource busy; retrying ${attempt + 1}/${attempts} after ${delayMs}ms\n`,
+      `hdiutil ${args[0]} reported a busy image; retrying ${attempt + 1}/${attempts} after ${delayMs}ms\n`,
     );
     waitSync(delayMs);
   }
@@ -199,7 +204,7 @@ try {
     rwImage,
   );
   if (existsSync(volume)) {
-    spawnSync("hdiutil", ["detach", volume, "-force"], { stdio: "inherit" });
+    detachDmgUntilReleased({ mount: volume, image: rwImage });
   }
   run("hdiutil", ["attach", rwImage, "-readwrite", "-noverify", "-nobrowse"]);
   try {
@@ -208,7 +213,7 @@ try {
     }
     layoutDmgWindow(volume);
   } finally {
-    spawnSync("hdiutil", ["detach", volume, "-force"], { stdio: "inherit" });
+    detachDmgUntilReleased({ mount: volume, image: rwImage });
   }
   createDmg(
     hdiutilConvertArgs({

--- a/scripts/lib/hdiutil-image.mjs
+++ b/scripts/lib/hdiutil-image.mjs
@@ -1,5 +1,33 @@
 /** argv builders for hdiutil create/convert. Convert must use -o and one image. */
 
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+
+export function hdiutilBusyRetryable(diagnostic) {
+  return /resource busy|resource temporarily unavailable|couldn't eject/i.test(
+    String(diagnostic ?? ""),
+  );
+}
+
+export function detachDmgUntilReleased({ mount, image, attempts = 8, waitMs = 1_000 } = {}) {
+  if (!mount && !image) {
+    throw new Error("hdiutil detach requires a mount or image");
+  }
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    if (mount) {
+      spawnSync("hdiutil", ["detach", mount, "-force"], { encoding: "utf8" });
+    }
+    if (image) {
+      spawnSync("hdiutil", ["detach", image, "-force"], { encoding: "utf8" });
+    }
+    if (!mount || !existsSync(mount)) return;
+    if (attempt === attempts) {
+      throw new Error(`hdiutil detach did not release ${mount}`);
+    }
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, attempt * waitMs);
+  }
+}
+
 const CREATE_VALUE_FLAGS = new Set(["-volname", "-srcfolder", "-format", "-fs", "-size"]);
 const CREATE_BARE_FLAGS = new Set(["-ov", "-plist", "-verbose", "-debug", "-quiet"]);
 

--- a/scripts/lib/hdiutil-image.mjs
+++ b/scripts/lib/hdiutil-image.mjs
@@ -4,9 +4,33 @@ import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 
 export function hdiutilBusyRetryable(diagnostic) {
-  return /resource busy|resource temporarily unavailable|couldn't eject/i.test(
+  return /resource busy|resource temporarily unavailable|couldn't eject|资源暂时不可用|无法推出/i.test(
     String(diagnostic ?? ""),
   );
+}
+
+export function disksAttachedToImage(infoText, imagePath) {
+  const image = String(imagePath ?? "");
+  if (!image) return [];
+  const disks = [];
+  const seen = new Set();
+  for (const block of String(infoText ?? "").split(/^=+$/mu)) {
+    if (!block.includes(image)) continue;
+    for (const line of block.split(/\n/u)) {
+      const match = /^(\/dev\/disk\d+)(?:\s|$)/u.exec(line.trim());
+      if (!match || seen.has(match[1])) continue;
+      seen.add(match[1]);
+      disks.push(match[1]);
+    }
+  }
+  return disks;
+}
+
+function hdiutilInfoText() {
+  const result = spawnSync("hdiutil", ["info"], { encoding: "utf8" });
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  return `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
 }
 
 export function detachDmgUntilReleased({ mount, image, attempts = 8, waitMs = 1_000 } = {}) {
@@ -14,15 +38,26 @@ export function detachDmgUntilReleased({ mount, image, attempts = 8, waitMs = 1_
     throw new Error("hdiutil detach requires a mount or image");
   }
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    if (mount) {
-      spawnSync("hdiutil", ["detach", mount, "-force"], { encoding: "utf8" });
+    const info = hdiutilInfoText();
+    const disks = image ? disksAttachedToImage(info, image) : [];
+    const targets = [];
+    if (mount) targets.push(mount);
+    for (const disk of disks) {
+      if (!targets.includes(disk)) targets.push(disk);
     }
-    if (image) {
-      spawnSync("hdiutil", ["detach", image, "-force"], { encoding: "utf8" });
+    for (const target of targets) {
+      if (target.startsWith("/dev/") && !existsSync(target)) continue;
+      const detached = spawnSync("hdiutil", ["detach", target, "-force"], { encoding: "utf8" });
+      if (detached.stdout) process.stdout.write(detached.stdout);
+      if (detached.stderr) process.stderr.write(detached.stderr);
     }
-    if (!mount || !existsSync(mount)) return;
+    const stillMounted = Boolean(mount && existsSync(mount));
+    const stillAttached = image ? disksAttachedToImage(hdiutilInfoText(), image).length > 0 : false;
+    if (!stillMounted && !stillAttached) return;
     if (attempt === attempts) {
-      throw new Error(`hdiutil detach did not release ${mount}`);
+      throw new Error(
+        `hdiutil detach did not release ${[mount, image].filter(Boolean).join(" ")}`,
+      );
     }
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, attempt * waitMs);
   }

--- a/scripts/lib/hdiutil-image.test.mjs
+++ b/scripts/lib/hdiutil-image.test.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import test from "node:test";
 import {
   assertHdiutilConvertArgs,
+  hdiutilBusyRetryable,
   hdiutilConvertArgs,
   hdiutilCreateArgs,
 } from "./hdiutil-image.mjs";
@@ -61,6 +62,18 @@ test("hdiutil convert requires -o and exactly one input image", () => {
     () => hdiutilConvertArgs({ image, output: image }),
     /input image and output must differ/,
   );
+});
+
+test("convert retries when the UDRW is still attached", () => {
+  assert.equal(
+    hdiutilBusyRetryable("hdiutil: convert failed - Resource temporarily unavailable"),
+    true,
+  );
+  assert.equal(hdiutilBusyRetryable('hdiutil: couldn\'t eject "disk5" - Resource busy'), true);
+  assert.equal(hdiutilBusyRetryable("only a single input file can be specified"), false);
+  const dmg = readFileSync(join(root, "scripts/build-local-dmg.mjs"), "utf8");
+  assert.match(dmg, /detachDmgUntilReleased/);
+  assert.match(dmg, /hdiutilBusyRetryable/);
 });
 
 test("build-local-dmg uses the convert builder instead of a second positional path", () => {

--- a/scripts/lib/hdiutil-image.test.mjs
+++ b/scripts/lib/hdiutil-image.test.mjs
@@ -7,6 +7,8 @@ import { fileURLToPath } from "node:url";
 import test from "node:test";
 import {
   assertHdiutilConvertArgs,
+  detachDmgUntilReleased,
+  disksAttachedToImage,
   hdiutilBusyRetryable,
   hdiutilConvertArgs,
   hdiutilCreateArgs,
@@ -70,10 +72,25 @@ test("convert retries when the UDRW is still attached", () => {
     true,
   );
   assert.equal(hdiutilBusyRetryable('hdiutil: couldn\'t eject "disk5" - Resource busy'), true);
+  assert.equal(hdiutilBusyRetryable("hdiutil: convert failed - 资源暂时不可用"), true);
   assert.equal(hdiutilBusyRetryable("only a single input file can be specified"), false);
+  const info = [
+    "image-path      : /tmp/penglai-rw.dmg",
+    "/dev/disk5           GUID_partition_scheme",
+    "/dev/disk5s1         Apple_APFS",
+    "/dev/disk6           EF57347C-0000-11AA-AA11-0030654",
+    "/dev/disk6s1         41504653-0000-11AA-AA11-0030654 /Volumes/Penglai",
+  ].join("\n");
+  assert.deepEqual(disksAttachedToImage(info, "/tmp/penglai-rw.dmg"), [
+    "/dev/disk5",
+    "/dev/disk6",
+  ]);
+  assert.deepEqual(disksAttachedToImage(info, "/tmp/other.dmg"), []);
   const dmg = readFileSync(join(root, "scripts/build-local-dmg.mjs"), "utf8");
   assert.match(dmg, /detachDmgUntilReleased/);
   assert.match(dmg, /hdiutilBusyRetryable/);
+  assert.match(dmg, /onRetry/);
+  assert.doesNotMatch(dmg, /detach", image, "-force"/);
 });
 
 test("build-local-dmg uses the convert builder instead of a second positional path", () => {
@@ -113,6 +130,12 @@ test("hdiutil convert -o is the native class that failed without -o", {
       { encoding: "utf8" },
     );
     assert.equal(created.status, 0, created.stderr);
+    const attached = spawnSync("hdiutil", ["attach", rw, "-readwrite", "-noverify", "-nobrowse"], {
+      encoding: "utf8",
+    });
+    assert.equal(attached.status, 0, attached.stderr);
+    detachDmgUntilReleased({ image: rw });
+    assert.equal(disksAttachedToImage(spawnSync("hdiutil", ["info"], { encoding: "utf8" }).stdout, rw).length, 0);
     const broken = [
       "convert",
       rw,


### PR DESCRIPTION
## Why

Native run 34275887280 on `7575157d` rebuilt fs-ext and used convert `-o`, then Apple Silicon failed:

```
hdiutil: couldn't eject "disk5" - Resource busy
hdiutil: convert failed - Resource temporarily unavailable
```

The previous retry only matched `Resource busy` on the convert argv result. Detach failure was ignored, so convert ran against a still-attached UDRW.

## Change

- `detachDmgUntilReleased` retries `hdiutil detach -force` on the mount and image until `/Volumes/Penglai` is gone.
- Convert/create retries also treat `Resource temporarily unavailable` and `couldn't eject` as the same busy class.

Branded UDRW layout and UDZO remount checks are unchanged.

## Verification

- `node --test scripts/lib/hdiutil-image.test.mjs scripts/lib/installer-presentation.test.mjs` pass, including a real Darwin convert of a tiny UDRW.
- Independent grok-4.6 xhigh review in progress.

I05 packaged PDF page preview / bundled Poppler stays DEFERRED_BY_OWNER / OUT_OF_SCOPE, not PASS.
Owner-staged files are not in this PR.