### PR TITLE
fix: ExecWait scoped stop without aborting silent uninstall

### DIFF
--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -398,7 +398,7 @@ test("Windows child shutdown kills the process tree so NSIS upgrade is not block
   assert.match(nsis, /\/SD IDOK/);
   assert.match(nsis, /upgrade_rename_live/);
   assert.match(nsis, /PenglaiStopScoped/);
-  assert.match(nsis, /PENGLAI_INSTALL_ROOT/);
+  assert.match(nsis, /ExecWait \$8 \$R4/);
   assert.match(nsis, /ExecutablePath/);
   assert.doesNotMatch(nsis, /\/IM Penglai\.exe/);
   assert.match(nsis, /penglai-setup\.log/);

--- a/packages/runtime/src/leftover.test.ts
+++ b/packages/runtime/src/leftover.test.ts
@@ -236,7 +236,7 @@ test("Windows upgrade refuses the old live-tree delete-then-copy pattern", async
   assertWindowsNsisScript(live);
   assert.match(live, /upgrade_rename_live/);
   assert.match(live, /PenglaiStopScoped/);
-  assert.match(live, /PENGLAI_INSTALL_ROOT/);
+  assert.match(live, /ExecWait \$8 \$R4/);
   assert.match(live, /ExecutablePath/);
   assert.doesNotMatch(live, /\/IM Penglai\.exe/);
   assert.match(live, /penglai-setup\.log/);

--- a/packages/runtime/src/packaging.ts
+++ b/packages/runtime/src/packaging.ts
@@ -168,10 +168,10 @@ export function assertWindowsUpgradeStaging(script: string): void {
   if (scopedStop < 0 || retryLabel < 0 || retryLabel > liveRename) {
     throw new Error("Windows upgrade must stop scoped install-root processes and retry renaming the live app directory");
   }
-  if (!script.includes("PENGLAI_INSTALL_ROOT") || !script.includes("$$env:PENGLAI_INSTALL_ROOT")) {
-    throw new Error("Windows upgrade must pass INSTDIR through PENGLAI_INSTALL_ROOT instead of nested NSIS quotes");
+  if (!script.includes("ExecWait $8 $R4") || !script.includes("StrCpy $8 `")) {
+    throw new Error("Windows upgrade must ExecWait a single prebuilt command variable instead of nested NSIS quotes");
   }
-  if (/GetFullPath\(''\$INSTDIR''\)/.test(script) || /GetFullPath\('\$INSTDIR'\)/.test(script)) {
+  if (/GetFullPath\(''\$INSTDIR''\)/.test(script)) {
     throw new Error("Windows upgrade must not embed $INSTDIR in nested NSIS quotes");
   }
   if (!script.includes("ExecutablePath") || !script.includes("StartsWith")) {

--- a/packages/runtime/src/windows-host.test.ts
+++ b/packages/runtime/src/windows-host.test.ts
@@ -304,7 +304,7 @@ test("NSIS script always preserves user data after in-app exact deletion", () =>
   assert.match(script, /previous install was left in place/);
   assert.match(script, /upgrade_rename_live/);
   assert.match(script, /PenglaiStopScoped/);
-  assert.match(script, /PENGLAI_INSTALL_ROOT/);
+  assert.match(script, /ExecWait \$8 \$R4/);
   assert.match(script, /ExecutablePath/);
   assert.doesNotMatch(script, /\/IM Penglai\.exe/);
   assert.match(script, /penglai-setup\.log/);

--- a/scripts/lib/installer-presentation.test.mjs
+++ b/scripts/lib/installer-presentation.test.mjs
@@ -59,8 +59,8 @@ test("Windows NSIS welcome and header bitmaps are 24-bit branded pages", () => {
   assert.match(nsi, /MUI_WELCOMEFINISHPAGE_BITMAP/);
   assert.match(nsi, /MUI_HEADERIMAGE_BITMAP/);
   assert.match(nsi, /PenglaiStopScoped/);
-  assert.match(nsi, /PENGLAI_INSTALL_ROOT/);
-  assert.match(nsi, /\$\$env:PENGLAI_INSTALL_ROOT/);
+  assert.match(nsi, /ExecWait \$8 \$R4/);
+  assert.match(nsi, /GetFullPath\('\$INSTDIR'\)/);
   assert.doesNotMatch(nsi, /GetFullPath\(''\$INSTDIR''\)/);
   assert.doesNotMatch(nsi, /\/IM Penglai\.exe/);
   assert.match(packager, /PENGLAI_WELCOME_BMP=/);

--- a/scripts/lib/windows-process-scope.mjs
+++ b/scripts/lib/windows-process-scope.mjs
@@ -204,21 +204,25 @@ export function nsisScopedStopContract(script) {
   if (!/TrimEnd/.test(text) || !/\[char\]92/.test(text)) {
     errors.push("must bound INSTDIR with a trailing separator so 0.5 does not match 0.50");
   }
-  if (!/SetEnvironmentVariable\(t "PENGLAI_INSTALL_ROOT", t "\$INSTDIR"\)/.test(text)) {
-    errors.push("must set PENGLAI_INSTALL_ROOT from INSTDIR before PowerShell");
+  if (!/StrCpy \$8 `/.test(text) || !/ExecWait \$8 \$R4/.test(text)) {
+    errors.push("must ExecWait a single prebuilt command variable, not nested NSIS quotes");
   }
-  if (!/\$\$env:PENGLAI_INSTALL_ROOT/.test(text)) {
-    errors.push("must read INSTDIR from $$env:PENGLAI_INSTALL_ROOT, not nested quoted $INSTDIR");
-  }
-  if (/GetFullPath\(''\$INSTDIR''\)/.test(text) || /GetFullPath\('\$INSTDIR'\)/.test(text)) {
+  if (/GetFullPath\(''\$INSTDIR''\)/.test(text)) {
     errors.push("must not embed $INSTDIR in nested NSIS quotes");
+  }
+  const macro = text.match(/!macro PenglaiStopScoped([\s\S]*?)!macroend/u);
+  if (macro && /\bAbort\b/.test(macro[1])) {
+    errors.push("PenglaiStopScoped must not Abort silent uninstall");
   }
   for (const command of nsisExecWaitCommands(text)) {
     if (command.args.length < 1 || command.args.length > 2) {
       errors.push(`ExecWait expects 1-2 parameters, got ${command.args.length}`);
     }
   }
-  const stopCommand = nsisDollarUnescape(extractNsisScopedStopCommand(text));
+  const stopCommand = nsisDollarUnescape(extractNsisScopedStopCommand(text)).replace(
+    /GetFullPath\('\$INSTDIR'\)/gu,
+    "GetFullPath($env:PENGLAI_INSTALL_ROOT)",
+  );
   if (!stopCommand) {
     errors.push("PenglaiStopScoped must include a PowerShell -Command");
   } else if (collapseWhitespace(stopCommand) !== collapseWhitespace(WINDOWS_SCOPED_STOP_POWERSHELL)) {

--- a/scripts/lib/windows-process-scope.test.mjs
+++ b/scripts/lib/windows-process-scope.test.mjs
@@ -64,8 +64,8 @@ test("NSIS and upgrade verifier must not kill every Penglai.exe by image name", 
   }
   assert.match(nsis, /ExecutablePath/);
   assert.match(nsis, /StartsWith/);
-  assert.match(nsis, /PENGLAI_INSTALL_ROOT/);
-  assert.match(nsis, /\$\$env:PENGLAI_INSTALL_ROOT/);
+  assert.match(nsis, /ExecWait \$8 \$R4/);
+  assert.match(nsis, /GetFullPath\('\$INSTDIR'\)/);
   assert.doesNotMatch(nsis, /GetFullPath\(''\$INSTDIR''\)/);
   assert.doesNotMatch(upgrade, /DisableRealtimeMonitoring \$true/);
   assert.doesNotMatch(upgrade, /Add-MpPreference -ExclusionPath/);
@@ -80,13 +80,13 @@ test("NSIS ExecWait nested single quotes are the class that yielded four paramet
   const errors = nsisScopedStopContract(`!macro PenglaiStopScoped\n${broken}\n!macroend\n`);
   assert.ok(errors.some((row) => row.includes("got 4")));
   assert.ok(errors.some((row) => row.includes("nested NSIS quotes")));
-  assert.ok(errors.some((row) => row.includes("PENGLAI_INSTALL_ROOT")));
+  assert.ok(errors.some((row) => row.includes("prebuilt command variable")));
   const nsis = readFileSync(join(root, "scripts/nsis/Penglai.nsi"), "utf8");
   for (const command of nsisExecWaitCommands(nsis)) {
     assert.ok(command.args.length >= 1 && command.args.length <= 2, command.line);
   }
-  const stop = nsisExecWaitCommands(nsis).find((command) => command.line.includes("powershell.exe"));
+  const stop = nsisExecWaitCommands(nsis).find((command) => command.args[0] === "$8");
   assert.equal(stop?.args.length, 2);
-  assert.match(nsisDollarUnescape(stop.args[0]), /\$env:PENGLAI_INSTALL_ROOT/);
+  assert.match(nsis, /GetFullPath\('\$INSTDIR'\)/);
   assert.match(WINDOWS_SCOPED_STOP_POWERSHELL, /\$env:PENGLAI_INSTALL_ROOT/);
 });

--- a/scripts/nsis/Penglai.nsi
+++ b/scripts/nsis/Penglai.nsi
@@ -53,14 +53,11 @@ InstallDirRegKey HKCU "Software\Penglai\0.5" "InstallDir"
 ; Stop only processes whose ExecutablePath is under this INSTDIR. Image-name
 ; taskkill would kill a second Penglai instance with a different install root.
 ; ExecWait accepts 1-2 tokens. Nested NSIS single quotes around $INSTDIR split
-; the command ("got 4"). Pass INSTDIR through PENGLAI_INSTALL_ROOT instead.
+; the command ("got 4"). Build one command in a backtick string, then ExecWait
+; the variable so silent uninstall cannot Abort on System::Call.
 !macro PenglaiStopScoped
-  System::Call 'kernel32::SetEnvironmentVariable(t "PENGLAI_INSTALL_ROOT", t "$INSTDIR") i .r9'
-  ${If} $9 == 0
-    MessageBox MB_ICONSTOP|MB_SETFOREGROUND "Penglai could not scope the running-app stop to this install directory." /SD IDOK
-    Abort
-  ${EndIf}
-  ExecWait '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -Command "$$root = [IO.Path]::GetFullPath($$env:PENGLAI_INSTALL_ROOT).TrimEnd([char]92); $$prefix = $$root + [char]92; Get-CimInstance Win32_Process | ForEach-Object { if ($$_.ExecutablePath -and ($$_.ExecutablePath.Equals($$root, [StringComparison]::OrdinalIgnoreCase) -or $$_.ExecutablePath.StartsWith($$prefix, [StringComparison]::OrdinalIgnoreCase))) { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue } }"' $R4
+  StrCpy $8 `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -Command "$$root = [IO.Path]::GetFullPath('$INSTDIR').TrimEnd([char]92); $$prefix = $$root + [char]92; Get-CimInstance Win32_Process | ForEach-Object { if ($$_.ExecutablePath -and ($$_.ExecutablePath.Equals($$root, [StringComparison]::OrdinalIgnoreCase) -or $$_.ExecutablePath.StartsWith($$prefix, [StringComparison]::OrdinalIgnoreCase))) { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue } }"`
+  ExecWait $8 $R4
 !macroend
 
 !define MUI_ABORTWARNING


### PR DESCRIPTION
## Why

Native `34280077388` on `d92b4d70`: Apple Silicon installer **SUCCESS**. Windows built the setup, passed e2e/welcome/plugins, then `verify:upgrade-uninstall` failed with `Windows uninstaller returned failure` status `4294967295` on the 0.5.12 `Uninstall.exe /S` after 0.5.8 upgrade.

`PenglaiStopScoped` called `kernel32::SetEnvironmentVariable` and `Abort` when the BOOL was 0. Silent uninstall then failed closed by aborting instead of stopping scoped processes and removing the default tree.

## Change

Build the PowerShell command in one backtick-quoted `StrCpy` and `ExecWait $8 $R4`. INSTDIR is passed as `GetFullPath('$INSTDIR')`. No System::Call, no Abort in the stop macro. ExecutablePath scoping, trailing-separator bound, and no `/IM` are unchanged.

## Verification

- `node --test scripts/lib/windows-process-scope.test.mjs scripts/lib/installer-presentation.test.mjs` pass.
- Independent grok-4.6 xhigh review in progress.
- ARM success on `d92b4d70` is diagnostic; final three-target must bind the later same SHA.

I05 stays DEFERRED_BY_OWNER / OUT_OF_SCOPE, not PASS.
Owner-staged files are not in this PR.