### PR TITLE
fix: treat Cloudflare _redirects as routing config in site readback

### DIFF
--- a/packages/release-identity/src/website-publication.test.ts
+++ b/packages/release-identity/src/website-publication.test.ts
@@ -184,6 +184,8 @@ test("website workflow grants write only to the main-gated deployment job", () =
   const readback = readFileSync(join(root, "scripts/readback-website.mjs"), "utf8");
   assert.ok(readback.includes('const origins = ["https://penglai.pages.dev/", "https://kevinchennewbee.github.io/PenglaiAgent/"];'));
   assert.match(readback, /digest\(bytes\) !== file\.sha256/);
+  assert.match(readback, /isCloudflareRoutingConfig/);
+  assert.match(readback, /cloudflare-routing-config/);
   assert.match(readback, /html\.includes\(releaseSha\)/);
   assert.match(readback, /Penglai \$\{version\}/);
   assert.doesNotMatch(readback, /Penglai 0\.5\.10/);

--- a/scripts/readback-website.mjs
+++ b/scripts/readback-website.mjs
@@ -8,6 +8,13 @@ const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const version = JSON.parse(readFileSync(join(root, "release-contract.json"), "utf8")).version;
 
 const origins = ["https://penglai.pages.dev/", "https://kevinchennewbee.github.io/PenglaiAgent/"];
+const cloudflareOrigin = origins[0];
+
+function isCloudflareRoutingConfig(origin, name) {
+  // Cloudflare Pages consumes `_redirects` as routing config and serves HTML at
+  // that URL. GitHub Pages serves the sealed file as a static document.
+  return origin === cloudflareOrigin && name === "_redirects";
+}
 const index = process.argv.indexOf("--directory");
 const directory = resolve(index < 0 ? "website" : process.argv[index + 1]);
 const releaseSha = process.env.RELEASE_SHA;
@@ -42,6 +49,10 @@ try {
       for (const file of pending) {
         if (Date.now() >= deadline) throw new Error("public website verification deadline exceeded");
         const url = new URL(file.name.replace(/(^|\/)index\.html$/, "$1"), origin);
+        if (isCloudflareRoutingConfig(origin, file.name)) {
+          result.files.push({ ...file, size: null, url: url.href, servedAs: "cloudflare-routing-config" });
+          continue;
+        }
         try {
           const response = await fetch(url, { signal: AbortSignal.timeout(20_000), headers: { "Cache-Control": "no-cache" } });
           if (!response.ok) throw new Error(`HTTP ${response.status}`);


### PR DESCRIPTION
## Summary
Deploy website `34307578798` verified public v0.5.12 bytes and pushed gh-pages, then origin compare failed because `https://penglai.pages.dev/_redirects` returns English `index.html`. Cloudflare consumes `_redirects` as routing config; GitHub Pages still serves the sealed file.

This is a class-level origin difference, not a hash exception for one URL. `/zh/` and `/en/` already compare as sealed HTML. GitHub Pages `_redirects` remains exact-byte.

## Evidence
- Live `penglai.pages.dev/_redirects` is `text/html` 0.5.12 index
- Live `kevinchennewbee.github.io/PenglaiAgent/_redirects` matches sealed SHA `36cffa3e…`
- `website-publication` tests 6/6 PASS