### PR TITLE
fix: retry hdiutil create on Resource busy; redact review session paths

### DIFF
--- a/docs/0.5.12/REVIEW_PRODUCTION.md
+++ b/docs/0.5.12/REVIEW_PRODUCTION.md
@@ -516,8 +516,8 @@ I01–I04 已部分落地：卸载先分类残留、不再关 Defender、robocop
 
 ## Reviewer session identity
 
-Quoted from this reviewer session
-`/Users/agent/.grok/sessions/%2FVolumes%2FKevinSSD-in%2Fmacmini%2FPenglaiAgent/01a07fbc-0dd6-76d2-a570-615702d3f8fe/summary.json`:
+Independent grok-4.6 xhigh review. Local session path and host volume layout
+are omitted from the public tree.
 
 - `current_model_id`: `grok-4.6`
 - `reasoning_effort`: `xhigh`

--- a/docs/0.5.12/REVIEW_SESSION_API.md
+++ b/docs/0.5.12/REVIEW_SESSION_API.md
@@ -270,8 +270,8 @@ overlay 仍锁 `0.1.1-rc.2` 哈希，必须随 0.1.3 前端重做。`PINNED_DSH`
 
 ## Reviewer session identity
 
-Quoted from this reviewer session
-`/Users/agent/.grok/sessions/%2FVolumes%2FKevinSSD-in%2Fmacmini%2FPenglaiAgent/01a07fbc-0dd6-76d2-a570-614cad697398/summary.json`:
+Independent grok-4.6 xhigh review. Local session path and host volume layout
+are omitted from the public tree.
 
 - `current_model_id`: `grok-4.6`
 - `reasoning_effort`: `xhigh`

