### PR TITLE
fix: ship DSH home skip in the packaged bundle and skip before lstat

### DIFF
--- a/packages/runtime/src/dsh-home-upgrade.test.ts
+++ b/packages/runtime/src/dsh-home-upgrade.test.ts
@@ -1318,4 +1318,118 @@ test("activation of a lived-in 0.5.12 copy still requires Office and Memory", (c
   assert.equal(readActiveDshHome(root)?.activeVersion, DSH_HOME_ALPHA13_VERSION);
 });
 
+const PM_RUNTIME_LINKS = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../testdata/pm-old-profile-runtime-links.json",
+);
+
+test("collectHistoricalSessionLogs skips managed runtime trees before lstat", () => {
+  const src = readFileSync(new URL("./dsh-home-upgrade.ts", import.meta.url), "utf8");
+  const collect = src.slice(
+    src.indexOf("function collectHistoricalSessionLogs"),
+    src.indexOf("function assertHistoricalSessionLogsCopied"),
+  );
+  assert.match(collect, /isManagedProfileRuntimeTree/);
+  assert.ok(
+    collect.indexOf("isManagedProfileRuntimeTree") < collect.indexOf("isSymbolicLink"),
+    "session-log walk must skip regenerated runtime trees before lstat",
+  );
+});
+
+test("bundle-desktop rebuilds runtime dist before packing the DSH home skip", () => {
+  const src = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../../../scripts/bundle-desktop.mjs"),
+    "utf8",
+  );
+  assert.match(src, /tsc.*-b/);
+  assert.match(src, /dsh-module-fallback/);
+  assert.match(src, /startsWith\("profiles\/node_modules\/"\)/);
+});
+
+test("PM 498-link 0.1.3-alpha.2 descriptor copies through Home without SECURITY_POLICY", (context) => {
+  if (process.platform === "win32") {
+    context.skip("ordinary Windows users cannot create this symlink fixture");
+    return;
+  }
+  const descriptor = JSON.parse(readFileSync(PM_RUNTIME_LINKS, "utf8")) as {
+    links: Array<{ path: string; target: string }>;
+  };
+  assert.equal(descriptor.links.length, 498);
+  assert.equal(
+    descriptor.links.filter((row) => row.path === "profiles/web/node_modules/@deepseek-ai").length,
+    1,
+  );
+  assert.equal(
+    descriptor.links.filter((row) => row.path.startsWith("profiles/node_modules/")).length,
+    497,
+  );
+
+  const appRuntime = mkdtempSync(join(tmpdir(), "penglai-packaged-app-root-"));
+  const appRoot = join(appRuntime, "Penglai.app");
+  mkdirSync(join(appRoot, "Contents", "Resources", "runtime", "dsh", "node_modules"), { recursive: true });
+  const root = mkdtempSync(join(tmpdir(), "penglai-dsh-home-498-"));
+  const previousHome = join(root, "dsh-homes", `dsh-v${DSH_HOME_ALPHA13_VERSION}`);
+  mkdirSync(join(previousHome, "storages", "sessions"), { recursive: true, mode: 0o700 });
+  mkdirSync(join(previousHome, "profiles", "web"), { recursive: true, mode: 0o700 });
+  writeFileSync(join(previousHome, "settings.yaml"), "locale:\n  preference: zh\n", { mode: 0o600 });
+  writeFileSync(join(previousHome, ".credentials.yaml"), FIXTURE_CREDENTIAL, { mode: 0o600 });
+  writeFileSync(
+    join(previousHome, "storages", "sessions", "session.jsonl"),
+    legalSessionJsonl("pm-498"),
+    { mode: 0o600 },
+  );
+  writeFileSync(
+    join(previousHome, "profiles", "web", "package.json"),
+    JSON.stringify({ name: "web", private: true }),
+    { mode: 0o600 },
+  );
+  const activatedAt = "2026-09-07T00:00:00.000Z";
+  const targetDigest = "c".repeat(64);
+  writeFileSync(
+    join(previousHome, ".penglai-dsh-home.json"),
+    JSON.stringify({
+      schema: 1,
+      kind: "fresh",
+      dshVersion: DSH_HOME_ALPHA13_VERSION,
+      state: "active",
+      preparedAt: activatedAt,
+      activatedAt,
+      targetDigest,
+    }),
+  );
+  writeFileSync(
+    join(root, "dsh-home-active.json"),
+    JSON.stringify({
+      schema: 1,
+      activeVersion: DSH_HOME_ALPHA13_VERSION,
+      homeRelative: `dsh-homes/dsh-v${DSH_HOME_ALPHA13_VERSION}`,
+      activationKind: "fresh",
+      activatedAt,
+      targetDigest,
+    }),
+  );
+  for (const row of descriptor.links) {
+    const linkPath = join(previousHome, row.path);
+    mkdirSync(dirname(linkPath), { recursive: true, mode: 0o700 });
+    symlinkSync(row.target.replaceAll("${APP_ROOT}", appRoot), linkPath);
+  }
+
+  const plan = prepareDshHomeForBoot({
+    userRoot: root,
+    reserveBytes: 0,
+    availableBytes: 1024 * 1024 * 1024,
+  });
+  assert.equal(plan.kind, "migration-prepared");
+  assert.equal(existsSync(join(plan.dshHome, "settings.yaml")), true);
+  assert.equal(readFileSync(join(plan.dshHome, ".credentials.yaml"), "utf8"), FIXTURE_CREDENTIAL);
+  assert.equal(
+    readFileSync(join(plan.dshHome, "storages", "sessions", "session.jsonl"), "utf8"),
+    legalSessionJsonl("pm-498"),
+  );
+  assert.equal(existsSync(join(plan.dshHome, "profiles", "node_modules")), false);
+  assert.equal(existsSync(join(plan.dshHome, "profiles", "web", "node_modules")), false);
+  assert.equal(existsSync(join(root, "dsh-home-migrations", `${plan.operationId}.json`)), true);
+});
+
+
 

