### PR TITLE
docs: publish verified 0.5.12 downloads and bilingual release records

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,29 +6,26 @@
 
 DeepSeek Harness, ready to live on a personal computer.
 
-[English](#english) · [中文](#中文) · [Website](https://penglai.pages.dev) · [中文网站](https://penglai.pages.dev/zh/) · [Download 0.5.11](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.11) · [Security](SECURITY.md)
+[English](#english) · [中文](#中文) · [Website](https://penglai.pages.dev) · [中文网站](https://penglai.pages.dev/zh/) · [Download 0.5.12](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12) · [Security](SECURITY.md)
 
-The current public product is **Penglai 0.5.11**, an immutable release built from
-`77e7105773b4d43abb7315ea6e83abe17e646cb4`. It consumes official DeepSeek Harness
-`0.1.2-rc.1` npm packages, reconciled to tag `dsh-v0.1.2-rc.1` at
-`a66e4702047846cdaa10c66c9d3df3951f5ea70d`. All 254 package archives, registry
+The current public product is **Penglai 0.5.12**, an immutable release built from
+`54a0ef30afa4e3d653e400a637d4aa8eb4abbb75`. It consumes official DeepSeek Harness
+`0.1.3-alpha.2` npm packages, reconciled to tag `dsh-v0.1.3-alpha.2` at
+`82a5fd61a7cf5c293cec4bdff68f455398d685e9`. All 263 package archives, registry
 signatures and pinned source manifests were verified. macOS is ad-hoc signed and
 not notarized; Windows has no Authenticode.
-[Release notes](docs/RELEASE_NOTES_0.5.11.md) ·
-[Verified publication](docs/PUBLICATION_MANIFEST_0.5.11.md)
+[Release notes](docs/RELEASE_NOTES_0.5.12.md) ·
+[Verified publication](docs/PUBLICATION_MANIFEST_0.5.12.md)
 
-Published v0.5.10 tags and assets remain immutable. This repository is the
-**0.5.12 source candidate**, not a public release. There is no `v0.5.12`
-installer, SHA-256, or download card yet. Every download link below is published
-0.5.11. Public 0.5.11 ships Mnemon `0.2.4` and was built with Node `22.22.2`.
-This candidate tree pins Mnemon `0.2.8` and Node `22.23.2`; those are source
-facts, not a download claim. Source tests are not live-account evidence.
+Published v0.5.10 and v0.5.11 tags and assets remain immutable. Public 0.5.12
+ships Mnemon `0.2.8` and was built with Node `22.23.2`. Source tests are not
+live-account evidence.
 
 <p align="center">
   <img src="website/shots/0.5.5/plugin-center.png" width="48%" alt="Penglai 0.5.5 Plugin Center in the installed DSH settings">
   <img src="website/shots/0.5.5/memory.png" width="48%" alt="Penglai Memory in the installed DSH settings">
 </p>
-<p align="center"><sub>Installed 0.5.5 screens kept as UI references. They are not 0.5.11 screenshots; native 0.5.11 evidence lives in the publication manifest.</sub></p>
+<p align="center"><sub>Installed 0.5.5 screens kept as UI references. They are not 0.5.12 screenshots; native 0.5.12 evidence lives in the publication manifest.</sub></p>
 
 <a id="english"></a>
 
@@ -55,12 +52,12 @@ You
        → DeepSeek Harness (models, tools, Workspace, Session, conversation)
 ```
 
-Version 0.5.11 keeps that official Session snapshot path and adds isolation,
+Version 0.5.12 keeps that official Session snapshot path and adds isolation,
 recovery, Memory library, official IM question/approval identity, bounded PDF
-inspect, and redacted Plugin Center diagnostics. Upgrades from 0.5.8, 0.5.9 and
-0.5.10 use an isolated rc.1 DSH Home and preserve the previous generation for
-rollback. All three native installers pass credential-free onboarding and plugin
-checks, the three pinned upgrade paths, and default uninstall with user data
+inspect, and redacted Plugin Center diagnostics. Upgrades from 0.5.8, 0.5.9,
+0.5.10 and 0.5.11 use an isolated DSH Home and preserve the previous generation
+for rollback. All three native installers pass credential-free onboarding and plugin
+checks, the four pinned upgrade paths, and default uninstall with user data
 preserved.
 
 ## A day with Penglai
@@ -83,13 +80,13 @@ preserved.
 </p>
 <p align="center"><sub>First-run welcome from the 0.5.5 installed UI reference.</sub></p>
 
-## What ships in 0.5.11
+## What ships in 0.5.12
 
 | Product surface | Fresh install | What it does |
 | --- | --- | --- |
 | Penglai Office | On | Inspect, create, edit, preview, and save DOCX, XLSX, PPTX, and PDF |
 | Penglai Memory | On | Automatic current-Workspace memory, explicit personal memory, authorised sources, provenance, and a knowledge graph |
-| Mobile Messaging | Off | Eight platform connectors under one IM control plane; WhatsApp is not exposed or supported in 0.5.11 |
+| Mobile Messaging | Off | Eight platform connectors under one IM control plane; WhatsApp is not exposed or supported in 0.5.12 |
 | Speech Recognition | Off | Local SenseVoice transcription; enabling it adds the conversation microphone entry |
 | Voice Generation | Off | Local MOSS-TTS-Nano preview, desktop playback, and supported channel audio |
 | Companion | Off | Opt-in scheduled contact with quiet hours, daily limits, and a bound IM route |
@@ -146,7 +143,7 @@ for it. The exact capability matrix and remaining format limits live in
 ## Memory that knows which project it belongs to
 
 Penglai Memory stores and recalls records locally and is enabled by default.
-Mnemon 0.2.4 is its only recall engine. The fresh mode intelligently organizes
+Mnemon 0.2.8 is its only recall engine. The fresh mode intelligently organizes
 safe project facts inside the current official Workspace. A separate no-tools
 official Agent uses the current provider/model after a Turn, so that curation
 request is a model call to the provider rather than an offline-only step. The
@@ -179,7 +176,7 @@ the official DSH image store. Office files and audio use scoped opaque
 `artifact:<uuid>` references. A mocked webhook is never live evidence.
 
 Slack, Telegram, and Discord use official token or manifest flows and do not
-fake QR. QQ is official Bot QR, not personal QQ login. WhatsApp is not a 0.5.11
+fake QR. QQ is official Bot QR, not personal QQ login. WhatsApp is not a 0.5.12
 product surface: it is not displayed, supported, planned, or bundled.
 
 SenseVoice and MOSS-TTS stay off until requested because their model files are
@@ -197,7 +194,7 @@ It verifies the catalog signature, archive identity, SHA-256, DSH compatibility,
 platform, and declared permissions before staging a package. Activation is a
 separate step and failed activation rolls back.
 
-This is why a reviewed DSH `0.1.2-rc.1`-compatible plugin can join later without
+This is why a reviewed DSH `0.1.3-alpha.2`-compatible plugin can join later without
 publishing a new desktop version merely to change a list. The catalog is still
 fail-closed: arbitrary npm names, Git repositories, and download URLs are not
 accepted. A DSH plugin shares the local DSH process permissions; the permission
@@ -221,32 +218,32 @@ silent update. External Workspaces and the `Penglai/0.5` data generation are
 preserved. Default uninstall removes the application and cache while preserving
 user data.
 
-The immutable [0.5.11 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.11)
+The immutable [0.5.12 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12)
 contains exactly ten files: three native installers and seven integrity and
-license files. All installers were built from the same source SHA and passed
-[native installed-product gates](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34151469696)
+license files. All installers were built from the same source SHA `54a0ef30afa4e3d653e400a637d4aa8eb4abbb75` and passed
+[native installed-product gates](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34293608792)
 and public download readback.
 
 ### Apple Silicon, macOS 13+
 
-[`Penglai_0.5.11_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_aarch64.dmg)
+[`Penglai_0.5.12_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_aarch64.dmg)
 
-467,172,406 bytes · SHA-256 `7a59833e32ae7cdcfc6dae6b1c2d744f251cb929cf251d758479c25fca41c536`
+284,207,080 bytes · SHA-256 `1f6d7f9ceab13c62a6e31d52a0517c4972a52378e5ce102bf2983f3c32fd8034`
 
 ### Intel Mac, macOS 13+
 
-[`Penglai_0.5.11_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_x64.dmg)
+[`Penglai_0.5.12_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_x64.dmg)
 
-408,749,431 bytes · SHA-256 `783fcf5c042998d1a550d7c48fe30879d78f996d5602f002dea411826e210798`
+293,808,479 bytes · SHA-256 `f82a5d44bccb7d15def176602f8320d1464eae802897e41c5ec39c8d471d61c3`
 
 ### Windows 10+ x64
 
-[`Penglai_0.5.11_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_windows_x64_setup.exe)
+[`Penglai_0.5.12_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_windows_x64_setup.exe)
 
-357,628,547 bytes · SHA-256 `5862cf0df14daf12ef223d5a825cad501ea56f78a40cdb54bef4fa8b7779c929`
+371,054,561 bytes · SHA-256 `5d926a884ca2b93c43f8ee8d8e8897df636585d449f1810d25ab4bffae3159da`
 
 Check the downloaded installer against `SHA256SUMS` before running it. The
-Beijing mirror has not published 0.5.11; GitHub Releases is the authoritative
+Beijing mirror has not published 0.5.12; GitHub Releases is the authoritative
 public source.
 
 ## Privacy
@@ -279,8 +276,7 @@ No. Official DeepSeek Harness is the only core. Penglai owns install, lifecycle,
 and first-party plugins.
 
 **Which version should I download?**
-The public installers are 0.5.11. Published 0.5.10 remains immutable. There is
-no public 0.5.12 installer yet. This GitHub tree is the 0.5.12 source candidate.
+The public installers are 0.5.12. Published 0.5.10 and 0.5.11 remain immutable.
 
 **Why does Gatekeeper or SmartScreen warn?**
 macOS packages are ad-hoc signed and not notarized. Windows packages do not have
@@ -341,8 +337,7 @@ history because they explain the road here; their runtimes are not mixed into
 
 ## Build, contribute, and AI-assisted work
 
-This 0.5.12 candidate tree uses Node `22.23.2` and pnpm `11.7.0`. Published
-0.5.11 was built with Node `22.22.2` and pnpm `11.7.0`.
+This tree uses Node `22.23.2` and pnpm `11.7.0`.
 
 ```bash
 corepack enable
@@ -415,13 +410,12 @@ Turn 和会话界面都归 DSH。蓬莱负责那些不太耀眼、却决定桌�
        → DeepSeek Harness（模型、工具、Workspace、Session、会话）
 ```
 
-0.5.11 继续使用未经修改的官方 DSH `0.1.2-rc.1` npm 包，并补上隔离、恢复、
-记忆库、官方 IM 提问/审批身份、有界 PDF 检查和脱敏插件诊断。从 0.5.8、0.5.9
-和 0.5.10 升级时使用独立的 rc.1 数据目录，保留旧代际用于回退。三端安装包均
-通过无需真实账号的引导和插件检查、三条升级路径，以及默认保留用户数据的卸载
-验证。本仓库是 **0.5.12 源码候选**，不是公开版本；下载链接仍指向已发布的
-0.5.11。公开的 0.5.11 使用 Mnemon `0.2.4` 与 Node `22.22.2`；当前候选树钉住
-Mnemon `0.2.8` 与 Node `22.23.2`，这是源码事实，不是下载声明。中文网站在
+0.5.12 使用未经修改的官方 DSH `0.1.3-alpha.2` npm 包，并补上隔离、恢复、
+记忆库、官方 IM 提问/审批身份、有界 PDF 检查和脱敏插件诊断。从 0.5.8、0.5.9、
+0.5.10 和 0.5.11 升级时使用独立的数据目录，保留旧代际用于回退。三端安装包均
+通过无需真实账号的引导和插件检查、四条升级路径，以及默认保留用户数据的卸载
+验证。公开的 0.5.12 使用 Mnemon `0.2.8` 与 Node `22.23.2`。已发布的 0.5.10 与
+0.5.11 标签与附件仍不可变。中文网站在
 [penglai.pages.dev/zh](https://penglai.pages.dev/zh/)，英文默认首页在
 [penglai.pages.dev](https://penglai.pages.dev/)。
 
@@ -441,13 +435,13 @@ Mnemon `0.2.8` 与 Node `22.23.2`，这是源码事实，不是下载声明。�
 </p>
 <p align="center"><sub>0.5.5 安装版首次引导欢迎页，作为界面参考。</sub></p>
 
-## 0.5.11 带来了什么
+## 0.5.12 带来了什么
 
 | 产品功能 | 全新安装 | 能做什么 |
 | --- | --- | --- |
 | 蓬莱办公 | 默认启用 | 检查、创建、编辑、预览和保存 DOCX、XLSX、PPTX、PDF |
 | 蓬莱记忆 | 默认启用 | 当前 Workspace 自动记忆、明确个人记忆、授权资料、来源追溯和知识图谱 |
-| 消息连接 | 默认关闭 | 八个平台共用一个 IM 控制平面；0.5.11 不展示或支持 WhatsApp |
+| 消息连接 | 默认关闭 | 八个平台共用一个 IM 控制平面；0.5.12 不展示或支持 WhatsApp |
 | 蓬莱语音识别 | 默认关闭 | 本地 SenseVoice 转写；启用后为电脑会话提供麦克风入口 |
 | 蓬莱语音生成 | 默认关闭 | 本地 MOSS-TTS-Nano 试听、电脑播放和支持渠道的语音输出 |
 | 蓬莱主动陪伴 | 默认关闭 | 安静时段、每日上限、指定 IM 路由下的主动联系 |
@@ -497,7 +491,7 @@ typed operation：检查和创建文件、生成可见修改计划、预览、�
 
 ## 蓬莱记忆知道自己属于哪个项目
 
-蓬莱记忆在本机保存和召回记录，并且默认启用。Mnemon 0.2.4 是唯一召回引擎。全新
+蓬莱记忆在本机保存和召回记录，并且默认启用。Mnemon 0.2.8 是唯一召回引擎。全新
 profile 会智能整理当前 official Workspace 的安全项目事实：Turn 结束后，一个禁用全部
 工具的 official Agent 沿用当前供应商和模型，因此“整理候选”本身会调用模型供应商，
 不是完全离线步骤。Host 再用封闭格式与本地策略过滤密钥、敏感内容、类似提示词注入和
@@ -524,7 +518,7 @@ QQ、Slack、Telegram、Discord。文字和受支持的图片、文件、语音�
 图片走 official 图片存储；文件和音频走 `artifact:<uuid>`。
 
 Slack、Telegram、Discord 走官方 Token/Manifest，禁止伪装扫码。QQ 只做官方
-Bot 扫码，不模拟个人号。WhatsApp 不是 0.5.11 的产品能力：不展示、不支持、不列为
+Bot 扫码，不模拟个人号。WhatsApp 不是 0.5.12 的产品能力：不展示、不支持、不列为
 规划，也不捆绑运行时。
 
 SenseVoice 和 MOSS-TTS 默认关闭，是因为模型文件较大。语音识别启用并下载模型后，
@@ -538,7 +532,7 @@ SenseVoice 和 MOSS-TTS 默认关闭，是因为模型文件较大。语音识�
 读取带版本、不可变的 GitHub Release。安装前会校验目录签名、包身份、SHA-256、DSH
 兼容版本、平台和声明权限。下载与启用是两个阶段，启用失败会回滚。
 
-因此以后审核出一个优秀的 DSH `0.1.2-rc.1` 兼容插件，可以只发布新一代签名目录，不必为了列表变化
+因此以后审核出一个优秀的 DSH `0.1.3-alpha.2` 兼容插件，可以只发布新一代签名目录，不必为了列表变化
 再打一个桌面客户端。它仍然是 fail-closed：任意 npm 包名、Git 仓库或下载地址都
 不会被接受。DSH 插件与本地 DSH 进程共享权限，权限列表用于审核和确认，不是操作
 系统沙箱。
@@ -556,31 +550,31 @@ SenseVoice 和 MOSS-TTS 默认关闭，是因为模型文件较大。语音识�
 升级；外部 Workspace 与 `Penglai/0.5` 数据代际会保留。默认卸载去掉应用和缓存，
 保留用户数据。
 
-不可变的 [0.5.11 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.11)
+不可变的 [0.5.12 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12)
 固定十项附件：三个原生安装包和七项完整性、签名与许可证材料。
-三个安装包来自同一源码提交，并已通过
-[三端原生安装门禁](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34151469696)
+三个安装包来自同一源码提交 `54a0ef30afa4e3d653e400a637d4aa8eb4abbb75`，并已通过
+[三端原生安装门禁](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34293608792)
 和公网下载回读。
 
 ### Apple 芯片，macOS 13+
 
-[`Penglai_0.5.11_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_aarch64.dmg)
+[`Penglai_0.5.12_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_aarch64.dmg)
 
-467,172,406 字节 · SHA-256 `7a59833e32ae7cdcfc6dae6b1c2d744f251cb929cf251d758479c25fca41c536`
+284,207,080 字节 · SHA-256 `1f6d7f9ceab13c62a6e31d52a0517c4972a52378e5ce102bf2983f3c32fd8034`
 
 ### Intel Mac，macOS 13+
 
-[`Penglai_0.5.11_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_x64.dmg)
+[`Penglai_0.5.12_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_x64.dmg)
 
-408,749,431 字节 · SHA-256 `783fcf5c042998d1a550d7c48fe30879d78f996d5602f002dea411826e210798`
+293,808,479 字节 · SHA-256 `f82a5d44bccb7d15def176602f8320d1464eae802897e41c5ec39c8d471d61c3`
 
 ### Windows 10+ x64
 
-[`Penglai_0.5.11_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_windows_x64_setup.exe)
+[`Penglai_0.5.12_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_windows_x64_setup.exe)
 
-357,628,547 字节 · SHA-256 `5862cf0df14daf12ef223d5a825cad501ea56f78a40cdb54bef4fa8b7779c929`
+371,054,561 字节 · SHA-256 `5d926a884ca2b93c43f8ee8d8e8897df636585d449f1810d25ab4bffae3159da`
 
-运行前请用 `SHA256SUMS` 核对下载文件。北京镜像尚未发布 0.5.11；权威公开源是
+运行前请用 `SHA256SUMS` 核对下载文件。北京镜像尚未发布 0.5.12；权威公开源是
 GitHub Release。
 
 ## 隐私
@@ -609,8 +603,7 @@ GitHub Release。
 不是。官方 DeepSeek Harness 是唯一核心。蓬莱负责安装、生命周期和第一方插件。
 
 **现在该下载哪个版本？**
-公开安装包是 0.5.11。已发布的 0.5.10 仍不可变。目前没有公开的 0.5.12 安装包。
-本仓库是 0.5.12 源码候选。
+公开安装包是 0.5.12。已发布的 0.5.10 与 0.5.11 仍不可变。
 
 **为什么 Gatekeeper 或 SmartScreen 会提示？**
 macOS 是 ad-hoc 签名、未公证；Windows 没有 Authenticode。这是已知限制，不是
@@ -656,8 +649,7 @@ macOS 是 ad-hoc 签名、未公证；Windows 没有 Authenticode。这是已知
 
 ## 构建、贡献与 AI 协作
 
-这份 0.5.12 候选树使用 Node `22.23.2` 和 pnpm `11.7.0`。已发布的 0.5.11
-使用 Node `22.22.2` 和 pnpm `11.7.0`。
+这份树使用 Node `22.23.2` 和 pnpm `11.7.0`。
 
 ```bash
 corepack enable

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,18 +1,19 @@
 # Security Policy
 
-Penglai 0.5.11 is a **community-verified** desktop distribution of official DeepSeek Harness (DSH). This file is the public security entry. The full product contract lives in [`docs/SECURITY.md`](docs/SECURITY.md).
+Penglai 0.5.12 is a **community-verified** desktop distribution of official DeepSeek Harness (DSH). This file is the public security entry. The full product contract lives in [`docs/SECURITY.md`](docs/SECURITY.md).
 
 ## Supported versions
 
 | Version | Status |
 | --- | --- |
-| 0.5.11 | Current immutable public release |
-| 0.5.10 | Historical immutable release; native upgrades to 0.5.11 verified on all three targets |
-| 0.5.8 and 0.5.9 | Historical releases; native upgrades to 0.5.11 verified on all three targets |
+| 0.5.12 | Current immutable public release |
+| 0.5.11 | Historical immutable release; native upgrades to 0.5.12 verified on all three targets |
+| 0.5.10 | Historical immutable release; native upgrades to 0.5.12 verified on all three targets |
+| 0.5.8 and 0.5.9 | Historical releases; native upgrades to 0.5.12 verified on all three targets |
 | Earlier 0.5.x | Historical releases; use the documented migration path |
 | 0.4.1 and earlier | Unsupported; 0.5 does not silently import or delete old secrets or databases |
 
-The 0.5.11 release contains all ten files in its release contract, including
+The 0.5.12 release contains all ten files in its release contract, including
 signed update metadata, SHA256SUMS, the three-target SBOM and third-party notices.
 The immutable 0.5.9 release contains only its three installers; its missing
 metadata is a historical publication defect. Do not infer signed updater
@@ -35,7 +36,7 @@ On macOS the credentials directory/file use 0700/0600. On Windows they use a cur
 
 0.4.1 credentials and databases are not read, imported, or deleted.
 
-Official DSH 0.1.2-rc.1 bundles a session-telemetry adapter and a configured DeepSeek
+Official DSH 0.1.3-alpha.2 bundles a session-telemetry adapter and a configured DeepSeek
 OTLP endpoint. Penglai does not operate that backend and does not rely only on
 the adapter's default mode: the owned DSH child receives
 `DSH_TELEMETRY_DISABLED=1` from a closed environment allowlist. DSH applies that
@@ -49,7 +50,7 @@ Adapters cannot call a parallel Agent. `docs/0.5.7/LIVE_IM_MATRIX.md` preserves
 historical account-test requirements; it does not establish current-version live
 results. Current account journeys are claimed only with current evidence. Slack,
 Telegram, and Discord do not fake QR.
-WhatsApp is not displayed, supported, planned, or bundled in 0.5.11.
+WhatsApp is not displayed, supported, planned, or bundled in 0.5.12.
 
 - Weixin: real QR login. The scanner is the only allowed identity unless the user expands the allowlist.
 - Feishu: the official application-registration QR flow is used where available, with manual App ID/Secret setup as a fallback. Penglai does not host the application or invent a login QR.
@@ -80,11 +81,11 @@ Penglai will not claim notarization, Authenticode, App Store trust, silent auto-
 
 ## 中文
 
-当前正式版本为 0.5.11，使用固定的官方 DSH `0.1.2-rc.1` npm 包。
-Apple Silicon、Intel Mac 和 Windows x64 均验证从 0.5.8、0.5.9、0.5.10 升级并在默认
-卸载后保留用户数据。旧版 DSH Home 保留，rc.1 在独立目录通过健康检查后启用。
+当前正式版本为 0.5.12，使用固定的官方 DSH `0.1.3-alpha.2` npm 包。
+Apple Silicon、Intel Mac 和 Windows x64 均验证从 0.5.8、0.5.9、0.5.10、0.5.11 升级并在默认
+卸载后保留用户数据。旧版 DSH Home 保留，新代际在独立目录通过健康检查后启用。
 
-0.5.11 的正式发布包含十项完整附件，包括签名更新清单、校验和、三端 SBOM 与
+0.5.12 的正式发布包含十项完整附件，包括签名更新清单、校验和、三端 SBOM 与
 第三方声明。0.5.9 历史发布只有三个安装包，缺少元数据属于当时的发布缺陷；
 不能据此声称该版签名更新链路完整。原有不可变附件未被修改。
 

--- a/docs/0.5.12/ACCEPTANCE_DELTA.md
+++ b/docs/0.5.12/ACCEPTANCE_DELTA.md
@@ -11,7 +11,16 @@ Final published ruling: **v0.5.11** from source SHA
 recorded from `main` `87f6aec04b2b77d45a5c2b280d1b75332a80eb33`.
 
 Public README/website download tables remain **0.5.11** until immutable
-`v0.5.12` GitHub Release bytes exist and are read back.
+`v0.5.12` GitHub Release bytes exist and are read back. That sentence is a
+development-tree snapshot. Final published ruling: **v0.5.12** from source SHA
+`54a0ef30afa4e3d653e400a637d4aa8eb4abbb75` on 2026-09-09; native
+[34293608792](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34293608792);
+publication
+[34305249020](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34305249020);
+see `docs/PUBLICATION_MANIFEST_0.5.12.md`. Published **v0.5.10** and
+**v0.5.11** tags and assets were not rewritten. I05 packaged PDF page preview
+and bundled Poppler remain **DEFERRED_BY_OWNER / OUT_OF_SCOPE**, not PASS.
+Hosted Windows Defender default-on remains **NOT PROVEN** (`defaultOs=INCOMPLETE`).
 
 ## In scope for this development tree
 

--- a/docs/0.5.12/TODO.md
+++ b/docs/0.5.12/TODO.md
@@ -220,8 +220,22 @@ mock.
 - U01 GitHub: `v0.1.3-alpha.2` released 2026-09-07, short SHA `82a5fd6`;
   `v0.1.3-alpha.1` short SHA `d347e70`. npm graph probe in progress.
 
+## Incremental verification — 2026-09-09 (public v0.5.12)
+
+Public identity is **0.5.12**. Immutable release [`v0.5.12`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12). Build source SHA `54a0ef30afa4e3d653e400a637d4aa8eb4abbb75`. Published v0.5.10 and v0.5.11 were not rewritten.
+
+- V04/V05: three-target native [PASS](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34293608792) including 0.5.8/0.5.9/0.5.10/0.5.11 upgrade and default uninstall.
+- P03: ten-file set assembled; GitHub asset digests match `SHA256SUMS`.
+- P04: publication and public-byte readback [PASS](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34305249020).
+- Signed Plugin Center distribution: catalog-mode native [PASS](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34306423051) against live immutable `plugin-catalog-v1.000006`; no new catalog sequence published.
+- P05: README, `website/`, and SECURITY.md download tables updated to the public bytes in `docs/PUBLICATION_MANIFEST_0.5.12.md`; live origin readback follows merge/deploy.
+- I02: hosted Windows `defaultOs=INCOMPLETE` (runner RTM already off with `C:\`/`D:\` exclusions; Penglai `mutated: false`). Not default-OS Defender-on PASS.
+- I05: DEFERRED_BY_OWNER / OUT_OF_SCOPE, not PASS.
+- V06: LIVE_NOT_RUN. No live model/IM credentials in this isolated profile.
+
 ## 中文
 
-未勾选项均待完成。历史 0.5.11 开发树文档另行快照+终裁，不在本账本当成
-当前未发布状态。公开下载在 v0.5.12 字节回读前仍指向 0.5.11。I05 打包页
-光栅为 DEFERRED_BY_OWNER / OUT_OF_SCOPE，不是 PASS。
+未勾选项均待完成。历史 0.5.11 开发树文档另行快照+终裁。v0.5.12 已按
+`docs/PUBLICATION_MANIFEST_0.5.12.md` 公开发布；已发布的 0.5.10 与 0.5.11
+未被改写。I05 打包页光栅为 DEFERRED_BY_OWNER / OUT_OF_SCOPE，不是 PASS。
+I02 托管 Windows Defender 默认开启仍为 NOT PROVEN。

--- a/docs/PUBLICATION_MANIFEST_0.5.12.md
+++ b/docs/PUBLICATION_MANIFEST_0.5.12.md
@@ -1,0 +1,38 @@
+# PUBLICATION_MANIFEST 0.5.12
+
+Status: `PUBLIC_READBACK_PASS`
+
+All ten immutable assets were downloaded after publication. Their exact sizes, SHA-256 digests, update signature and installer signatures passed verification. The table records observed public bytes; source templates remain `UNFROZEN` and are not substituted for generated release identities.
+
+| Field | Value |
+| --- | --- |
+| Product | `0.5.12` |
+| DSH | official unmodified npm `0.1.3-alpha.2`; tag `dsh-v0.1.3-alpha.2`; commit `82a5fd61a7cf5c293cec4bdff68f455398d685e9` |
+| Upstream cohort | 263 packages with registry archive, signature and fixed-source manifest verification |
+| Build source SHA | `54a0ef30afa4e3d653e400a637d4aa8eb4abbb75` |
+| Public export tree | `6ee3670247e0a75c9b78f80da0449934fa88d50d959b2640fbe6bb57f1559c62` |
+| Release | [`v0.5.12`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12), immutable |
+| Three native targets | [PASS](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34293608792) |
+| Complete publication and public readback | [PASS](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34305249020) |
+| Signed catalog | live [`plugin-catalog-v1.000006`](https://github.com/kevinchennewbee/PenglaiPluginRegistry/releases/tag/plugin-catalog-v1.000006) verified after native publication: [catalog mode PASS](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34306423051) (`verify:live-plugin-catalog`, disabled install, offline recovery). Native run `34293608792` skipped this job because `mode: native`. No new catalog sequence was published; 000006 remains the immutable live catalog. |
+| Update sequence | `8` |
+| Trust | community-verified; macOS ad-hoc, not notarized; Windows no Authenticode |
+
+| Asset | Bytes | SHA-256 |
+| --- | ---: | --- |
+| [`Penglai_0.5.12_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_aarch64.dmg) | 284,207,080 | `1f6d7f9ceab13c62a6e31d52a0517c4972a52378e5ce102bf2983f3c32fd8034` |
+| [`Penglai_0.5.12_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_x64.dmg) | 293,808,479 | `f82a5d44bccb7d15def176602f8320d1464eae802897e41c5ec39c8d471d61c3` |
+| [`Penglai_0.5.12_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_windows_x64_setup.exe) | 371,054,561 | `5d926a884ca2b93c43f8ee8d8e8897df636585d449f1810d25ab4bffae3159da` |
+| [`SBOM.cdx.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/SBOM.cdx.json) | 1,212,321 | `a5865f974c889ace54d6d043c4d4c8417f67e785d75ebd254acb68a31914cc3b` |
+| [`SHA256SUMS`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/SHA256SUMS) | 833 | `d2ee615709f5883219f68cd9d45326975484891a7488e1dbc37461a7b65d1754` |
+| [`THIRD_PARTY_NOTICES.txt`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/THIRD_PARTY_NOTICES.txt) | 186,668 | `5ee7590fdb7a546ad17284caf362ea998abf6d92eb765971287d398ce2196c0c` |
+| [`public-export-manifest.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/public-export-manifest.json) | 293,031 | `3c43880ce2fb35dc38ce628d46fdac9e07d80363c3194bdd55534dc46f878b3f` |
+| [`release-manifest.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/release-manifest.json) | 758 | `6fba9db1b549538cb2ffffb93c441e3cb7af5810f8b6576ed94968a57c1cca44` |
+| [`update-manifest-v1.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/update-manifest-v1.json) | 2,023 | `cb7b8464485f3682bf4b44e51780a47a010d26ce94fb291feb0ac1db330825de` |
+| [`update-manifest-v1.json.sig`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/update-manifest-v1.json.sig) | 64 | `f94452244ec05f22e7f144448e47fc2b26f90658131585c0384cfdd2915dc720` |
+
+Native lifecycle verification covers 0.5.8, 0.5.9, 0.5.10 and 0.5.11 upgrades on each target, with default uninstall preserving user data. Installed resource UI tests and native executable checks retain their separate evidence classes. Packaged PDF page-image preview and bundled Poppler are deferred by Owner / out of scope, not PASS. GitHub-hosted Windows runners observed Defender realtime monitoring already off with broad `C:\` / `D:\` exclusions before Penglai; Penglai did not mutate Defender. That is not default-OS Defender-on proof. Private account delivery and real provider responses are not inferred from credential-free tests. Published `v0.5.10` and `v0.5.11` tags and assets were not rewritten.
+
+## 中文
+
+以上十项附件均已从不可变公开发布下载回读，文件大小、摘要、更新签名及安装器签名通过验证。三端来自同一源码 `54a0ef30afa4e3d653e400a637d4aa8eb4abbb75`，均验证 0.5.8、0.5.9、0.5.10、0.5.11 升级路径与默认卸载数据保留。新增 PDF 页预览与捆绑 Poppler 由 Owner 推迟，不是 PASS。托管 Windows 上的 Defender 默认开启未取证。无凭据测试不代表真实模型回复或私人账号消息送达；系统公证与发布者信誉限制见上表。已发布的 0.5.10 与 0.5.11 标签与附件未被改写。

--- a/docs/RELEASE_NOTES_0.5.12.md
+++ b/docs/RELEASE_NOTES_0.5.12.md
@@ -1,0 +1,29 @@
+# Penglai 0.5.12
+
+Penglai 0.5.12 uses the unmodified official DeepSeek Harness `0.1.3-alpha.2` npm packages, fixed to tag `dsh-v0.1.3-alpha.2` and commit `82a5fd61a7cf5c293cec4bdff68f455398d685e9`. DSH remains the only agent core. Penglai supplies the desktop application, onboarding, local data lifecycle and bundled plugins.
+
+Immutable public bytes: [`v0.5.12`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12). Verified publication: [`docs/PUBLICATION_MANIFEST_0.5.12.md`](PUBLICATION_MANIFEST_0.5.12.md). Published **v0.5.10** and **v0.5.11** tags and assets stay immutable.
+
+## Changes
+
+- Official DSH `0.1.3-alpha.2` full 263-package cohort freeze, with first-party plugin, Remote, IM, Memory, session projection and Home-generation re-verification on that cohort.
+- Native installer class repairs: DMG convert/eject identity, NSIS ExecWait construction, scoped process stop that does not kill `Uninstall.exe` running from INSTDIR, and Finder paper-hall plates behind native DMG icon names.
+- Packaged PDF page-image preview and bundled Poppler are **deferred by Owner / out of scope** for 0.5.12, not PASS. Existing PDF inspect and digest-bound text preview remain.
+- Upgrades from 0.5.8, 0.5.9, 0.5.10 and 0.5.11 on matching native hosts. Default uninstall preserves user data.
+- Publication requires the complete ten-file signed release set. The signed update sequence is 8.
+
+## Downloads and verification
+
+Apple Silicon, Intel Mac and Windows x64 installers were built on matching native hosts from the same clean main commit: `54a0ef30afa4e3d653e400a637d4aa8eb4abbb75`.
+
+[Native build and installed checks](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34293608792) cover installed startup, credential-free onboarding/recovery, bundled plugin modes, the four pinned upgrade paths and default uninstall with user data preserved. [Complete publication and public-byte readback](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34305249020) verified the ten-file set after the draft became public.
+
+Check the downloaded installer against `SHA256SUMS` before running it. Office and Memory start enabled. Messaging, speech recognition, voice generation and Companion start disabled.
+
+## Known boundaries
+
+macOS is ad-hoc signed and **not notarized**. Windows has **no Authenticode signature**. GitHub-hosted Windows runners observed Defender realtime monitoring already off with broad `C:\` / `D:\` exclusions before Penglai; Penglai did not mutate Defender. That is **not** default-OS Defender-on proof. Private account delivery and real provider responses are not inferred from credential-free tests. UOS/LoongArch is not a release target.
+
+## 中文
+
+蓬莱 0.5.12 使用未经修改的官方 DeepSeek Harness `0.1.3-alpha.2`（tag `dsh-v0.1.3-alpha.2`，commit `82a5fd61…`，263 包队列）。DSH 仍是唯一 Agent 核心。三端安装包来自同一干净 main 提交 `54a0ef30afa4e3d653e400a637d4aa8eb4abbb75`，并验证从 0.5.8、0.5.9、0.5.10、0.5.11 升级与默认卸载保留用户数据。新增 PDF 页预览与捆绑 Poppler 由 Owner 推迟，不是 PASS。macOS 为 ad-hoc 签名、未公证；Windows 无 Authenticode。托管 Windows 上的 Defender 默认开启未取证。无凭据测试不代表真实账号送达。已发布的 0.5.10 与 0.5.11 未被改写。

--- a/website/en/index.html
+++ b/website/en/index.html
@@ -4,9 +4,9 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Penglai 0.5.11 | DeepSeek Harness, ready for a personal computer</title>
-  <meta name="description" content="Penglai 0.5.11 is an installable desktop distribution of official DeepSeek Harness 0.1.2-rc.1, with Office, Memory, messaging, and local voice.">
-  <meta property="og:title" content="Penglai 0.5.11">
+  <title>Penglai 0.5.12 | DeepSeek Harness, ready for a personal computer</title>
+  <meta name="description" content="Penglai 0.5.12 is an installable desktop distribution of official DeepSeek Harness 0.1.3-alpha.2, with Office, Memory, messaging, and local voice.">
+  <meta property="og:title" content="Penglai 0.5.12">
   <meta property="og:description" content="DeepSeek Harness, ready to install. Office, Memory, mobile messaging, and local voice in one desktop distribution.">
   <meta name="theme-color" content="#0B1C2C">
   <meta property="og:type" content="website">
@@ -53,11 +53,11 @@
       <img class="hero-art" src="../shots/banner-v1.png" alt="The island of Penglai rising above a sea of clouds">
       <div class="hero-shade"></div>
       <div class="hero-copy">
-        <p class="eyebrow">Penglai 0.5.11 · DeepSeek Harness 0.1.2-rc.1</p>
+        <p class="eyebrow">Penglai 0.5.12 · DeepSeek Harness 0.1.3-alpha.2</p>
         <h1>Not another agent.<br>Official DeepSeek Harness,<br>installed on your computer.</h1>
         <p class="lead">Penglai puts official DeepSeek Harness, Node, Electron, first-run setup, updates, uninstall, and a reviewed set of DSH plugins into one desktop app. You do not need to learn a terminal first, or move daily work into another cloud account.</p>
         <div class="actions">
-          <a class="button primary" href="#download">Download 0.5.11</a>
+          <a class="button primary" href="#download">Download 0.5.12</a>
           <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent">Read the source</a>
         </div>
         <p class="quiet">MIT licensed · Local first · Apple Silicon / Intel Mac / Windows x64</p>
@@ -70,12 +70,12 @@
         <h2>Penglai owns install and boundaries. The conversation still belongs to DeepSeek Harness.</h2>
         <div class="gold-rule" aria-hidden="true"></div>
       </div>
-      <p>Official DeepSeek Harness owns models, tools, approvals, Workspace, Session, Turn, and the conversation interface. Penglai 0.5.11 consumes the exact official <code>0.1.2-rc.1</code> npm packages, tag <code>dsh-v0.1.2-rc.1</code>, commit <code>a66e4702047846cdaa10c66c9d3df3951f5ea70d</code>. Message recovery, budget reconciliation and Companion replay use its Session snapshot API. Upgrades from 0.5.8, 0.5.9 and 0.5.10 prepare a separate data generation and keep the previous one for rollback. All three native installers come from source <code>77e7105773b4d43abb7315ea6e83abe17e646cb4</code>.</p>
+      <p>Official DeepSeek Harness owns models, tools, approvals, Workspace, Session, Turn, and the conversation interface. Penglai 0.5.12 consumes the exact official <code>0.1.3-alpha.2</code> npm packages, tag <code>dsh-v0.1.3-alpha.2</code>, commit <code>82a5fd61a7cf5c293cec4bdff68f455398d685e9</code>. Message recovery, budget reconciliation and Companion replay use its Session snapshot API. Upgrades from 0.5.8, 0.5.9, 0.5.10 and 0.5.11 prepare a separate data generation and keep the previous one for rollback. All three native installers come from source <code>54a0ef30afa4e3d653e400a637d4aa8eb4abbb75</code>.</p>
     </section>
 
     <figure class="feature-shot wide-shot" data-reveal>
       <img src="../shots/0.5.5/plugin-center.png" alt="The real Penglai 0.5.5 Plugin Center running in installed DSH settings">
-      <figcaption>An installed 0.5.5 screen kept as a UI reference. Native installation and public-byte evidence for 0.5.11 is recorded in its publication manifest; these frames are not 0.5.11 screenshots.</figcaption>
+      <figcaption>An installed 0.5.5 screen kept as a UI reference. Native installation and public-byte evidence for 0.5.12 is recorded in its publication manifest; these frames are not 0.5.12 screenshots.</figcaption>
     </figure>
 
     <section class="section" id="inside" data-reveal>
@@ -95,7 +95,7 @@
         <article>
           <span class="state">Opt in</span>
           <h3>Messaging</h3>
-          <p>Weixin, Feishu, DingTalk, WeCom, QQ, Slack, Telegram, and Discord enter one <code>@penglai/im</code> control plane, using each platform's QR, device-registration, or official-token flow. WhatsApp is not displayed, supported, or bundled in 0.5.11.</p>
+          <p>Weixin, Feishu, DingTalk, WeCom, QQ, Slack, Telegram, and Discord enter one <code>@penglai/im</code> control plane, using each platform's QR, device-registration, or official-token flow. WhatsApp is not displayed, supported, or bundled in 0.5.12.</p>
         </article>
         <article>
           <span class="state">Opt in</span>
@@ -110,7 +110,7 @@
         <article>
           <span class="state">Independent updates</span>
           <h3>Signed Plugin Center</h3>
-          <p>The catalog comes from immutable GitHub Releases. A reviewed DSH 0.1.2-rc.1-compatible plugin can join later without shipping a new desktop version merely to change a list. UI state is never proof of installation or health.</p>
+          <p>The catalog comes from immutable GitHub Releases. A reviewed DSH 0.1.3-alpha.2-compatible plugin can join later without shipping a new desktop version merely to change a list. UI state is never proof of installation or health.</p>
         </article>
       </div>
     </section>
@@ -156,7 +156,7 @@
         <ul class="workflow-list">
           <li>You can turn memory off, or review candidates first.</li>
           <li>Authorised folders are indexed without changing the originals.</li>
-          <li>Mnemon 0.2.4 is the only recall engine and is already bundled.</li>
+          <li>Mnemon 0.2.8 is the only recall engine and is already bundled.</li>
         </ul>
       </div>
       <img src="../shots/0.5.5/memory.png" alt="Penglai Memory scope, graph, and correction">
@@ -205,7 +205,7 @@
         </article>
         <article>
           <h3>Which version should I download?</h3>
-          <p>The public installers are 0.5.11. Published 0.5.10 remains an immutable historical release. There is no public 0.5.12 installer yet.</p>
+          <p>The public installers are 0.5.12. Published 0.5.10 and 0.5.11 remain immutable historical releases.</p>
         </article>
         <article>
           <h3>Why does Gatekeeper warn?</h3>
@@ -227,28 +227,28 @@
     </section>
 
     <section class="download section" id="download" data-reveal>
-      <p class="eyebrow">Penglai 0.5.11</p>
+      <p class="eyebrow">Penglai 0.5.12</p>
       <h2>Choose your computer.</h2>
       <div class="download-grid">
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_aarch64.dmg">
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_aarch64.dmg">
           <strong>macOS · Apple Silicon</strong>
-          <span>GitHub · 445.5 MiB · M1 / M2 / M3 / M4 / M5</span>
-          <code>7a59833e32ae7cdcfc6dae6b1c2d744f251cb929cf251d758479c25fca41c536</code>
+          <span>GitHub · 271.0 MiB · M1 / M2 / M3 / M4 / M5</span>
+          <code>1f6d7f9ceab13c62a6e31d52a0517c4972a52378e5ce102bf2983f3c32fd8034</code>
         </a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_x64.dmg">
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_x64.dmg">
           <strong>macOS · Intel</strong>
-          <span>GitHub · 389.8 MiB · x86_64 Mac</span>
-          <code>783fcf5c042998d1a550d7c48fe30879d78f996d5602f002dea411826e210798</code>
+          <span>GitHub · 280.2 MiB · x86_64 Mac</span>
+          <code>f82a5d44bccb7d15def176602f8320d1464eae802897e41c5ec39c8d471d61c3</code>
         </a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_windows_x64_setup.exe">
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_windows_x64_setup.exe">
           <strong>Windows · x64</strong>
-          <span>GitHub · 341.1 MiB · 64-bit installer</span>
-          <code>5862cf0df14daf12ef223d5a825cad501ea56f78a40cdb54bef4fa8b7779c929</code>
+          <span>GitHub · 353.9 MiB · 64-bit installer</span>
+          <code>5d926a884ca2b93c43f8ee8d8e8897df636585d449f1810d25ab4bffae3159da</code>
         </a>
       </div>
-      <p class="note-panel">The current public download is published 0.5.11. Published 0.5.10 remains immutable. There is no public 0.5.12 installer yet; when those immutable bytes exist, these cards will name them. This page is the 0.5.12 website candidate, not a 0.5.12 download. The immutable GitHub Release is the sole authoritative public download source; the Beijing mirror has not published 0.5.11. All three installers come from source <code>77e7105773b4d43abb7315ea6e83abe17e646cb4</code>. Full SHA256SUMS, SBOM, third-party notices, and signed update metadata are on the same page. Updates are never silent.</p>
+      <p class="note-panel">The current public download is published 0.5.12. Published 0.5.10 and 0.5.11 remain immutable. The immutable GitHub Release is the sole authoritative public download source; the Beijing mirror has not published 0.5.12. All three installers come from source <code>54a0ef30afa4e3d653e400a637d4aa8eb4abbb75</code>. Full SHA256SUMS, SBOM, third-party notices, and signed update metadata are on the same page. Updates are never silent.</p>
       <div class="actions centered">
-        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.11">Bilingual release notes</a>
+        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12">Bilingual release notes</a>
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">Security notes</a>
       </div>
     </section>

--- a/website/index.html
+++ b/website/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Penglai 0.5.11 | DeepSeek Harness, ready for a personal computer</title>
-  <meta name="description" content="Penglai 0.5.11 is an installable desktop distribution of official DeepSeek Harness 0.1.2-rc.1, with Office, Memory, messaging, and local voice.">
-  <meta property="og:title" content="Penglai 0.5.11">
+  <title>Penglai 0.5.12 | DeepSeek Harness, ready for a personal computer</title>
+  <meta name="description" content="Penglai 0.5.12 is an installable desktop distribution of official DeepSeek Harness 0.1.3-alpha.2, with Office, Memory, messaging, and local voice.">
+  <meta property="og:title" content="Penglai 0.5.12">
   <meta property="og:description" content="DeepSeek Harness, ready to install. Office, Memory, mobile messaging, and local voice in one desktop distribution.">
   <meta name="theme-color" content="#0B1C2C">
   <meta property="og:type" content="website">
@@ -52,11 +52,11 @@
       <img class="hero-art" src="./shots/banner-v1.png" alt="The island of Penglai rising above a sea of clouds">
       <div class="hero-shade"></div>
       <div class="hero-copy">
-        <p class="eyebrow">Penglai 0.5.11 · DeepSeek Harness 0.1.2-rc.1</p>
+        <p class="eyebrow">Penglai 0.5.12 · DeepSeek Harness 0.1.3-alpha.2</p>
         <h1>Not another agent.<br>Official DeepSeek Harness,<br>installed on your computer.</h1>
         <p class="lead">Penglai puts official DeepSeek Harness, Node, Electron, first-run setup, updates, uninstall, and a reviewed set of DSH plugins into one desktop app. You do not need to learn a terminal first, or move daily work into another cloud account.</p>
         <div class="actions">
-          <a class="button primary" href="#download">Download 0.5.11</a>
+          <a class="button primary" href="#download">Download 0.5.12</a>
           <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent">Read the source</a>
         </div>
         <p class="quiet">MIT licensed · Local first · Apple Silicon / Intel Mac / Windows x64</p>
@@ -69,12 +69,12 @@
         <h2>Penglai owns install and boundaries. The conversation still belongs to DeepSeek Harness.</h2>
         <div class="gold-rule" aria-hidden="true"></div>
       </div>
-      <p>Official DeepSeek Harness owns models, tools, approvals, Workspace, Session, Turn, and the conversation interface. Penglai 0.5.11 consumes the exact official <code>0.1.2-rc.1</code> npm packages, tag <code>dsh-v0.1.2-rc.1</code>, commit <code>a66e4702047846cdaa10c66c9d3df3951f5ea70d</code>. Message recovery, budget reconciliation and Companion replay use its Session snapshot API. Upgrades from 0.5.8, 0.5.9 and 0.5.10 prepare a separate data generation and keep the previous one for rollback. All three native installers come from source <code>77e7105773b4d43abb7315ea6e83abe17e646cb4</code>.</p>
+      <p>Official DeepSeek Harness owns models, tools, approvals, Workspace, Session, Turn, and the conversation interface. Penglai 0.5.12 consumes the exact official <code>0.1.3-alpha.2</code> npm packages, tag <code>dsh-v0.1.3-alpha.2</code>, commit <code>82a5fd61a7cf5c293cec4bdff68f455398d685e9</code>. Message recovery, budget reconciliation and Companion replay use its Session snapshot API. Upgrades from 0.5.8, 0.5.9, 0.5.10 and 0.5.11 prepare a separate data generation and keep the previous one for rollback. All three native installers come from source <code>54a0ef30afa4e3d653e400a637d4aa8eb4abbb75</code>.</p>
     </section>
 
     <figure class="feature-shot wide-shot" data-reveal>
       <img src="./shots/0.5.5/plugin-center.png" alt="The real Penglai 0.5.5 Plugin Center running in installed DSH settings">
-      <figcaption>An installed 0.5.5 screen kept as a UI reference. Native installation and public-byte evidence for 0.5.11 is recorded in its publication manifest; these frames are not 0.5.11 screenshots.</figcaption>
+      <figcaption>An installed 0.5.5 screen kept as a UI reference. Native installation and public-byte evidence for 0.5.12 is recorded in its publication manifest; these frames are not 0.5.12 screenshots.</figcaption>
     </figure>
 
     <section class="section" id="inside" data-reveal>
@@ -94,7 +94,7 @@
         <article>
           <span class="state">Opt in</span>
           <h3>Messaging</h3>
-          <p>Weixin, Feishu, DingTalk, WeCom, QQ, Slack, Telegram, and Discord enter one <code>@penglai/im</code> control plane, using each platform's QR, device-registration, or official-token flow. WhatsApp is not displayed, supported, or bundled in 0.5.11.</p>
+          <p>Weixin, Feishu, DingTalk, WeCom, QQ, Slack, Telegram, and Discord enter one <code>@penglai/im</code> control plane, using each platform's QR, device-registration, or official-token flow. WhatsApp is not displayed, supported, or bundled in 0.5.12.</p>
         </article>
         <article>
           <span class="state">Opt in</span>
@@ -109,7 +109,7 @@
         <article>
           <span class="state">Independent updates</span>
           <h3>Signed Plugin Center</h3>
-          <p>The catalog comes from immutable GitHub Releases. A reviewed DSH 0.1.2-rc.1-compatible plugin can join later without shipping a new desktop version merely to change a list. UI state is never proof of installation or health.</p>
+          <p>The catalog comes from immutable GitHub Releases. A reviewed DSH 0.1.3-alpha.2-compatible plugin can join later without shipping a new desktop version merely to change a list. UI state is never proof of installation or health.</p>
         </article>
       </div>
     </section>
@@ -155,7 +155,7 @@
         <ul class="workflow-list">
           <li>You can turn memory off, or review candidates first.</li>
           <li>Authorised folders are indexed without changing the originals.</li>
-          <li>Mnemon 0.2.4 is the only recall engine and is already bundled.</li>
+          <li>Mnemon 0.2.8 is the only recall engine and is already bundled.</li>
         </ul>
       </div>
       <img src="./shots/0.5.5/memory.png" alt="Penglai Memory scope, graph, and correction">
@@ -204,7 +204,7 @@
         </article>
         <article>
           <h3>Which version should I download?</h3>
-          <p>The public installers are 0.5.11. Published 0.5.10 remains an immutable historical release. There is no public 0.5.12 installer yet.</p>
+          <p>The public installers are 0.5.12. Published 0.5.10 and 0.5.11 remain immutable historical releases.</p>
         </article>
         <article>
           <h3>Why does Gatekeeper warn?</h3>
@@ -226,28 +226,28 @@
     </section>
 
     <section class="download section" id="download" data-reveal>
-      <p class="eyebrow">Penglai 0.5.11</p>
+      <p class="eyebrow">Penglai 0.5.12</p>
       <h2>Choose your computer.</h2>
       <div class="download-grid">
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_aarch64.dmg">
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_aarch64.dmg">
           <strong>macOS · Apple Silicon</strong>
-          <span>GitHub · 445.5 MiB · M1 / M2 / M3 / M4 / M5</span>
-          <code>7a59833e32ae7cdcfc6dae6b1c2d744f251cb929cf251d758479c25fca41c536</code>
+          <span>GitHub · 271.0 MiB · M1 / M2 / M3 / M4 / M5</span>
+          <code>1f6d7f9ceab13c62a6e31d52a0517c4972a52378e5ce102bf2983f3c32fd8034</code>
         </a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_x64.dmg">
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_x64.dmg">
           <strong>macOS · Intel</strong>
-          <span>GitHub · 389.8 MiB · x86_64 Mac</span>
-          <code>783fcf5c042998d1a550d7c48fe30879d78f996d5602f002dea411826e210798</code>
+          <span>GitHub · 280.2 MiB · x86_64 Mac</span>
+          <code>f82a5d44bccb7d15def176602f8320d1464eae802897e41c5ec39c8d471d61c3</code>
         </a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_windows_x64_setup.exe">
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_windows_x64_setup.exe">
           <strong>Windows · x64</strong>
-          <span>GitHub · 341.1 MiB · 64-bit installer</span>
-          <code>5862cf0df14daf12ef223d5a825cad501ea56f78a40cdb54bef4fa8b7779c929</code>
+          <span>GitHub · 353.9 MiB · 64-bit installer</span>
+          <code>5d926a884ca2b93c43f8ee8d8e8897df636585d449f1810d25ab4bffae3159da</code>
         </a>
       </div>
-      <p class="note-panel">The current public download is published 0.5.11. Published 0.5.10 remains immutable. There is no public 0.5.12 installer yet; when those immutable bytes exist, these cards will name them. This page is the 0.5.12 website candidate, not a 0.5.12 download. The immutable GitHub Release is the sole authoritative public download source; the Beijing mirror has not published 0.5.11. All three installers come from source <code>77e7105773b4d43abb7315ea6e83abe17e646cb4</code>. Full SHA256SUMS, SBOM, third-party notices, and signed update metadata are on the same page. Updates are never silent.</p>
+      <p class="note-panel">The current public download is published 0.5.12. Published 0.5.10 and 0.5.11 remain immutable. The immutable GitHub Release is the sole authoritative public download source; the Beijing mirror has not published 0.5.12. All three installers come from source <code>54a0ef30afa4e3d653e400a637d4aa8eb4abbb75</code>. Full SHA256SUMS, SBOM, third-party notices, and signed update metadata are on the same page. Updates are never silent.</p>
       <div class="actions centered">
-        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.11">Bilingual release notes</a>
+        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12">Bilingual release notes</a>
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">Security notes</a>
       </div>
     </section>

--- a/website/zh/index.html
+++ b/website/zh/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>蓬莱 0.5.11 | 把 DeepSeek Harness 装进你的电脑</title>
-  <meta name="description" content="蓬莱 0.5.11 是官方 DeepSeek Harness 0.1.2-rc.1 的桌面发行版：办公、记忆、消息连接与本地语音装在同一个可安装的客户端里。">
-  <meta property="og:title" content="蓬莱 0.5.11">
+  <title>蓬莱 0.5.12 | 把 DeepSeek Harness 装进你的电脑</title>
+  <meta name="description" content="蓬莱 0.5.12 是官方 DeepSeek Harness 0.1.3-alpha.2 的桌面发行版：办公、记忆、消息连接与本地语音装在同一个可安装的客户端里。">
+  <meta property="og:title" content="蓬莱 0.5.12">
   <meta property="og:description" content="DeepSeek Harness，装好就能用。办公、记忆、手机消息和本地语音都在一个桌面发行版里。">
   <meta name="theme-color" content="#0B1C2C">
   <meta property="og:type" content="website">
@@ -52,11 +52,11 @@
       <img class="hero-art" src="../shots/banner-v1.png" alt="云海中的蓬莱仙山，原版产品画">
       <div class="hero-shade"></div>
       <div class="hero-copy">
-        <p class="eyebrow">Penglai 0.5.11 · DeepSeek Harness 0.1.2-rc.1</p>
+        <p class="eyebrow">Penglai 0.5.12 · DeepSeek Harness 0.1.3-alpha.2</p>
         <h1>不是另一个 Agent。<br>官方 DeepSeek Harness，<br>装进你的电脑。</h1>
         <p class="lead">蓬莱把官方 DeepSeek Harness、Node、Electron、首次引导、更新、卸载和一组经过审核的 DSH 插件放进一个桌面客户端。你不用先学终端，也不用把日常交给一个新的云账号。</p>
         <div class="actions">
-          <a class="button primary" href="#download">下载 0.5.11</a>
+          <a class="button primary" href="#download">下载 0.5.12</a>
           <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent">查看源代码</a>
         </div>
         <p class="quiet">MIT 开源 · 本地优先 · Apple Silicon / Intel Mac / Windows x64</p>
@@ -69,12 +69,12 @@
         <h2>蓬莱负责安装与边界，会话仍归 DeepSeek Harness。</h2>
         <div class="gold-rule" aria-hidden="true"></div>
       </div>
-      <p>模型、工具、审批、Workspace、Session、Turn 和会话界面都由官方 DeepSeek Harness 拥有。Penglai 0.5.11 消费精确固定的官方 <code>0.1.2-rc.1</code> npm 包，对应 tag <code>dsh-v0.1.2-rc.1</code>、commit <code>a66e4702047846cdaa10c66c9d3df3951f5ea70d</code>。消息恢复、预算结算和主动陪伴回放走官方 Session 快照。从 0.5.8、0.5.9 和 0.5.10 升级时准备独立数据代际，并保留旧版以便回退。三端安装包来自源码 <code>77e7105773b4d43abb7315ea6e83abe17e646cb4</code>。</p>
+      <p>模型、工具、审批、Workspace、Session、Turn 和会话界面都由官方 DeepSeek Harness 拥有。Penglai 0.5.12 消费精确固定的官方 <code>0.1.3-alpha.2</code> npm 包，对应 tag <code>dsh-v0.1.3-alpha.2</code>、commit <code>82a5fd61a7cf5c293cec4bdff68f455398d685e9</code>。消息恢复、预算结算和主动陪伴回放走官方 Session 快照。从 0.5.8、0.5.9、0.5.10 和 0.5.11 升级时准备独立数据代际，并保留旧版以便回退。三端安装包来自源码 <code>54a0ef30afa4e3d653e400a637d4aa8eb4abbb75</code>。</p>
     </section>
 
     <figure class="feature-shot wide-shot" data-reveal>
       <img src="../shots/0.5.5/plugin-center.png" alt="真实安装的蓬莱 0.5.5 插件中心，运行在官方 DSH 设置里">
-      <figcaption>0.5.5 安装版截图，作为界面参考。0.5.11 的原生安装与公开字节证据记录在发布清单中，这些画面不是 0.5.11 新截图。</figcaption>
+      <figcaption>0.5.5 安装版截图，作为界面参考。0.5.12 的原生安装与公开字节证据记录在发布清单中，这些画面不是 0.5.12 新截图。</figcaption>
     </figure>
 
     <section class="section" id="inside" data-reveal>
@@ -94,7 +94,7 @@
         <article>
           <span class="state">按需启用</span>
           <h3>消息连接</h3>
-          <p>微信、飞书、钉钉、企业微信、QQ、Slack、Telegram 与 Discord 进入同一个 <code>@penglai/im</code>。按平台使用扫码、设备注册或官方 Token。WhatsApp 在 0.5.11 中不展示、不支持，也不捆绑运行时。</p>
+          <p>微信、飞书、钉钉、企业微信、QQ、Slack、Telegram 与 Discord 进入同一个 <code>@penglai/im</code>。按平台使用扫码、设备注册或官方 Token。WhatsApp 在 0.5.12 中不展示、不支持，也不捆绑运行时。</p>
         </article>
         <article>
           <span class="state">按需启用</span>
@@ -109,7 +109,7 @@
         <article>
           <span class="state">独立更新</span>
           <h3>签名插件中心</h3>
-          <p>目录来自不可变 GitHub Release。通过审核、兼容 DSH 0.1.2-rc.1 的插件可以后加入，不必只为改一张列表重发桌面版本。界面状态不等于已安装或健康。</p>
+          <p>目录来自不可变 GitHub Release。通过审核、兼容 DSH 0.1.3-alpha.2 的插件可以后加入，不必只为改一张列表重发桌面版本。界面状态不等于已安装或健康。</p>
         </article>
       </div>
     </section>
@@ -155,7 +155,7 @@
         <ul class="workflow-list">
           <li>可以关闭记忆，或改成先看候选。</li>
           <li>授权文件夹只建派生索引，撤销时不改原文件。</li>
-          <li>Mnemon 0.2.4 是唯一召回引擎，已随包装入。</li>
+          <li>Mnemon 0.2.8 是唯一召回引擎，已随包装入。</li>
         </ul>
       </div>
       <img src="../shots/0.5.5/memory.png" alt="蓬莱记忆的范围、图谱和更正">
@@ -204,7 +204,7 @@
         </article>
         <article>
           <h3>现在该下载哪个版本？</h3>
-          <p>公开安装包是 0.5.11。已发布的 0.5.10 仍是不可变历史版本。没有公开的 0.5.12 安装包。</p>
+          <p>公开安装包是 0.5.12。已发布的 0.5.10 与 0.5.11 仍是不可变历史版本。</p>
         </article>
         <article>
           <h3>为什么 Gatekeeper 会提示？</h3>
@@ -226,28 +226,28 @@
     </section>
 
     <section class="download section" id="download" data-reveal>
-      <p class="eyebrow">Penglai 0.5.11</p>
+      <p class="eyebrow">Penglai 0.5.12</p>
       <h2>选择你的电脑。</h2>
       <div class="download-grid">
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_aarch64.dmg">
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_aarch64.dmg">
           <strong>macOS · Apple 芯片</strong>
-          <span>GitHub · 445.5 MiB · M1 / M2 / M3 / M4 / M5</span>
-          <code>7a59833e32ae7cdcfc6dae6b1c2d744f251cb929cf251d758479c25fca41c536</code>
+          <span>GitHub · 271.0 MiB · M1 / M2 / M3 / M4 / M5</span>
+          <code>1f6d7f9ceab13c62a6e31d52a0517c4972a52378e5ce102bf2983f3c32fd8034</code>
         </a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_macos_x64.dmg">
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_x64.dmg">
           <strong>macOS · Intel</strong>
-          <span>GitHub · 389.8 MiB · x86_64 Mac</span>
-          <code>783fcf5c042998d1a550d7c48fe30879d78f996d5602f002dea411826e210798</code>
+          <span>GitHub · 280.2 MiB · x86_64 Mac</span>
+          <code>f82a5d44bccb7d15def176602f8320d1464eae802897e41c5ec39c8d471d61c3</code>
         </a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.11/Penglai_0.5.11_windows_x64_setup.exe">
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_windows_x64_setup.exe">
           <strong>Windows · x64</strong>
-          <span>GitHub · 341.1 MiB · 64 位安装器</span>
-          <code>5862cf0df14daf12ef223d5a825cad501ea56f78a40cdb54bef4fa8b7779c929</code>
+          <span>GitHub · 353.9 MiB · 64 位安装器</span>
+          <code>5d926a884ca2b93c43f8ee8d8e8897df636585d449f1810d25ab4bffae3159da</code>
         </a>
       </div>
-      <p class="note-panel">当前公开下载是已发布的 0.5.11。已发布的 0.5.10 仍不可变。没有公开的 0.5.12 安装包；等那些不可变字节存在后，这里的卡片才会改写。本页是 0.5.12 的网站候选，不是 0.5.12 下载。只以不可变 GitHub Release 为权威公开下载源；北京镜像尚未发布 0.5.11。三个安装包来自源码 <code>77e7105773b4d43abb7315ea6e83abe17e646cb4</code>。完整 SHA256SUMS、SBOM、第三方声明与签名元数据同页提供；更新不会静默执行。</p>
+      <p class="note-panel">当前公开下载是已发布的 0.5.12。已发布的 0.5.10 与 0.5.11 仍不可变。只以不可变 GitHub Release 为权威公开下载源；北京镜像尚未发布 0.5.12。三个安装包来自源码 <code>54a0ef30afa4e3d653e400a637d4aa8eb4abbb75</code>。完整 SHA256SUMS、SBOM、第三方声明与签名元数据同页提供；更新不会静默执行。</p>
       <div class="actions centered">
-        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.11">中英文发布说明</a>
+        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12">中英文发布说明</a>
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">安全说明</a>
       </div>
     </section>


### PR DESCRIPTION
## Summary
Post-readback publication identity for immutable **v0.5.12**. Build SHA remains `54a0ef30afa4e3d653e400a637d4aa8eb4abbb75`. This is documentation-only; no installer rebuild.

- README, SECURITY, and both official website languages now name public 0.5.12, DSH `0.1.3-alpha.2`, peeled SHA `54a0ef30…`, and the exact ten-asset hashes/sizes.
- Adds `docs/PUBLICATION_MANIFEST_0.5.12.md` and `docs/RELEASE_NOTES_0.5.12.md`.
- Published v0.5.10 and v0.5.11 tags/assets are not rewritten.
- I05 stays DEFERRED_BY_OWNER / OUT_OF_SCOPE. I02 hosted Defender-on stays NOT PROVEN.

## Evidence
- Native: https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34293608792
- Publish: https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34305249020
- Signed catalog verify (mode=catalog): https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34306423051
- Release: https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12

Local `assertWebsitePublication` PASS on these files. After merge, dispatch `Deploy website` for both origins.