--- a/packages/plugin-center/src/diagnostics-export.test.ts
+++ b/packages/plugin-center/src/diagnostics-export.test.ts
@@ -16,7 +16,7 @@ test("redacted Center diagnostics omit credentials, chat, QR and private paths",
   assert.doesNotMatch(json, /api[_-]?key|sk-|otpauth|\/Users\/|chat body/i);
   assert.throws(
     () => exportRedactedCenterDiagnostics({
-      catalog: [{ id: "@penglai/im", error: "token=sk-live-secret /Users/agent/.penglai" }],
+      catalog: [{ id: "@penglai/im", error: "token=sk-live-secret /Users/example/.penglai" }],
     }),
     /CENTER_DIAGNOSTIC_REDACTION/,
   );

--- a/scripts/build-local-dmg.mjs
+++ b/scripts/build-local-dmg.mjs
@@ -24,9 +24,10 @@ import { inspectPackagedCandidate } from "./lib/packaged-candidate.mjs";
 import { readReleaseIdentityPins } from "./lib/release-pins-source.mjs";
 import {
   detachDmgUntilReleased,
-  hdiutilBusyRetryable,
+  spawnHdiutilWithBusyRetry,
   hdiutilConvertArgs,
   hdiutilCreateArgs,
+  waitSync,
 } from "./lib/hdiutil-image.mjs";
 
 const releasePins = readReleaseIdentityPins();
@@ -39,37 +40,15 @@ function run(command, args, options = {}) {
   execFileSync(command, args, { cwd: ROOT, stdio: "inherit", ...options });
 }
 
-function waitSync(milliseconds) {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
-}
-
 function createDmg(args, dmgPath, { onRetry } = {}) {
-  const attempts = 3;
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    const result = spawnSync("hdiutil", args, {
-      cwd: ROOT,
-      encoding: "utf8",
-    });
-    if (result.stdout) process.stdout.write(result.stdout);
-    if (result.stderr) process.stderr.write(result.stderr);
-    if (result.status === 0) return;
-
-    const diagnostic = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
-    const retryable = hdiutilBusyRetryable(diagnostic);
-    if (!retryable || attempt === attempts) {
-      const detail =
-        result.error?.message ?? `exit ${result.status ?? "unknown"}`;
-      throw new Error(`hdiutil ${args[0]} failed: ${detail}`);
-    }
-
-    onRetry?.();
-    rmSync(dmgPath, { force: true });
-    const delayMs = attempt * 2_000;
-    process.stderr.write(
-      `hdiutil ${args[0]} reported a busy image; retrying ${attempt + 1}/${attempts} after ${delayMs}ms\n`,
-    );
-    waitSync(delayMs);
-  }
+  const result = spawnHdiutilWithBusyRetry(args, {
+    cwd: ROOT,
+    outputPath: dmgPath,
+    onRetry,
+  });
+  if (result.status === 0) return;
+  const detail = result.error?.message ?? `exit ${result.status ?? "unknown"}`;
+  throw new Error(`hdiutil ${args[0]} failed: ${detail}`);
 }
 
 function layoutDmgWindow(mountPoint) {

--- a/scripts/lib/hdiutil-image.mjs
+++ b/scripts/lib/hdiutil-image.mjs
@@ -1,7 +1,7 @@
 /** argv builders for hdiutil create/convert. Convert must use -o and one image. */
 
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 
 export function hdiutilBusyRetryable(diagnostic) {
   return /resource busy|resource temporarily unavailable|couldn't eject|资源暂时不可用|无法推出/i.test(
@@ -31,6 +31,45 @@ function hdiutilInfoText() {
   if (result.stdout) process.stdout.write(result.stdout);
   if (result.stderr) process.stderr.write(result.stderr);
   return `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+}
+
+export function waitSync(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+/**
+ * hdiutil create/convert/attach can fail with Resource busy on GitHub
+ * macos-15 while Disk Arbitration holds a previous image. Production DMG
+ * packing already retries; live unit tests must use the same class.
+ */
+export function spawnHdiutilWithBusyRetry(
+  args,
+  { attempts = 3, cwd, onRetry, outputPath } = {},
+) {
+  if (!Array.isArray(args) || typeof args[0] !== "string" || args[0].length === 0) {
+    throw new Error("hdiutil argv must start with a verb");
+  }
+  let last;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    last = spawnSync("hdiutil", args, { encoding: "utf8", ...(cwd ? { cwd } : {}) });
+    if (last.stdout) process.stdout.write(last.stdout);
+    if (last.stderr) process.stderr.write(last.stderr);
+    if (last.status === 0) return last;
+    const diagnostic = `${last.stdout ?? ""}\n${last.stderr ?? ""}\n${last.error?.message ?? ""}`;
+    if (!hdiutilBusyRetryable(diagnostic) || attempt === attempts) {
+      return last;
+    }
+    onRetry?.({ attempt, diagnostic });
+    if (typeof outputPath === "string" && outputPath.length > 0) {
+      rmSync(outputPath, { force: true });
+    }
+    const delayMs = attempt * 2_000;
+    process.stderr.write(
+      `hdiutil ${args[0]} reported a busy image; retrying ${attempt + 1}/${attempts} after ${delayMs}ms\n`,
+    );
+    waitSync(delayMs);
+  }
+  return last;
 }
 
 export function detachDmgUntilReleased({ mount, image, attempts = 8, waitMs = 1_000 } = {}) {

--- a/scripts/lib/hdiutil-image.test.mjs
+++ b/scripts/lib/hdiutil-image.test.mjs
@@ -12,6 +12,7 @@ import {
   hdiutilBusyRetryable,
   hdiutilConvertArgs,
   hdiutilCreateArgs,
+  spawnHdiutilWithBusyRetry,
 } from "./hdiutil-image.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "../..");
@@ -71,6 +72,7 @@ test("convert retries when the UDRW is still attached", () => {
     hdiutilBusyRetryable("hdiutil: convert failed - Resource temporarily unavailable"),
     true,
   );
+  assert.equal(hdiutilBusyRetryable("hdiutil: create failed - Resource busy"), true);
   assert.equal(hdiutilBusyRetryable('hdiutil: couldn\'t eject "disk5" - Resource busy'), true);
   assert.equal(hdiutilBusyRetryable("hdiutil: convert failed - 资源暂时不可用"), true);
   assert.equal(hdiutilBusyRetryable("only a single input file can be specified"), false);
@@ -88,9 +90,13 @@ test("convert retries when the UDRW is still attached", () => {
   assert.deepEqual(disksAttachedToImage(info, "/tmp/other.dmg"), []);
   const dmg = readFileSync(join(root, "scripts/build-local-dmg.mjs"), "utf8");
   assert.match(dmg, /detachDmgUntilReleased/);
-  assert.match(dmg, /hdiutilBusyRetryable/);
+  assert.match(dmg, /spawnHdiutilWithBusyRetry/);
   assert.match(dmg, /onRetry/);
+  assert.match(dmg, /waitSync/);
   assert.doesNotMatch(dmg, /detach", image, "-force"/);
+  const helper = readFileSync(join(root, "scripts/lib/hdiutil-image.mjs"), "utf8");
+  assert.match(helper, /hdiutilBusyRetryable\(diagnostic\)/);
+  assert.match(helper, /spawnHdiutilWithBusyRetry/);
 });
 
 test("build-local-dmg uses the convert builder instead of a second positional path", () => {
@@ -113,26 +119,24 @@ test("hdiutil convert -o is the native class that failed without -o", {
   skip: process.platform !== "darwin" ? "hdiutil is macOS-only" : false,
 }, () => {
   const dir = mkdtempSync(join(tmpdir(), "penglai-hdiutil-"));
+  const volumeName = `PenglaiConvertTest-${process.pid}`;
   try {
     const src = join(dir, "src");
     mkdirSync(src);
     writeFileSync(join(src, "hello.txt"), "penglai");
     const rw = join(dir, "rw.dmg");
     const out = join(dir, "out.dmg");
-    const created = spawnSync(
-      "hdiutil",
+    const created = spawnHdiutilWithBusyRetry(
       hdiutilCreateArgs({
-        volumeName: "PenglaiConvertTest",
+        volumeName,
         sourceFolder: src,
         format: "UDRW",
         output: rw,
       }),
-      { encoding: "utf8" },
+      { outputPath: rw },
     );
     assert.equal(created.status, 0, created.stderr);
-    const attached = spawnSync("hdiutil", ["attach", rw, "-readwrite", "-noverify", "-nobrowse"], {
-      encoding: "utf8",
-    });
+    const attached = spawnHdiutilWithBusyRetry(["attach", rw, "-readwrite", "-noverify", "-nobrowse"]);
     assert.equal(attached.status, 0, attached.stderr);
     detachDmgUntilReleased({ image: rw });
     assert.equal(disksAttachedToImage(spawnSync("hdiutil", ["info"], { encoding: "utf8" }).stdout, rw).length, 0);
@@ -152,21 +156,25 @@ test("hdiutil convert -o is the native class that failed without -o", {
       `${bad.stderr ?? ""}\n${bad.stdout ?? ""}`,
       /only a single input file can be specified/,
     );
-    const ok = spawnSync(
-      "hdiutil",
+    const ok = spawnHdiutilWithBusyRetry(
       hdiutilConvertArgs({
         image: rw,
         output: out,
         format: "UDZO",
         imageKey: "zlib-level=9",
       }),
-      { encoding: "utf8" },
+      { outputPath: out, onRetry: () => detachDmgUntilReleased({ image: rw }) },
     );
     assert.equal(ok.status, 0, ok.stderr);
     assert.equal(existsSync(out), true);
-    const verify = spawnSync("hdiutil", ["verify", out], { encoding: "utf8" });
+    const verify = spawnHdiutilWithBusyRetry(["verify", out]);
     assert.equal(verify.status, 0, verify.stderr);
   } finally {
+    try {
+      detachDmgUntilReleased({ image: join(dir, "rw.dmg") });
+    } catch {
+      /* best-effort release before tmpdir removal */
+    }
     rmSync(dir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Why

Main Source CI [34309173854](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34309173854) failed `verify:clean-clone` `test:unit` on `65c3b4e1`. The live `hdiutil create` in `scripts/lib/hdiutil-image.test.mjs` returned `Resource busy` with no retry. Production `build-local-dmg.mjs` already retried create/convert on that class.

GitHub-tracked 0.5.12 review notes also quoted local `.grok` session paths and the Owner volume layout.

## What

- Shared `spawnHdiutilWithBusyRetry` for create/convert/attach/verify. Broken convert without `-o` stays a direct spawn and must still fail with `only a single input file can be specified`.
- Finder layout retry still uses imported `waitSync`.
- Review docs keep model identity only. Diagnostics fixture uses `/Users/example`.

Independent grok-4.6 xhigh review: REQUEST_CHANGES on missing `waitSync` import, then APPROVE after the import + `waitSync` source pin.

Does not rewrite v0.5.12 / v0.5.11 / v0.5.10 assets. Does not claim I02 Defender-on.

## Tests

`node --import tsx --test scripts/lib/hdiutil-image.test.mjs` 4 pass
`node --import tsx --test packages/plugin-center/src/diagnostics-export.test.ts` 1 pass