--- a/packages/runtime/src/dsh-home-upgrade.ts
+++ b/packages/runtime/src/dsh-home-upgrade.ts
@@ -499,6 +499,8 @@ function collectHistoricalSessionLogs(root: string): string[] {
       current === canonicalRoot
         ? ""
         : relative(canonicalRoot, current).replaceAll("\\", "/");
+    // Skip before lstat so regenerated installation links are not copied.
+    if (isManagedProfileRuntimeTree(currentRelative)) continue;
     const stat = lstatSync(current);
     if (stat.isSymbolicLink()) {
       throw new PenglaiError(
@@ -511,7 +513,6 @@ function collectHistoricalSessionLogs(root: string): string[] {
       continue;
     }
     if (!stat.isDirectory()) continue;
-    if (isManagedProfileRuntimeTree(currentRelative)) continue;
     if (!inside(canonicalRoot, realpathSync(current))) {
       throw new PenglaiError(
         "SECURITY_POLICY",

--- a/packages/runtime/testdata/pm-old-profile-runtime-links.json
+++ b/packages/runtime/testdata/pm-old-profile-runtime-links.json
@@ -1,0 +1,1998 @@
+{
+  "kind": "symlink metadata only; no file contents or credentials",
+  "fromDsh": "0.1.3-alpha.2",
+  "links": [
+    {
+      "path": "profiles/web/node_modules/@deepseek-ai",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai"
+    },
+    {
+      "path": "profiles/node_modules/pkce-challenge",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/pkce-challenge"
+    },
+    {
+      "path": "profiles/node_modules/is-docker",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/is-docker"
+    },
+    {
+      "path": "profiles/node_modules/jws",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/jws"
+    },
+    {
+      "path": "profiles/node_modules/is-inside-container",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/is-inside-container"
+    },
+    {
+      "path": "profiles/node_modules/json-schema-to-ts",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/json-schema-to-ts"
+    },
+    {
+      "path": "profiles/node_modules/zod",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/zod"
+    },
+    {
+      "path": "profiles/node_modules/on-headers",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/on-headers"
+    },
+    {
+      "path": "profiles/node_modules/formdata-polyfill",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/formdata-polyfill"
+    },
+    {
+      "path": "profiles/node_modules/shebang-regex",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/shebang-regex"
+    },
+    {
+      "path": "profiles/node_modules/eventsource",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/eventsource"
+    },
+    {
+      "path": "profiles/node_modules/jwa",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/jwa"
+    },
+    {
+      "path": "profiles/node_modules/web-streams-polyfill",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/web-streams-polyfill"
+    },
+    {
+      "path": "profiles/node_modules/is-wsl",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/is-wsl"
+    },
+    {
+      "path": "profiles/node_modules/toidentifier",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/toidentifier"
+    },
+    {
+      "path": "profiles/node_modules/extend",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/extend"
+    },
+    {
+      "path": "profiles/node_modules/content-type",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/content-type"
+    },
+    {
+      "path": "profiles/node_modules/eventsource-parser",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/eventsource-parser"
+    },
+    {
+      "path": "profiles/node_modules/loose-envify",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/loose-envify"
+    },
+    {
+      "path": "profiles/node_modules/es-errors",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/es-errors"
+    },
+    {
+      "path": "profiles/node_modules/node-domexception",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/node-domexception"
+    },
+    {
+      "path": "profiles/node_modules/agent-base",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/agent-base"
+    },
+    {
+      "path": "profiles/node_modules/bundle-name",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/bundle-name"
+    },
+    {
+      "path": "profiles/node_modules/node-addon-api",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/node-addon-api"
+    },
+    {
+      "path": "profiles/node_modules/ms",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/ms"
+    },
+    {
+      "path": "profiles/node_modules/content-disposition",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/content-disposition"
+    },
+    {
+      "path": "profiles/node_modules/math-intrinsics",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/math-intrinsics"
+    },
+    {
+      "path": "profiles/node_modules/lexical",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/lexical"
+    },
+    {
+      "path": "profiles/node_modules/use-sync-external-store",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/use-sync-external-store"
+    },
+    {
+      "path": "profiles/node_modules/node-pty",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/node-pty"
+    },
+    {
+      "path": "profiles/node_modules/commander",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/commander"
+    },
+    {
+      "path": "profiles/node_modules/proxy-addr",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/proxy-addr"
+    },
+    {
+      "path": "profiles/node_modules/depd",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/depd"
+    },
+    {
+      "path": "profiles/node_modules/node-fetch",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/node-fetch"
+    },
+    {
+      "path": "profiles/node_modules/ip-address",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/ip-address"
+    },
+    {
+      "path": "profiles/node_modules/range-parser",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/range-parser"
+    },
+    {
+      "path": "profiles/node_modules/side-channel-list",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/side-channel-list"
+    },
+    {
+      "path": "profiles/node_modules/detect-libc",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/detect-libc"
+    },
+    {
+      "path": "profiles/node_modules/bytes",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/bytes"
+    },
+    {
+      "path": "profiles/node_modules/retry",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/retry"
+    },
+    {
+      "path": "profiles/node_modules/call-bind-apply-helpers",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/call-bind-apply-helpers"
+    },
+    {
+      "path": "profiles/node_modules/define-lazy-prop",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/define-lazy-prop"
+    },
+    {
+      "path": "profiles/node_modules/base64-js",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/base64-js"
+    },
+    {
+      "path": "profiles/node_modules/typebox",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/typebox"
+    },
+    {
+      "path": "profiles/node_modules/express",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/express"
+    },
+    {
+      "path": "profiles/node_modules/encodeurl",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/encodeurl"
+    },
+    {
+      "path": "profiles/node_modules/once",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/once"
+    },
+    {
+      "path": "profiles/node_modules/gaxios",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/gaxios"
+    },
+    {
+      "path": "profiles/node_modules/merge-descriptors",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/merge-descriptors"
+    },
+    {
+      "path": "profiles/node_modules/tslib",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/tslib"
+    },
+    {
+      "path": "profiles/node_modules/ajv-formats",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/ajv-formats"
+    },
+    {
+      "path": "profiles/node_modules/argparse",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/argparse"
+    },
+    {
+      "path": "profiles/node_modules/picomatch",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/picomatch"
+    },
+    {
+      "path": "profiles/node_modules/safe-buffer",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/safe-buffer"
+    },
+    {
+      "path": "profiles/node_modules/function-bind",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/function-bind"
+    },
+    {
+      "path": "profiles/node_modules/ee-first",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/ee-first"
+    },
+    {
+      "path": "profiles/node_modules/inherits",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/inherits"
+    },
+    {
+      "path": "profiles/node_modules/json-bigint",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/json-bigint"
+    },
+    {
+      "path": "profiles/node_modules/turndown",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/turndown"
+    },
+    {
+      "path": "profiles/node_modules/iconv-lite",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/iconv-lite"
+    },
+    {
+      "path": "profiles/node_modules/es-define-property",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/es-define-property"
+    },
+    {
+      "path": "profiles/node_modules/chokidar",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/chokidar"
+    },
+    {
+      "path": "profiles/node_modules/fresh",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/fresh"
+    },
+    {
+      "path": "profiles/node_modules/undici",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/undici"
+    },
+    {
+      "path": "profiles/node_modules/get-intrinsic",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/get-intrinsic"
+    },
+    {
+      "path": "profiles/node_modules/zod-to-json-schema",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/zod-to-json-schema"
+    },
+    {
+      "path": "profiles/node_modules/qs",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/qs"
+    },
+    {
+      "path": "profiles/node_modules/js-yaml",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/js-yaml"
+    },
+    {
+      "path": "profiles/node_modules/call-bound",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/call-bound"
+    },
+    {
+      "path": "profiles/node_modules/scheduler",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/scheduler"
+    },
+    {
+      "path": "profiles/node_modules/p-retry",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/p-retry"
+    },
+    {
+      "path": "profiles/node_modules/is-in-ssh",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/is-in-ssh"
+    },
+    {
+      "path": "profiles/node_modules/dunder-proto",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/dunder-proto"
+    },
+    {
+      "path": "profiles/node_modules/path-to-regexp",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/path-to-regexp"
+    },
+    {
+      "path": "profiles/node_modules/hasown",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/hasown"
+    },
+    {
+      "path": "profiles/node_modules/safer-buffer",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/safer-buffer"
+    },
+    {
+      "path": "profiles/node_modules/side-channel-weakmap",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/side-channel-weakmap"
+    },
+    {
+      "path": "profiles/node_modules/is-promise",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/is-promise"
+    },
+    {
+      "path": "profiles/node_modules/diff",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/diff"
+    },
+    {
+      "path": "profiles/node_modules/mime-types",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/mime-types"
+    },
+    {
+      "path": "profiles/node_modules/bignumber.js",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/bignumber.js"
+    },
+    {
+      "path": "profiles/node_modules/undici-types",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/undici-types"
+    },
+    {
+      "path": "profiles/node_modules/wsl-utils",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/wsl-utils"
+    },
+    {
+      "path": "profiles/node_modules/json-schema-traverse",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/json-schema-traverse"
+    },
+    {
+      "path": "profiles/node_modules/type-is",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/type-is"
+    },
+    {
+      "path": "profiles/node_modules/jose",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/jose"
+    },
+    {
+      "path": "profiles/node_modules/vary",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/vary"
+    },
+    {
+      "path": "profiles/node_modules/path-key",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/path-key"
+    },
+    {
+      "path": "profiles/node_modules/readdirp",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/readdirp"
+    },
+    {
+      "path": "profiles/node_modules/unpipe",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/unpipe"
+    },
+    {
+      "path": "profiles/node_modules/standardwebhooks",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/standardwebhooks"
+    },
+    {
+      "path": "profiles/node_modules/react-dom",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/react-dom"
+    },
+    {
+      "path": "profiles/node_modules/google-auth-library",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/google-auth-library"
+    },
+    {
+      "path": "profiles/node_modules/json-schema-typed",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/json-schema-typed"
+    },
+    {
+      "path": "profiles/node_modules/has-symbols",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/has-symbols"
+    },
+    {
+      "path": "profiles/node_modules/powershell-utils",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/powershell-utils"
+    },
+    {
+      "path": "profiles/node_modules/clsx",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/clsx"
+    },
+    {
+      "path": "profiles/node_modules/koffi",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/koffi"
+    },
+    {
+      "path": "profiles/node_modules/picocolors",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/picocolors"
+    },
+    {
+      "path": "profiles/node_modules/long",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/long"
+    },
+    {
+      "path": "profiles/node_modules/default-browser-id",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/default-browser-id"
+    },
+    {
+      "path": "profiles/node_modules/raw-body",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/raw-body"
+    },
+    {
+      "path": "profiles/node_modules/semver",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/semver"
+    },
+    {
+      "path": "profiles/node_modules/hono",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/hono"
+    },
+    {
+      "path": "profiles/node_modules/http-errors",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/http-errors"
+    },
+    {
+      "path": "profiles/node_modules/ecdsa-sig-formatter",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/ecdsa-sig-formatter"
+    },
+    {
+      "path": "profiles/node_modules/accepts",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/accepts"
+    },
+    {
+      "path": "profiles/node_modules/fast-uri",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/fast-uri"
+    },
+    {
+      "path": "profiles/node_modules/cookie-signature",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/cookie-signature"
+    },
+    {
+      "path": "profiles/node_modules/forwarded",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/forwarded"
+    },
+    {
+      "path": "profiles/node_modules/js-tokens",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/js-tokens"
+    },
+    {
+      "path": "profiles/node_modules/negotiator",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/negotiator"
+    },
+    {
+      "path": "profiles/node_modules/body-parser",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/body-parser"
+    },
+    {
+      "path": "profiles/node_modules/gcp-metadata",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/gcp-metadata"
+    },
+    {
+      "path": "profiles/node_modules/resolve.exports",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/resolve.exports"
+    },
+    {
+      "path": "profiles/node_modules/express-rate-limit",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/express-rate-limit"
+    },
+    {
+      "path": "profiles/node_modules/side-channel",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/side-channel"
+    },
+    {
+      "path": "profiles/node_modules/compression",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/compression"
+    },
+    {
+      "path": "profiles/node_modules/protobufjs",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/protobufjs"
+    },
+    {
+      "path": "profiles/node_modules/ts-algebra",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/ts-algebra"
+    },
+    {
+      "path": "profiles/node_modules/node-addon-require-builtin",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/node-addon-require-builtin"
+    },
+    {
+      "path": "profiles/node_modules/cors",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/cors"
+    },
+    {
+      "path": "profiles/node_modules/serve-static",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/serve-static"
+    },
+    {
+      "path": "profiles/node_modules/buffer-equal-constant-time",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/buffer-equal-constant-time"
+    },
+    {
+      "path": "profiles/node_modules/object-assign",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/object-assign"
+    },
+    {
+      "path": "profiles/node_modules/get-proto",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/get-proto"
+    },
+    {
+      "path": "profiles/node_modules/yaml",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/yaml"
+    },
+    {
+      "path": "profiles/node_modules/cross-spawn",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/cross-spawn"
+    },
+    {
+      "path": "profiles/node_modules/ipaddr.js",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/ipaddr.js"
+    },
+    {
+      "path": "profiles/node_modules/cookie",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/cookie"
+    },
+    {
+      "path": "profiles/node_modules/default-browser",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/default-browser"
+    },
+    {
+      "path": "profiles/node_modules/partial-json",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/partial-json"
+    },
+    {
+      "path": "profiles/node_modules/gopd",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/gopd"
+    },
+    {
+      "path": "profiles/node_modules/escape-html",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/escape-html"
+    },
+    {
+      "path": "profiles/node_modules/run-applescript",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/run-applescript"
+    },
+    {
+      "path": "profiles/node_modules/statuses",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/statuses"
+    },
+    {
+      "path": "profiles/node_modules/https-proxy-agent",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/https-proxy-agent"
+    },
+    {
+      "path": "profiles/node_modules/bowser",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/bowser"
+    },
+    {
+      "path": "profiles/node_modules/parseurl",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/parseurl"
+    },
+    {
+      "path": "profiles/node_modules/etag",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/etag"
+    },
+    {
+      "path": "profiles/node_modules/wrappy",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/wrappy"
+    },
+    {
+      "path": "profiles/node_modules/http-proxy-agent",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/http-proxy-agent"
+    },
+    {
+      "path": "profiles/node_modules/send",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/send"
+    },
+    {
+      "path": "profiles/node_modules/data-uri-to-buffer",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/data-uri-to-buffer"
+    },
+    {
+      "path": "profiles/node_modules/fast-sha256",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/fast-sha256"
+    },
+    {
+      "path": "profiles/node_modules/finalhandler",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/finalhandler"
+    },
+    {
+      "path": "profiles/node_modules/fetch-blob",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/fetch-blob"
+    },
+    {
+      "path": "profiles/node_modules/react",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/react"
+    },
+    {
+      "path": "profiles/node_modules/node-addon-native-custom-loader",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/node-addon-native-custom-loader"
+    },
+    {
+      "path": "profiles/node_modules/compressible",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/compressible"
+    },
+    {
+      "path": "profiles/node_modules/which",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/which"
+    },
+    {
+      "path": "profiles/node_modules/side-channel-map",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/side-channel-map"
+    },
+    {
+      "path": "profiles/node_modules/ajv",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/ajv"
+    },
+    {
+      "path": "profiles/node_modules/google-logging-utils",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/google-logging-utils"
+    },
+    {
+      "path": "profiles/node_modules/open",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/open"
+    },
+    {
+      "path": "profiles/node_modules/object-inspect",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/object-inspect"
+    },
+    {
+      "path": "profiles/node_modules/sharp",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/sharp"
+    },
+    {
+      "path": "profiles/node_modules/on-finished",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/on-finished"
+    },
+    {
+      "path": "profiles/node_modules/fflate",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/fflate"
+    },
+    {
+      "path": "profiles/node_modules/ws",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/ws"
+    },
+    {
+      "path": "profiles/node_modules/fast-deep-equal",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/fast-deep-equal"
+    },
+    {
+      "path": "profiles/node_modules/openai",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/openai"
+    },
+    {
+      "path": "profiles/node_modules/shebang-command",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/shebang-command"
+    },
+    {
+      "path": "profiles/node_modules/require-from-string",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/require-from-string"
+    },
+    {
+      "path": "profiles/node_modules/debug",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/debug"
+    },
+    {
+      "path": "profiles/node_modules/media-typer",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/media-typer"
+    },
+    {
+      "path": "profiles/node_modules/mime-db",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/mime-db"
+    },
+    {
+      "path": "profiles/node_modules/isexe",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/isexe"
+    },
+    {
+      "path": "profiles/node_modules/es-object-atoms",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/es-object-atoms"
+    },
+    {
+      "path": "profiles/node_modules/router",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/router"
+    },
+    {
+      "path": "profiles/node_modules/setprototypeof",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/setprototypeof"
+    },
+    {
+      "path": "profiles/node_modules/nan",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/nan"
+    },
+    {
+      "path": "profiles/node_modules/fs-ext",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/fs-ext"
+    },
+    {
+      "path": "profiles/node_modules/@types/retry",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@types/retry"
+    },
+    {
+      "path": "profiles/node_modules/@types/trusted-types",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@types/trusted-types"
+    },
+    {
+      "path": "profiles/node_modules/@types/node",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@types/node"
+    },
+    {
+      "path": "profiles/node_modules/@lexical/extension",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@lexical/extension"
+    },
+    {
+      "path": "profiles/node_modules/@lexical/plain-text",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@lexical/plain-text"
+    },
+    {
+      "path": "profiles/node_modules/@lexical/internal",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@lexical/internal"
+    },
+    {
+      "path": "profiles/node_modules/@lexical/utils",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@lexical/utils"
+    },
+    {
+      "path": "profiles/node_modules/@lexical/html",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@lexical/html"
+    },
+    {
+      "path": "profiles/node_modules/@lexical/list",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@lexical/list"
+    },
+    {
+      "path": "profiles/node_modules/@lexical/history",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@lexical/history"
+    },
+    {
+      "path": "profiles/node_modules/@lexical/dragon",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@lexical/dragon"
+    },
+    {
+      "path": "profiles/node_modules/@lexical/selection",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@lexical/selection"
+    },
+    {
+      "path": "profiles/node_modules/@lexical/text",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@lexical/text"
+    },
+    {
+      "path": "profiles/node_modules/@lexical/clipboard",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@lexical/clipboard"
+    },
+    {
+      "path": "profiles/node_modules/@mixmark-io/domino",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@mixmark-io/domino"
+    },
+    {
+      "path": "profiles/node_modules/@vscode/ripgrep",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@vscode/ripgrep"
+    },
+    {
+      "path": "profiles/node_modules/@xterm/headless",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@xterm/headless"
+    },
+    {
+      "path": "profiles/node_modules/@anthropic-ai/sdk",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@anthropic-ai/sdk"
+    },
+    {
+      "path": "profiles/node_modules/@tanstack/virtual-core",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@tanstack/virtual-core"
+    },
+    {
+      "path": "profiles/node_modules/@tanstack/react-virtual",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@tanstack/react-virtual"
+    },
+    {
+      "path": "profiles/node_modules/@opentelemetry/sdk-logs",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@opentelemetry/sdk-logs"
+    },
+    {
+      "path": "profiles/node_modules/@opentelemetry/core",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@opentelemetry/core"
+    },
+    {
+      "path": "profiles/node_modules/@opentelemetry/api-logs",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@opentelemetry/api-logs"
+    },
+    {
+      "path": "profiles/node_modules/@opentelemetry/semantic-conventions",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@opentelemetry/semantic-conventions"
+    },
+    {
+      "path": "profiles/node_modules/@opentelemetry/sdk-trace",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@opentelemetry/sdk-trace"
+    },
+    {
+      "path": "profiles/node_modules/@opentelemetry/resources",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@opentelemetry/resources"
+    },
+    {
+      "path": "profiles/node_modules/@opentelemetry/exporter-logs-otlp-http",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@opentelemetry/exporter-logs-otlp-http"
+    },
+    {
+      "path": "profiles/node_modules/@opentelemetry/otlp-transformer",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@opentelemetry/otlp-transformer"
+    },
+    {
+      "path": "profiles/node_modules/@opentelemetry/otlp-exporter-base",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@opentelemetry/otlp-exporter-base"
+    },
+    {
+      "path": "profiles/node_modules/@opentelemetry/api",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@opentelemetry/api"
+    },
+    {
+      "path": "profiles/node_modules/@opentelemetry/sdk-metrics",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@opentelemetry/sdk-metrics"
+    },
+    {
+      "path": "profiles/node_modules/@aws-sdk/middleware-websocket",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-sdk/middleware-websocket"
+    },
+    {
+      "path": "profiles/node_modules/@aws-sdk/middleware-eventstream",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-sdk/middleware-eventstream"
+    },
+    {
+      "path": "profiles/node_modules/@aws-sdk/token-providers",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-sdk/token-providers"
+    },
+    {
+      "path": "profiles/node_modules/@aws-sdk/credential-provider-node",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-sdk/credential-provider-node"
+    },
+    {
+      "path": "profiles/node_modules/@aws-sdk/types",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-sdk/types"
+    },
+    {
+      "path": "profiles/node_modules/@aws-sdk/core",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-sdk/core"
+    },
+    {
+      "path": "profiles/node_modules/@aws-sdk/credential-provider-env",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-sdk/credential-provider-env"
+    },
+    {
+      "path": "profiles/node_modules/@aws-sdk/credential-provider-ini",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-sdk/credential-provider-ini"
+    },
+    {
+      "path": "profiles/node_modules/@aws-sdk/xml-builder",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-sdk/xml-builder"
+    },
+    {
+      "path": "profiles/node_modules/@aws-sdk/credential-provider-sso",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-sdk/credential-provider-sso"
+    },
+    {
+      "path": "profiles/node_modules/@aws-sdk/nested-clients",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-sdk/nested-clients"
+    },
+    {
+      "path": "profiles/node_modules/@aws-sdk/client-bedrock-runtime",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-sdk/client-bedrock-runtime"
+    },
+    {
+      "path": "profiles/node_modules/@aws-sdk/credential-provider-http",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-sdk/credential-provider-http"
+    },
+    {
+      "path": "profiles/node_modules/@aws-sdk/credential-provider-login",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-sdk/credential-provider-login"
+    },
+    {
+      "path": "profiles/node_modules/@aws-sdk/credential-provider-process",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-sdk/credential-provider-process"
+    },
+    {
+      "path": "profiles/node_modules/@aws-sdk/eventstream-handler-node",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-sdk/eventstream-handler-node"
+    },
+    {
+      "path": "profiles/node_modules/@aws-sdk/signature-v4-multi-region",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-sdk/signature-v4-multi-region"
+    },
+    {
+      "path": "profiles/node_modules/@aws-sdk/util-locate-window",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-sdk/util-locate-window"
+    },
+    {
+      "path": "profiles/node_modules/@aws-sdk/credential-provider-web-identity",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-sdk/credential-provider-web-identity"
+    },
+    {
+      "path": "profiles/node_modules/@hono/node-server",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@hono/node-server"
+    },
+    {
+      "path": "profiles/node_modules/@earendil-works/pi-telemetry",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@earendil-works/pi-telemetry"
+    },
+    {
+      "path": "profiles/node_modules/@earendil-works/pi-ai",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@earendil-works/pi-ai"
+    },
+    {
+      "path": "profiles/node_modules/@preact/signals-core",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@preact/signals-core"
+    },
+    {
+      "path": "profiles/node_modules/@agentclientprotocol/sdk",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@agentclientprotocol/sdk"
+    },
+    {
+      "path": "profiles/node_modules/@modelcontextprotocol/sdk",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@modelcontextprotocol/sdk"
+    },
+    {
+      "path": "profiles/node_modules/@stablelib/base64",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@stablelib/base64"
+    },
+    {
+      "path": "profiles/node_modules/@babel/runtime",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@babel/runtime"
+    },
+    {
+      "path": "profiles/node_modules/@babel/helper-validator-identifier",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@babel/helper-validator-identifier"
+    },
+    {
+      "path": "profiles/node_modules/@babel/code-frame",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@babel/code-frame"
+    },
+    {
+      "path": "profiles/node_modules/@img/colour",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@img/colour"
+    },
+    {
+      "path": "profiles/node_modules/@aws-crypto/util",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-crypto/util"
+    },
+    {
+      "path": "profiles/node_modules/@aws-crypto/sha256-browser",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-crypto/sha256-browser"
+    },
+    {
+      "path": "profiles/node_modules/@aws-crypto/sha256-js",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-crypto/sha256-js"
+    },
+    {
+      "path": "profiles/node_modules/@aws-crypto/supports-web-crypto",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws-crypto/supports-web-crypto"
+    },
+    {
+      "path": "profiles/node_modules/@joplin/turndown-plugin-gfm",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@joplin/turndown-plugin-gfm"
+    },
+    {
+      "path": "profiles/node_modules/@standard-schema/spec",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@standard-schema/spec"
+    },
+    {
+      "path": "profiles/node_modules/@google/genai",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@google/genai"
+    },
+    {
+      "path": "profiles/node_modules/@octokit/request-error",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@octokit/request-error"
+    },
+    {
+      "path": "profiles/node_modules/@octokit/webhooks-methods",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@octokit/webhooks-methods"
+    },
+    {
+      "path": "profiles/node_modules/@octokit/openapi-webhooks-types",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@octokit/openapi-webhooks-types"
+    },
+    {
+      "path": "profiles/node_modules/@octokit/types",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@octokit/types"
+    },
+    {
+      "path": "profiles/node_modules/@octokit/openapi-types",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@octokit/openapi-types"
+    },
+    {
+      "path": "profiles/node_modules/@octokit/webhooks",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@octokit/webhooks"
+    },
+    {
+      "path": "profiles/node_modules/@smithy/fetch-http-handler",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@smithy/fetch-http-handler"
+    },
+    {
+      "path": "profiles/node_modules/@smithy/is-array-buffer",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@smithy/is-array-buffer"
+    },
+    {
+      "path": "profiles/node_modules/@smithy/signature-v4",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@smithy/signature-v4"
+    },
+    {
+      "path": "profiles/node_modules/@smithy/types",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@smithy/types"
+    },
+    {
+      "path": "profiles/node_modules/@smithy/core",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@smithy/core"
+    },
+    {
+      "path": "profiles/node_modules/@smithy/node-http-handler",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@smithy/node-http-handler"
+    },
+    {
+      "path": "profiles/node_modules/@smithy/util-buffer-from",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@smithy/util-buffer-from"
+    },
+    {
+      "path": "profiles/node_modules/@smithy/util-utf8",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@smithy/util-utf8"
+    },
+    {
+      "path": "profiles/node_modules/@smithy/credential-provider-imds",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@smithy/credential-provider-imds"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-sdk-minimal",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-sdk-minimal"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tool-jobs",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tool-jobs"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-terminal-bash",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-terminal-bash"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-model-selection",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-model-selection"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tool-subagent-control",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tool-subagent-control"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-sandbox-windows-acl",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-sandbox-windows-acl"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-output-retention",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-output-retention"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tool-workflow",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tool-workflow"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-util-values",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-util-values"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/cordis-plugin-timer",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/cordis-plugin-timer"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-trajectory",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-trajectory"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-schedule",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-schedule"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-llm-retry",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-llm-retry"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/cordis-plugin-group",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/cordis-plugin-group"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tool-skill",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tool-skill"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-conversation",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-conversation"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-credentials-local",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-credentials-local"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tool-str-replace-editor",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tool-str-replace-editor"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-shell-env",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-shell-env"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-deque",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-deque"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-workspace",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-workspace"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-modules",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-modules"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-settings",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-settings"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-projection",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-projection"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-hmr",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-hmr"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-format-catalog",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-format-catalog"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-jobs",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-jobs"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-agent-loop",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-agent-loop"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-host-directory-picker-browse",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-host-directory-picker-browse"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-skill",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-skill"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-file-reference",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-file-reference"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-hooks-codex",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-hooks-codex"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tool-goal",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tool-goal"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-acp",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-acp"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-log-deepseek",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-log-deepseek"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-format-v0-to-v1",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-format-v0-to-v1"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-open-in-app",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-open-in-app"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-message-feedback",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-message-feedback"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-webhook-github",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-webhook-github"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-settings-plugin-inventory",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-settings-plugin-inventory"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-persistence",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-persistence"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-code-runtime",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-code-runtime"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-agent-default-model",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-agent-default-model"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-sandbox",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-sandbox"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tool-bash-persistent",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tool-bash-persistent"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-util-workspace-path",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-util-workspace-path"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-storage-domain",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-storage-domain"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-goal",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-goal"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-tool",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-tool"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-jobs-local",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-jobs-local"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-launch-environment",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-launch-environment"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-host-open-in-app",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-host-open-in-app"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-workflow-run",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-workflow-run"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-api-session-controller",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-api-session-controller"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-permission-presets",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-permission-presets"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-sandbox-policy",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-sandbox-policy"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-spill-local",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-spill-local"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-code-runtime-worker-thread",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-code-runtime-worker-thread"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tool-subagent",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tool-subagent"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-sdk-protocol",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-sdk-protocol"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-agent-preset",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-agent-preset"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tool-ralph",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tool-ralph"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-persistence-jsonl",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-persistence-jsonl"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-layout",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-layout"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-time-context",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-time-context"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-spill",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-spill"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-log-export",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-log-export"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-plugin-package-inventory-deepseek",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-plugin-package-inventory-deepseek"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-settings-general",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-settings-general"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tool-todo",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tool-todo"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-subagent-in-process-driver",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-subagent-in-process-driver"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-invariants",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-invariants"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-directory-picker-browse",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-directory-picker-browse"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/cosmokit",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/cosmokit"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-sidebar",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-sidebar"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-agent-instructions",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-agent-instructions"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-settings-plugins",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-settings-plugins"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-cordis-host-runner",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-cordis-host-runner"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-compaction",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-compaction"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-user-questions",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-user-questions"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-host-directory-picker",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-host-directory-picker"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-compaction-basic",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-compaction-basic"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-workspace",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-workspace"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-schedule",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-schedule"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-persona",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-persona"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-acp-app",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-acp-app"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-package-manifest",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-package-manifest"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-typert-loader",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-typert-loader"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-home-paths",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-home-paths"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-web-frontend",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-web-frontend"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-sdk-app",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-sdk-app"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-fs-observation-policy",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-fs-observation-policy"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-renderer",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-renderer"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-agent-presets",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-agent-presets"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-credentials",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-credentials"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-storage-json",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-storage-json"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-system-prompt",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-system-prompt"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-web-search-deepseek",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-web-search-deepseek"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-win32-process",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-win32-process"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-subprocess-local",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-subprocess-local"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-llm-deepseek",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-llm-deepseek"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-command-goal",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-command-goal"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-settings",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-settings"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-attachment",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-attachment"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-telemetry-otel",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-telemetry-otel"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-typert-registry",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-typert-registry"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-terminal",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-terminal"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-deliverables",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-deliverables"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-util-crypto",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-util-crypto"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-title",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-title"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-atomic-write",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-atomic-write"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-attachment-local",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-attachment-local"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-fs",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-fs"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tool-call-timeout-policy",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tool-call-timeout-policy"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-host-frontend-static",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-host-frontend-static"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-skill-filesystem",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-skill-filesystem"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-plan",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-plan"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-connection",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-connection"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-approval",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-approval"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-host-plugin-inventory",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-host-plugin-inventory"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-checkpoint-policy",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-checkpoint-policy"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-web",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-web"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-turn-outline",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-turn-outline"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-subagent-fork-in-process",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-subagent-fork-in-process"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-sdk-jsonrpc-server",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-sdk-jsonrpc-server"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-theme",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-theme"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-fs-local",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-fs-local"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-app-boot",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-app-boot"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tools",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tools"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-repeat-tool-reminder",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-repeat-tool-reminder"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tmux-context",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tmux-context"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-command-feedback",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-command-feedback"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-web-fetch-http",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-web-fetch-http"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-subagent",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-subagent"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-input-trigger",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-input-trigger"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-settings-models",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-settings-models"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/cordis-plugin-hmr",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/cordis-plugin-hmr"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-query",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-query"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-host-webserver",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-host-webserver"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-skill",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-skill"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-llm-pi-ai",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-llm-pi-ai"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-session",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-session"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-title-llm",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-title-llm"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-plan-mode",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-plan-mode"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-agent-tool-presentation",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-agent-tool-presentation"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-directory-picker-native",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-directory-picker-native"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-settings-file",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-settings-file"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-api-gateway",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-api-gateway"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-webhook",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-webhook"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-subagent-spawn-in-process",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-subagent-spawn-in-process"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tool-bash",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tool-bash"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-web-app",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-web-app"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/cordis-plugin-include",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/cordis-plugin-include"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tool-fs-search",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tool-fs-search"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-cordis",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-cordis"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-typert-protocol",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-typert-protocol"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-subprocess",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-subprocess"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/cordis",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/cordis"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-fs-sandbox",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-fs-sandbox"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-stats",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-stats"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-pwsh-sandbox",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-pwsh-sandbox"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-brand-official",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-brand-official"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-file-upload",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-file-upload"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-hooks-claude-code",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-hooks-claude-code"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-workflow",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-workflow"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tool-pwsh-persistent",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tool-pwsh-persistent"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-commands",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-commands"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-anonymous-user-id",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-anonymous-user-id"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-reference",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-reference"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-workflow-worker-thread",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-workflow-worker-thread"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-user-questions",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-user-questions"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/schemastery",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/schemastery"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-format",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-format"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-token-meter",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-token-meter"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-cmdline",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-cmdline"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-reference",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-reference"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-brand",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-brand"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tool-fs",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tool-fs"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-api-workspace-controller",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-api-workspace-controller"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tool-web",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tool-web"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-api-remotes",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-api-remotes"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-hook-protocol",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-hook-protocol"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-permission-presets",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-permission-presets"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-bash-sandbox",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-bash-sandbox"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-locale",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-locale"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/cordis-plugin-loader",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/cordis-plugin-loader"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-native-command",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-native-command"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-spill-policy",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-spill-policy"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tool-pwsh",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tool-pwsh"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-skill-badge",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-skill-badge"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-headless",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-headless"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-host-directory-picker-auto",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-host-directory-picker-auto"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-deepseek-llm-api-extensions",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-deepseek-llm-api-extensions"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-api-settings-controller",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-api-settings-controller"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-compaction-tool-result-pruner",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-compaction-tool-result-pruner"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-commands",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-commands"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-shell",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-shell"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-storage",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-storage"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-http-proxy",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-http-proxy"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-host-directory-picker-native",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-host-directory-picker-native"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-projection-cache",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-projection-cache"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-goal",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-goal"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-base",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-base"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tool-cordis",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tool-cordis"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-agent",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-agent"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-llm",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-llm"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-scope",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-scope"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-query-sqlite",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-query-sqlite"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-mcp-client",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-mcp-client"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-authorization",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-authorization"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-util-time",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-util-time"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-tool-ask-user",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-tool-ask-user"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-goal-round-driver",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-goal-round-driver"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-sandbox-local",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-sandbox-local"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-bash-local",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-bash-local"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-attachment",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-attachment"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-file-reference-local",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-file-reference-local"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-user-approval",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-user-approval"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-pwsh-local",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-pwsh-local"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-message-feedback",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-message-feedback"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-format-v1-to-v2",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-format-v1-to-v2"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-timeout",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-timeout"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-cordis-client-runner",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-cordis-client-runner"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-title-first-prompt-llm",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-title-first-prompt-llm"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-session-telemetry",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-session-telemetry"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-command-compact",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-command-compact"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-subagent",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-subagent"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-jobs",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-jobs"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/dsh-client-ui-chat",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/dsh-client-ui-chat"
+    },
+    {
+      "path": "profiles/node_modules/@deepseek-ai/node-addon-landlock-run",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@deepseek-ai/node-addon-landlock-run"
+    },
+    {
+      "path": "profiles/node_modules/@protobufjs/utf8",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@protobufjs/utf8"
+    },
+    {
+      "path": "profiles/node_modules/@protobufjs/path",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@protobufjs/path"
+    },
+    {
+      "path": "profiles/node_modules/@protobufjs/base64",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@protobufjs/base64"
+    },
+    {
+      "path": "profiles/node_modules/@protobufjs/codegen",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@protobufjs/codegen"
+    },
+    {
+      "path": "profiles/node_modules/@protobufjs/fetch",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@protobufjs/fetch"
+    },
+    {
+      "path": "profiles/node_modules/@protobufjs/float",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@protobufjs/float"
+    },
+    {
+      "path": "profiles/node_modules/@protobufjs/aspromise",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@protobufjs/aspromise"
+    },
+    {
+      "path": "profiles/node_modules/@protobufjs/pool",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@protobufjs/pool"
+    },
+    {
+      "path": "profiles/node_modules/@protobufjs/eventemitter",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@protobufjs/eventemitter"
+    },
+    {
+      "path": "profiles/node_modules/@aws/lambda-invoke-store",
+      "target": "${APP_ROOT}/Contents/Resources/runtime/dsh/node_modules/@aws/lambda-invoke-store"
+    }
+  ]
+}

--- a/scripts/bundle-desktop.mjs
+++ b/scripts/bundle-desktop.mjs
@@ -1,8 +1,16 @@
 import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import { mkdirSync, writeFileSync, cpSync, copyFileSync, existsSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { build } from "esbuild";
 import { ROOT } from "./lib/repo.mjs";
+
+const tsc = spawnSync(
+  process.execPath,
+  [join(ROOT, "node_modules/typescript/bin/tsc"), "-b", "--pretty", "false", "--force"],
+  { cwd: ROOT, stdio: "inherit" },
+);
+if (tsc.status !== 0) process.exit(tsc.status ?? 1);
 
 const outDir = join(ROOT, "dist/desktop-bundle");
 rmSync(outDir, { recursive: true, force: true });
@@ -54,4 +62,14 @@ writeFileSync(
   join(outDir, "package.json"),
   JSON.stringify({ name: "penglai", version: "0.6.0", type: "module", main: "electron-main.js" }, null, 2),
 );
+const bundledMain = readFileSync(join(outDir, "electron-main.js"), "utf8");
+if (
+  !bundledMain.includes(".dsh-module-fallback") ||
+  !bundledMain.includes('startsWith("profiles/node_modules/")')
+) {
+  console.error(
+    "bundle-desktop refused: packaged DSH home skip is stale; @penglai/runtime dist was not rebuilt into electron-main.js",
+  );
+  process.exit(1);
+}
 console.log("bundle-desktop", outDir);


### PR DESCRIPTION
## Diagnosis

PM d09083fb in-place 0.5.12 upgrade still CORE-0296BE8DD00A / SECURITY_POLICY. Synthetic helper tests had passed because they ran TypeScript source via tsx.

Packaged `electron-main.js` still had the old `isManagedProfileRuntimeTree`. `bundle-desktop` resolves `@penglai/runtime` to `packages/runtime/dist`, and `package-mac` never ran `tsc -b`, so the source skip never shipped.

PM 498-link descriptor (credential-free): 1× `profiles/web/node_modules/@deepseek-ai` and 497× `profiles/node_modules/*`. Repro against packaged APP_ROOT: stale dist `prepareDshHomeForBoot` throws `DSH home migration refuses symlink state` from `collectHistoricalSessionLogs` (lstat before skip) on the web `@deepseek-ai` link; no `dsh-v0.1.5-alpha.1` target and empty migrations. Source prepare succeeds. User-state symlinks still fail closed.

## Fix

- Skip managed runtime trees before lstat in the session-log walk (same policy as `walkTree`).
- `bundle-desktop` runs `tsc -b --force` then refuses a bundle missing the expanded skip strings.

Independent review: session `01a085af-25fa-7171-88dc-013de6762643`, receipt `/tmp/penglai-grok-manager/0.6.0/reviews/grok-review-07ef2b2c.md`, approve 0 issues.

Does not publish. UOS payload and Electron 31 remain next phase.