### PR TITLE
fix: run scoped process stop from a temp PowerShell file

### DIFF
--- a/apps/desktop/src/installed-walk.test.ts
+++ b/apps/desktop/src/installed-walk.test.ts
@@ -398,7 +398,7 @@ test("Windows child shutdown kills the process tree so NSIS upgrade is not block
   assert.match(nsis, /\/SD IDOK/);
   assert.match(nsis, /upgrade_rename_live/);
   assert.match(nsis, /PenglaiStopScoped/);
-  assert.match(nsis, /ExecWait \$8 \$R4/);
+  assert.match(nsis, /penglai-stop-scoped\.ps1/);
   assert.match(nsis, /ExecutablePath/);
   assert.doesNotMatch(nsis, /\/IM Penglai\.exe/);
   assert.match(nsis, /penglai-setup\.log/);

--- a/packages/runtime/src/leftover.test.ts
+++ b/packages/runtime/src/leftover.test.ts
@@ -236,7 +236,7 @@ test("Windows upgrade refuses the old live-tree delete-then-copy pattern", async
   assertWindowsNsisScript(live);
   assert.match(live, /upgrade_rename_live/);
   assert.match(live, /PenglaiStopScoped/);
-  assert.match(live, /ExecWait \$8 \$R4/);
+  assert.match(live, /penglai-stop-scoped\.ps1/);
   assert.match(live, /ExecutablePath/);
   assert.doesNotMatch(live, /\/IM Penglai\.exe/);
   assert.match(live, /penglai-setup\.log/);

--- a/packages/runtime/src/packaging.ts
+++ b/packages/runtime/src/packaging.ts
@@ -168,8 +168,8 @@ export function assertWindowsUpgradeStaging(script: string): void {
   if (scopedStop < 0 || retryLabel < 0 || retryLabel > liveRename) {
     throw new Error("Windows upgrade must stop scoped install-root processes and retry renaming the live app directory");
   }
-  if (!script.includes("ExecWait $8 $R4") || !script.includes("StrCpy $8 `")) {
-    throw new Error("Windows upgrade must ExecWait a single prebuilt command variable instead of nested NSIS quotes");
+  if (!script.includes("penglai-stop-scoped.ps1") || !script.includes("-File")) {
+    throw new Error("Windows upgrade must ExecWait powershell -File a temp stop script instead of nested NSIS quotes");
   }
   if (/GetFullPath\(''\$INSTDIR''\)/.test(script)) {
     throw new Error("Windows upgrade must not embed $INSTDIR in nested NSIS quotes");

--- a/packages/runtime/src/windows-host.test.ts
+++ b/packages/runtime/src/windows-host.test.ts
@@ -304,7 +304,7 @@ test("NSIS script always preserves user data after in-app exact deletion", () =>
   assert.match(script, /previous install was left in place/);
   assert.match(script, /upgrade_rename_live/);
   assert.match(script, /PenglaiStopScoped/);
-  assert.match(script, /ExecWait \$8 \$R4/);
+  assert.match(script, /penglai-stop-scoped\.ps1/);
   assert.match(script, /ExecutablePath/);
   assert.doesNotMatch(script, /\/IM Penglai\.exe/);
   assert.match(script, /penglai-setup\.log/);

--- a/scripts/lib/installer-presentation.test.mjs
+++ b/scripts/lib/installer-presentation.test.mjs
@@ -59,7 +59,7 @@ test("Windows NSIS welcome and header bitmaps are 24-bit branded pages", () => {
   assert.match(nsi, /MUI_WELCOMEFINISHPAGE_BITMAP/);
   assert.match(nsi, /MUI_HEADERIMAGE_BITMAP/);
   assert.match(nsi, /PenglaiStopScoped/);
-  assert.match(nsi, /ExecWait \$8 \$R4/);
+  assert.match(nsi, /penglai-stop-scoped\.ps1/);
   assert.match(nsi, /GetFullPath\('\$INSTDIR'\)/);
   assert.doesNotMatch(nsi, /GetFullPath\(''\$INSTDIR''\)/);
   assert.doesNotMatch(nsi, /\/IM Penglai\.exe/);

--- a/scripts/lib/windows-process-scope.mjs
+++ b/scripts/lib/windows-process-scope.mjs
@@ -179,10 +179,12 @@ export function nsisExecWaitCommands(script) {
 }
 
 export function extractNsisScopedStopCommand(script) {
-  const match = String(script ?? "").match(
-    /!macro PenglaiStopScoped[\s\S]*?-Command "([^"]+)"[\s\S]*?!macroend/u,
+  const macro = String(script ?? "").match(/!macro PenglaiStopScoped([\s\S]*?)!macroend/u)?.[1] ?? "";
+  const writes = [...macro.matchAll(/FileWrite \$8 "([^"]*)"/gu)].map((row) =>
+    row[1].replace(/\$\\r\$\\n$/u, ""),
   );
-  return match?.[1] ?? "";
+  if (writes.length) return writes.join("; ");
+  return macro.match(/-Command "([^"]+)"/u)?.[1] ?? "";
 }
 
 export function nsisDollarUnescape(text) {
@@ -204,8 +206,8 @@ export function nsisScopedStopContract(script) {
   if (!/TrimEnd/.test(text) || !/\[char\]92/.test(text)) {
     errors.push("must bound INSTDIR with a trailing separator so 0.5 does not match 0.50");
   }
-  if (!/StrCpy \$8 `/.test(text) || !/ExecWait \$8 \$R4/.test(text)) {
-    errors.push("must ExecWait a single prebuilt command variable, not nested NSIS quotes");
+  if (!/penglai-stop-scoped\.ps1/.test(text) || !/-File "\$TEMP\\penglai-stop-scoped\.ps1"/.test(text)) {
+    errors.push("must ExecWait powershell -File a temp stop script, not nested NSIS quotes");
   }
   if (/GetFullPath\(''\$INSTDIR''\)/.test(text)) {
     errors.push("must not embed $INSTDIR in nested NSIS quotes");

--- a/scripts/lib/windows-process-scope.mjs
+++ b/scripts/lib/windows-process-scope.mjs
@@ -95,7 +95,7 @@ export function selectProcessesForInstance(rows, { installRoot, dataRoot } = {})
 }
 
 export const WINDOWS_SCOPED_STOP_POWERSHELL =
-  "$root = [IO.Path]::GetFullPath($env:PENGLAI_INSTALL_ROOT).TrimEnd([char]92); $prefix = $root + [char]92; Get-CimInstance Win32_Process | ForEach-Object { if ($_.ExecutablePath -and ($_.ExecutablePath.Equals($root, [StringComparison]::OrdinalIgnoreCase) -or $_.ExecutablePath.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase))) { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue } }";
+  "$self = $PID; $parent = (Get-CimInstance Win32_Process -Filter ('ProcessId=' + $self)).ParentProcessId; $root = [IO.Path]::GetFullPath($env:PENGLAI_INSTALL_ROOT).TrimEnd([char]92); $prefix = $root + [char]92; Get-CimInstance Win32_Process | ForEach-Object { if ($_.ProcessId -ne $self -and $_.ProcessId -ne $parent -and $_.ExecutablePath -and ($_.ExecutablePath.Equals($root, [StringComparison]::OrdinalIgnoreCase) -or $_.ExecutablePath.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase))) { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue } }";
 
 const NSIS_ESCAPES = new Map([
   ["$", "$"],
@@ -202,6 +202,9 @@ export function nsisScopedStopContract(script) {
   }
   if (!/ExecutablePath/.test(text) || !/StartsWith/.test(text)) {
     errors.push("must stop processes by ExecutablePath under INSTDIR");
+  }
+  if (!/\$\$PID/.test(text) || !/ParentProcessId/.test(text)) {
+    errors.push("must not Stop-Process the uninstaller or its PowerShell child");
   }
   if (!/TrimEnd/.test(text) || !/\[char\]92/.test(text)) {
     errors.push("must bound INSTDIR with a trailing separator so 0.5 does not match 0.50");

--- a/scripts/lib/windows-process-scope.test.mjs
+++ b/scripts/lib/windows-process-scope.test.mjs
@@ -64,7 +64,7 @@ test("NSIS and upgrade verifier must not kill every Penglai.exe by image name", 
   }
   assert.match(nsis, /ExecutablePath/);
   assert.match(nsis, /StartsWith/);
-  assert.match(nsis, /ExecWait \$8 \$R4/);
+  assert.match(nsis, /penglai-stop-scoped\.ps1/);
   assert.match(nsis, /GetFullPath\('\$INSTDIR'\)/);
   assert.doesNotMatch(nsis, /GetFullPath\(''\$INSTDIR''\)/);
   assert.doesNotMatch(upgrade, /DisableRealtimeMonitoring \$true/);
@@ -80,13 +80,13 @@ test("NSIS ExecWait nested single quotes are the class that yielded four paramet
   const errors = nsisScopedStopContract(`!macro PenglaiStopScoped\n${broken}\n!macroend\n`);
   assert.ok(errors.some((row) => row.includes("got 4")));
   assert.ok(errors.some((row) => row.includes("nested NSIS quotes")));
-  assert.ok(errors.some((row) => row.includes("prebuilt command variable")));
+  assert.ok(errors.some((row) => row.includes("temp stop script")));
   const nsis = readFileSync(join(root, "scripts/nsis/Penglai.nsi"), "utf8");
   for (const command of nsisExecWaitCommands(nsis)) {
     assert.ok(command.args.length >= 1 && command.args.length <= 2, command.line);
   }
-  const stop = nsisExecWaitCommands(nsis).find((command) => command.args[0] === "$8");
+  const stop = nsisExecWaitCommands(nsis).find((command) => command.line.includes("powershell.exe"));
   assert.equal(stop?.args.length, 2);
-  assert.match(nsis, /GetFullPath\('\$INSTDIR'\)/);
+  assert.match(stop.args[0], /-File/);
   assert.match(WINDOWS_SCOPED_STOP_POWERSHELL, /\$env:PENGLAI_INSTALL_ROOT/);
 });

--- a/scripts/lib/windows-process-scope.test.mjs
+++ b/scripts/lib/windows-process-scope.test.mjs
@@ -66,6 +66,8 @@ test("NSIS and upgrade verifier must not kill every Penglai.exe by image name", 
   assert.match(nsis, /StartsWith/);
   assert.match(nsis, /penglai-stop-scoped\.ps1/);
   assert.match(nsis, /GetFullPath\('\$INSTDIR'\)/);
+  assert.match(nsis, /ParentProcessId/);
+  assert.match(nsis, /\$\$PID/);
   assert.doesNotMatch(nsis, /GetFullPath\(''\$INSTDIR''\)/);
   assert.doesNotMatch(upgrade, /DisableRealtimeMonitoring \$true/);
   assert.doesNotMatch(upgrade, /Add-MpPreference -ExclusionPath/);

--- a/scripts/nsis/Penglai.nsi
+++ b/scripts/nsis/Penglai.nsi
@@ -52,12 +52,16 @@ InstallDirRegKey HKCU "Software\Penglai\0.5" "InstallDir"
 
 ; Stop only processes whose ExecutablePath is under this INSTDIR. Image-name
 ; taskkill would kill a second Penglai instance with a different install root.
-; ExecWait accepts 1-2 tokens. Nested NSIS single quotes around $INSTDIR split
-; the command ("got 4"). Build one command in a backtick string, then ExecWait
-; the variable so silent uninstall cannot Abort on System::Call.
+; ExecWait accepts 1-2 tokens. Write a temp script and ExecWait -File so INSTDIR
+; is not nested in the same NSIS quote class as the command line.
 !macro PenglaiStopScoped
-  StrCpy $8 `"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -Command "$$root = [IO.Path]::GetFullPath('$INSTDIR').TrimEnd([char]92); $$prefix = $$root + [char]92; Get-CimInstance Win32_Process | ForEach-Object { if ($$_.ExecutablePath -and ($$_.ExecutablePath.Equals($$root, [StringComparison]::OrdinalIgnoreCase) -or $$_.ExecutablePath.StartsWith($$prefix, [StringComparison]::OrdinalIgnoreCase))) { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue } }"`
-  ExecWait $8 $R4
+  FileOpen $8 "$TEMP\penglai-stop-scoped.ps1" w
+  FileWrite $8 "$$root = [IO.Path]::GetFullPath('$INSTDIR').TrimEnd([char]92)$\r$\n"
+  FileWrite $8 "$$prefix = $$root + [char]92$\r$\n"
+  FileWrite $8 "Get-CimInstance Win32_Process | ForEach-Object { if ($$_.ExecutablePath -and ($$_.ExecutablePath.Equals($$root, [StringComparison]::OrdinalIgnoreCase) -or $$_.ExecutablePath.StartsWith($$prefix, [StringComparison]::OrdinalIgnoreCase))) { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue } }$\r$\n"
+  FileClose $8
+  ExecWait '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File "$TEMP\penglai-stop-scoped.ps1"' $R4
+  Delete "$TEMP\penglai-stop-scoped.ps1"
 !macroend
 
 !define MUI_ABORTWARNING

--- a/scripts/nsis/Penglai.nsi
+++ b/scripts/nsis/Penglai.nsi
@@ -56,9 +56,11 @@ InstallDirRegKey HKCU "Software\Penglai\0.5" "InstallDir"
 ; is not nested in the same NSIS quote class as the command line.
 !macro PenglaiStopScoped
   FileOpen $8 "$TEMP\penglai-stop-scoped.ps1" w
+  FileWrite $8 "$$self = $$PID$\r$\n"
+  FileWrite $8 "$$parent = (Get-CimInstance Win32_Process -Filter ('ProcessId=' + $$self)).ParentProcessId$\r$\n"
   FileWrite $8 "$$root = [IO.Path]::GetFullPath('$INSTDIR').TrimEnd([char]92)$\r$\n"
   FileWrite $8 "$$prefix = $$root + [char]92$\r$\n"
-  FileWrite $8 "Get-CimInstance Win32_Process | ForEach-Object { if ($$_.ExecutablePath -and ($$_.ExecutablePath.Equals($$root, [StringComparison]::OrdinalIgnoreCase) -or $$_.ExecutablePath.StartsWith($$prefix, [StringComparison]::OrdinalIgnoreCase))) { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue } }$\r$\n"
+  FileWrite $8 "Get-CimInstance Win32_Process | ForEach-Object { if ($$_.ProcessId -ne $$self -and $$_.ProcessId -ne $$parent -and $$_.ExecutablePath -and ($$_.ExecutablePath.Equals($$root, [StringComparison]::OrdinalIgnoreCase) -or $$_.ExecutablePath.StartsWith($$prefix, [StringComparison]::OrdinalIgnoreCase))) { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue } }$\r$\n"
   FileClose $8
   ExecWait '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File "$TEMP\penglai-stop-scoped.ps1"' $R4
   Delete "$TEMP\penglai-stop-scoped.ps1"

--- a/scripts/verify-upgrade-uninstall.mjs
+++ b/scripts/verify-upgrade-uninstall.mjs
@@ -342,6 +342,8 @@ if (target === "win32-x86_64") {
       status: uninstall.status,
       timedOut: uninstall.error?.code === "ETIMEDOUT",
       error: uninstall.error?.code,
+      stdout: sanitizeEvidenceText(String(uninstall.stdout ?? ""), 1_000),
+      stderr: sanitizeEvidenceText(String(uninstall.stderr ?? ""), 1_000),
     });
   }
   // `_?=` keeps Uninstall.exe in INSTDIR so spawnSync observes the real


### PR DESCRIPTION
## Why

Native `34285323001` on `45656f53`: Apple Silicon and Intel **SUCCESS**. Windows setup/e2e/welcome/plugins PASS. `verify:upgrade-uninstall` still failed with `Windows uninstaller returned failure` status `4294967295` after 0.5.8→0.5.12. Removing System::Call Abort did not change that exit.

## Change

Write `penglai-stop-scoped.ps1` with FileWrite and `ExecWait` powershell `-File`. INSTDIR is expanded inside the script, not nested in the ExecWait string. Capture uninstall stdout/stderr when the verifier fails. I04 scoped ExecutablePath matching is unchanged.

## Verification

- `node --test scripts/lib/windows-process-scope.test.mjs scripts/lib/installer-presentation.test.mjs` pass.
- Independent grok-4.6 xhigh review in progress.
- ARM+Intel success on `45656f53` is diagnostic; final three-target must bind the later same SHA.

I05 stays DEFERRED_BY_OWNER / OUT_OF_SCOPE.
Owner-staged files are not in this PR.