### PR TITLE
fix: optional internals packaging and startup-frozen web profile

### DIFF
--- a/docs/0.6.0/ACCEPTANCE_DELTA.md
+++ b/docs/0.6.0/ACCEPTANCE_DELTA.md
@@ -50,6 +50,11 @@ Public README/website download tables remain **0.5.12** until immutable
   storage, secrets, updates, uninstall, runtime closure, and mandatory
   Office/Memory semantics. Do not disable required plugins or sandbox
   to show a window. No unsolicited OS upgrade and no second Agent core.
+  `node-addon-require-builtin` is official optional internals probing,
+  not a required loong64 native. Do not invent
+  `node-addon-require-builtin-linux-loong64-gnu`. Product web profile
+  uses official `patchReload: startup`. Flock, pty, koffi, and sharp
+  remain required native capability.
 - Deterministic source gates. Owner excludes the two-hour installed soak.
   `test:soak` remains required.
 - Exact asset set updated for four installers, then sealed from one clean

--- a/docs/0.6.0/NATIVE_AND_PUBLICATION_PLAN.md
+++ b/docs/0.6.0/NATIVE_AND_PUBLICATION_PLAN.md
@@ -66,7 +66,9 @@ Previous upgrade sources: published 0.5.12 installers.
 
 Workflow job `linux` runs `pnpm build` then `pnpm package:linux-deb`. It
 must fail closed without the full old-world payload (DSH 272, Node 22.16.0,
-flock, pty, koffi, require-builtin, sharp, chrome-sandbox). It must not run
+flock, pty, koffi, sharp, chrome-sandbox). require-builtin native is optional
+internals and unpublished on loong64; Mac/Windows still require the published
+packages. It must not run
 `test:e2e:installed` or `verify:upgrade-uninstall`.
 
 Owner native install/startup/function on UOS 20 Professional 1070 stays

--- a/docs/0.6.0/NATIVE_AND_PUBLICATION_PLAN.md
+++ b/docs/0.6.0/NATIVE_AND_PUBLICATION_PLAN.md
@@ -89,5 +89,7 @@ Owner native install/startup/function on UOS 20 Professional 1070 stays
 
 ## Addon integration handoff
 
-A separate old-world addon worker owns koffi / require-builtin / sharp.
-This repo waits for its `MANIFEST.json`. Do not duplicate those builds here.
+A separate old-world addon worker owns koffi and sharp (+ libvips).
+`node-addon-require-builtin` native is optional internals and unpublished
+on loong64; do not copy or fabricate it. This repo waits for the worker
+`MANIFEST.json` for required natives. Do not duplicate those builds here.

--- a/docs/0.6.0/OPTIONAL_INTERNALS.md
+++ b/docs/0.6.0/OPTIONAL_INTERNALS.md
@@ -1,0 +1,46 @@
+# Optional internals probing vs required native capability
+
+Native Loongson execution is unrun. This is architecture-static policy from
+official DSH `0.1.5-alpha.1` (`5dda764e…`) and Penglai production sources.
+It is not a native UOS PASS.
+
+## Official loader (npm `@deepseek-ai/cordis-plugin-loader` 1.0.3)
+
+`node-addon-require-builtin` is an **optional peer**.
+`ModuleLoader.requireInternal` tries `--expose-internals`, then the addon,
+and **swallows both failures**. `fromInternal()` returns `undefined` when
+the probe is empty. Plugin import then uses public `import(name)`.
+
+The published JS package loads `createEntryApi` at module scope. The
+unpublished name `node-addon-require-builtin-linux-loong64-gnu` is what a
+glibc loong64 host would request. Official optionalDependencies list
+darwin, linux-x64/arm64-gnu, and win32 only. Do not invent that package.
+
+## HMR
+
+`@deepseek-ai/cordis-plugin-hmr` throws if `loader.internal` is missing.
+`@deepseek-ai/dsh-base` ships HMR `disabled: true`. Official `web` template
+defaults `patchReload: live`, which would mount a watch-only HMR instance
+after boot and fail closed without internals.
+
+Penglai never passes `--expose-internals` (Electron also fuses off
+`NODE_OPTIONS`). The product web profile is pinned to official
+`patchReload: "startup"`. Plugin Center enable/disable/update uses the
+loader public API (`create` / `update`), not HMR. Office and Memory stay
+required-builtin.
+
+## Packaging
+
+| Class | Examples | linux-loong64 |
+| --- | --- | --- |
+| Required native capability | flock, pty, koffi, sharp, chrome-sandbox | still fail-closed when missing |
+| Optional internals probing | require-builtin native | unpublished; omit; do not fabricate |
+
+Mac/Windows still require the published require-builtin native packages.
+
+## 中文
+
+`require-builtin` 是官方可选 internals 探测，不是冻结启动的必装原生依赖。
+未发布的 `node-addon-require-builtin-linux-loong64-gnu` 不得编造。蓬莱产品
+web 配置使用官方 `patchReload: startup`。 flock / pty / koffi / sharp 仍为
+必装原生能力。UOS 安装/启动/功能仍为 `OWNER_POST_RELEASE`。

--- a/docs/0.6.0/TODO.md
+++ b/docs/0.6.0/TODO.md
@@ -116,8 +116,9 @@ public checkout.
 - [ ] S05 Native addons: old-world flock ELF exists
       (`docs/0.6.0/UOS20_FLOCK.md`, SHA-256 `b065bcb1…`). npm
       `@koromix/koffi-linux-loong64@3.1.6` is new-world `GLIBC_2.36` —
-      do not embed. node-pty / require-builtin-linux-loong64-gnu / sharp
-      still lack old-world loong64 builds. Memory cannot be disabled.
+      do not embed. node-pty / sharp still need old-world loong64 builds.
+      require-builtin native is optional internals, unpublished on loong64;
+      do not fabricate it. Memory cannot be disabled.
 - [ ] S06 UOS native install/startup/function: **Owner post-publication
       acceptance** (2026-09-09). Not a pre-publication blocker. Do not
       request remote access. Label `OWNER_POST_RELEASE`, never PASS.

--- a/docs/0.6.0/UOS20_FLOCK.md
+++ b/docs/0.6.0/UOS20_FLOCK.md
@@ -51,7 +51,9 @@ darwin). Do not ship Zig’s default spawn-helper: it received
 ## Still missing for a complete `.deb`
 
 npm `@koromix/koffi-linux-loong64@3.1.6` ELF is **new-world**
-(`GLIBC_2.36`). Do not embed it. `node-addon-require-builtin-linux-loong64-gnu`
-and sharp have no old-world loong64 build yet. The packager fails closed
-unless the payload contains old-world Node, the pinned DSH CLI, and this
-flock addon.
+(`GLIBC_2.36`). Do not embed it. sharp still needs the old-world loong64
+build from the addon worker. `node-addon-require-builtin` native is
+**optional internals probing**, unpublished on loong64; do not fabricate
+`node-addon-require-builtin-linux-loong64-gnu`. See
+`docs/0.6.0/OPTIONAL_INTERNALS.md`. The packager fails closed unless the
+payload contains old-world Node, the pinned DSH CLI, and this flock addon.

--- a/docs/RELEASE_NOTES_0.6.0.md
+++ b/docs/RELEASE_NOTES_0.6.0.md
@@ -31,9 +31,10 @@ before that.
   folder error clears on a valid path; custom-model image input uses
   official DeepSeek `inputModalities` (no model-id regex).
 - Fourth target: actual UOS 20 old-world `.deb` class with Office/Memory
-  required and chrome-sandbox kept. Payload addons (koffi / require-builtin /
-  sharp) are integrated from a separate old-world build, not from new-world
-  npm `linux-loong64` wheels.
+  required and chrome-sandbox kept. Payload addons (koffi / sharp) are
+  integrated from a separate old-world build, not from new-world npm
+  `linux-loong64` wheels. `node-addon-require-builtin` native is official
+  optional internals probing and is unpublished on loong64.
 
 ## Known boundaries
 

--- a/packages/runtime/src/foundation.test.ts
+++ b/packages/runtime/src/foundation.test.ts
@@ -114,6 +114,12 @@ test("embed-runtime is target-aware and reads the release contract", () => {
   const closure = readFileSync(new URL("../../../scripts/lib/dsh-closure.mjs", import.meta.url), "utf8");
   assert.match(closure, /REQUIRE_BUILTIN_NATIVE_BY_TARGET/);
   assert.match(closure, /node-addon-require-builtin-darwin-arm64/);
+  assert.match(closure, /OPTIONAL_INTERNALS_TARGETS/);
+  assert.match(closure, /"linux-loong64": "linux-loong64"/);
+  assert.doesNotMatch(
+    closure,
+    /REQUIRE_BUILTIN_NATIVE_BY_TARGET = \{[^}]*linux-loong64/,
+  );
 });
 
 test("Windows signing inspection stays in the PowerShell 7 host module graph", () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -82,6 +82,8 @@ export * from "./fuses.js";
 export * from "./dsh-web-auth.js";
 
 export const PENGLAI_VERSION = RELEASE;
+/** Official DSH `startup` freeze: no live HMR. Internals probing is optional. */
+export const PRODUCT_WEB_PATCH_RELOAD = "startup";
 export const PINNED_DSH = "0.1.5-alpha.1";
 export const PINNED_NODE = "22.23.2";
 export const PINNED_ELECTRON = "43.6.0";
@@ -265,6 +267,31 @@ function removeTreeNoFollow(path: string): void {
 export function seedWebProfile(seedDir: string, destDir: string): void {
   mkdirSync(destDir, { recursive: true, mode: 0o700 });
   copyDir(seedDir, destDir);
+}
+
+/**
+ * Penglai's product web profile is startup-frozen. Official `web` defaults to
+ * `patchReload: live`, which mounts HMR and requires Node internals. Penglai
+ * never enables the internals execArgv. Pin the official `startup` value so a
+ * missing optional require-builtin native cannot fail boot.
+ */
+export function pinProductWebPatchReload(profileDir: string): boolean {
+  const manifestPath = join(profileDir, "package.json");
+  const manifestText = readRegularFileNoFollow(manifestPath, "utf8");
+  if (manifestText === undefined) return false;
+  const manifest = JSON.parse(manifestText) as {
+    dsh?: { profile?: { bundles?: string[]; patchReload?: string } };
+  };
+  if (manifest.dsh?.profile?.patchReload === PRODUCT_WEB_PATCH_RELOAD) return false;
+  manifest.dsh = {
+    ...manifest.dsh,
+    profile: {
+      ...(manifest.dsh?.profile ?? {}),
+      patchReload: PRODUCT_WEB_PATCH_RELOAD,
+    },
+  };
+  writeFileAtomic(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 0o600);
+  return true;
 }
 
 export function extractedPackageRoot(tmp: string): string {
@@ -785,6 +812,7 @@ export function activatePrivateProfile(layout: RuntimeLayout, user: UserLayout):
     installFirstPartyPlugins(layout, user.profileWeb, user.transactions);
   }
   linkOfficialDeepseek(layout, user.profileWeb);
+  pinProductWebPatchReload(user.profileWeb);
   seedFreshSettings(user);
   recordKeychainMigrationIfNeeded(user);
 }

--- a/packages/runtime/src/runtime.test.ts
+++ b/packages/runtime/src/runtime.test.ts
@@ -34,6 +34,8 @@ import {
   isPenglaiProductTitle,
   linkOfficialDeepseek,
   mergeLegacyContextIntoMemory,
+  pinProductWebPatchReload,
+  PRODUCT_WEB_PATCH_RELOAD,
   probeOfficialDsh,
   recoverProfile,
   resetManagedDshModuleFallback,
@@ -79,6 +81,33 @@ test("embedded DSH Web never opens the operating-system browser", () => {
     "--port",
     "3080",
   ]);
+  const supervisor = readFileSync(new URL("./index.ts", import.meta.url), "utf8");
+  assert.match(supervisor, /spawn\(this\.layout\.nodeBin, \[this\.layout\.dshEntry, \.\.\.dshArgs\]/);
+  const envBlock = supervisor.slice(supervisor.indexOf("const childEnv"), supervisor.indexOf("const dshArgs"));
+  assert.match(envBlock, /PATH: "\/usr\/bin:\/bin"/);
+  assert.doesNotMatch(envBlock, /NODE_OPTIONS/);
+});
+
+test("product web profile is official startup-frozen, not live HMR", () => {
+  const seed = JSON.parse(
+    readFileSync(new URL("../../../profile-seed/web/package.json", import.meta.url), "utf8"),
+  );
+  assert.equal(seed.dsh.profile.patchReload, "startup");
+  assert.equal(PRODUCT_WEB_PATCH_RELOAD, "startup");
+  const profile = mkdtempSync(join(tmpdir(), "penglai-web-reload-"));
+  writeFileSync(
+    join(profile, "package.json"),
+    JSON.stringify({
+      name: "dsh-profile-web",
+      dsh: { profile: { bundles: ["@deepseek-ai/dsh-base", "@deepseek-ai/dsh-web-app"], patchReload: "live" } },
+    }),
+  );
+  assert.equal(pinProductWebPatchReload(profile), true);
+  assert.equal(
+    JSON.parse(readFileSync(join(profile, "package.json"), "utf8")).dsh.profile.patchReload,
+    "startup",
+  );
+  assert.equal(pinProductWebPatchReload(profile), false);
 });
 
 test("Windows owned DSH receives only the required OS environment", () => {

--- a/packages/runtime/src/runtime.test.ts
+++ b/packages/runtime/src/runtime.test.ts
@@ -317,6 +317,36 @@ test("existing profile is refreshed from newer first-party plugin tarballs", () 
   assert.match(readFileSync(join(user.profileWeb, "node_modules", "@penglai", "plugin-reference", "dist", "index.js"), "utf8"), /v2/);
 });
 
+test("activatePrivateProfile pins lived-in live HMR to official startup without dropping bundles", () => {
+  const app = mkdtempSync(join(tmpdir(), "penglai-app-"));
+  const user = resolveUserLayout(mkdtempSync(join(tmpdir(), "penglai-user-")));
+  mkdirSync(join(app, "profile-seed", "web"), { recursive: true });
+  writeFileSync(join(app, "profile-seed", "web", "package.json"), "{\"name\":\"web\"}\n");
+  writeTrustedPluginSet(app);
+  mkdirSync(join(app, "runtime", "dsh", "node_modules", "@deepseek-ai"), { recursive: true });
+  writeFileSync(join(app, "runtime", "dsh", "node_modules", "@deepseek-ai", ".keep"), "official\n");
+  mkdirSync(user.profileWeb, { recursive: true });
+  mkdirSync(user.transactions, { recursive: true });
+  writeFileSync(
+    join(user.profileWeb, "package.json"),
+    JSON.stringify({
+      name: "dsh-profile-web",
+      dependencies: { "@penglai/office": "0.6.0" },
+      dsh: {
+        profile: {
+          bundles: ["@deepseek-ai/dsh-base", "@deepseek-ai/dsh-web-app"],
+          patchReload: "live",
+        },
+      },
+    }),
+  );
+  activatePrivateProfile(resolveRuntimeLayout(app), user);
+  const manifest = JSON.parse(readFileSync(join(user.profileWeb, "package.json"), "utf8"));
+  assert.equal(manifest.dsh.profile.patchReload, "startup");
+  assert.deepEqual(manifest.dsh.profile.bundles, ["@deepseek-ai/dsh-base", "@deepseek-ai/dsh-web-app"]);
+  assert.equal(manifest.dependencies["@penglai/office"], "0.6.0");
+});
+
 test("R2-DIST-011 seed activates private profile once", () => {
   const app = mkdtempSync(join(tmpdir(), "penglai-app-"));
   const user = resolveUserLayout(mkdtempSync(join(tmpdir(), "penglai-user-")));

--- a/profile-seed/web/package.json
+++ b/profile-seed/web/package.json
@@ -17,7 +17,8 @@
       "bundles": [
         "@deepseek-ai/dsh-base",
         "@deepseek-ai/dsh-web-app"
-      ]
+      ],
+      "patchReload": "startup"
     }
   }
 }

--- a/scripts/lib/dsh-closure.mjs
+++ b/scripts/lib/dsh-closure.mjs
@@ -29,12 +29,20 @@ export const DSH_RUNTIME_INTEGRATION_ROOTS = [
   "@deepseek-ai/dsh-client-ui-slots",
 ];
 
+/** Published require-builtin native packages. Missing these is a flatten FAIL. */
 export const REQUIRE_BUILTIN_NATIVE_BY_TARGET = {
   "darwin-aarch64": "node-addon-require-builtin-darwin-arm64",
   "darwin-x86_64": "node-addon-require-builtin-darwin-x64",
   "win32-x86_64": "node-addon-require-builtin-win32-x64-msvc",
-  "linux-loong64": "node-addon-require-builtin-linux-loong64-gnu",
 };
+
+/**
+ * Targets whose official loader internals probe is optional and whose
+ * require-builtin native package is unpublished. Do not invent a loong64
+ * gnu optional package. This is not a waiver of required natives
+ * (flock, pty, koffi, sharp).
+ */
+export const OPTIONAL_INTERNALS_TARGETS = Object.freeze(["linux-loong64"]);
 
 export const NODE_PTY_PREBUILD_BY_TARGET = {
   "darwin-aarch64": "darwin-arm64",
@@ -326,6 +334,9 @@ export function pruneNodePtyNativePayloads(modulesDir, target) {
 }
 
 export function resolveRequireBuiltinNative(installAnchor, target) {
+  if (OPTIONAL_INTERNALS_TARGETS.includes(target)) {
+    return { name: undefined, dir: undefined, required: false };
+  }
   const name = REQUIRE_BUILTIN_NATIVE_BY_TARGET[target];
   if (!name) throw new Error(`no require-builtin native mapping for ${target}`);
   const anchors = [
@@ -335,9 +346,9 @@ export function resolveRequireBuiltinNative(installAnchor, target) {
   ];
   for (const anchor of anchors) {
     const dir = packageDirFromAnchor(anchor, name);
-    if (dir) return { name, dir };
+    if (dir) return { name, dir, required: true };
   }
-  return { name, dir: undefined };
+  return { name, dir: undefined, required: true };
 }
 
 export function materializeDshClosure(installAnchor, destRoot, target) {
@@ -355,23 +366,26 @@ export function materializeDshClosure(installAnchor, destRoot, target) {
   assertNestedVersionConflicts(links, modulesDir, target);
   const nodePty = pruneNodePtyNativePayloads(modulesDir, target);
   const native = resolveRequireBuiltinNative(installAnchor, target);
-  if (!native.dir || !existsSync(join(native.dir, "package.json"))) {
-    throw new Error(`embedded DSH closure missing ${native.name} for ${target}`);
-  }
-  copyFlatPackage(native.dir, join(modulesDir, native.name));
   const flattened = new Map(
     [...links.keys()]
       .filter((name) => name !== appName)
       .map((name) => [name, join(modulesDir, name)]),
   );
-  flattened.set(native.name, join(modulesDir, native.name));
-  assertDshClosure(flattened);
-  if (!existsSync(join(modulesDir, native.name, "package.json"))) {
-    throw new Error(`flattened DSH closure missing ${native.name}`);
+  if (native.required !== false) {
+    if (!native.name || !native.dir || !existsSync(join(native.dir, "package.json"))) {
+      throw new Error(`embedded DSH closure missing ${native.name} for ${target}`);
+    }
+    copyFlatPackage(native.dir, join(modulesDir, native.name));
+    flattened.set(native.name, join(modulesDir, native.name));
+    if (!existsSync(join(modulesDir, native.name, "package.json"))) {
+      throw new Error(`flattened DSH closure missing ${native.name}`);
+    }
   }
+  assertDshClosure(flattened);
   return {
     packages: [...flattened.keys()],
-    native: native.name,
+    native: native.name ?? null,
+    optionalInternals: native.required === false ? "unavailable" : "embedded",
     nodePty,
     nestedConflicts,
   };

--- a/scripts/lib/dsh-closure.test.mjs
+++ b/scripts/lib/dsh-closure.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolve } from "node:path";
@@ -8,6 +8,7 @@ import {
   collectDshClosure,
   DSH_RUNTIME_INTEGRATION_ROOTS,
   locateWorkspaceDsh,
+  materializeDshClosure,
   materializeNestedVersionConflicts,
   OPTIONAL_INTERNALS_TARGETS,
   packageSupportsTarget,
@@ -132,6 +133,52 @@ test("require-builtin native is required only where npm publishes it", () => {
   assert.throws(
     () => resolveRequireBuiltinNative(resolve("package.json"), "linux-x64"),
     /no require-builtin native mapping/,
+  );
+});
+
+function writeClosureFixture(work, { withPty } = {}) {
+  writeFileSync(
+    join(work, "package.json"),
+    JSON.stringify({
+      name: "fixture-root",
+      version: "1.0.0",
+      dependencies: Object.fromEntries(
+        [...REQUIRED_DSH_RUNTIME_PACKAGES, ...(withPty ? ["node-pty"] : [])].map((name) => [name, "1.0.0"]),
+      ),
+    }),
+  );
+  for (const name of REQUIRED_DSH_RUNTIME_PACKAGES) {
+    const dir = join(work, "node_modules", name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name, version: "1.0.0" }));
+  }
+}
+
+test("linux-loong64 flatten omits unpublished require-builtin native and still requires pty", () => {
+  const work = mkdtempSync(join(tmpdir(), "penglai-dsh-optional-int-"));
+  writeClosureFixture(work, { withPty: true });
+  const pty = join(work, "node_modules", "node-pty");
+  mkdirSync(join(pty, "prebuilds", "linux-loong64"), { recursive: true });
+  writeFileSync(join(pty, "package.json"), JSON.stringify({ name: "node-pty", version: "1.0.0" }));
+  writeFileSync(join(pty, "prebuilds", "linux-loong64", "pty.node"), "pty\n");
+  const dest = join(work, "dest");
+  const flattened = materializeDshClosure(join(work, "package.json"), dest, "linux-loong64");
+  assert.equal(flattened.optionalInternals, "unavailable");
+  assert.equal(flattened.native, null);
+  assert.equal(existsSync(join(dest, "node_modules", "node-addon-require-builtin-linux-loong64-gnu")), false);
+  assert.equal(existsSync(join(dest, "node_modules", "node-pty", "prebuilds", "linux-loong64", "pty.node")), true);
+});
+
+test("darwin flatten still embeds the published require-builtin native", () => {
+  const work = mkdtempSync(join(tmpdir(), "penglai-dsh-required-int-"));
+  writeClosureFixture(work);
+  const dest = join(work, "dest");
+  const flattened = materializeDshClosure(join(work, "package.json"), dest, "darwin-aarch64");
+  assert.equal(flattened.native, "node-addon-require-builtin-darwin-arm64");
+  assert.equal(flattened.optionalInternals, "embedded");
+  assert.equal(
+    existsSync(join(dest, "node_modules", "node-addon-require-builtin-darwin-arm64", "package.json")),
+    true,
   );
 });
 

--- a/scripts/lib/dsh-closure.test.mjs
+++ b/scripts/lib/dsh-closure.test.mjs
@@ -9,8 +9,11 @@ import {
   DSH_RUNTIME_INTEGRATION_ROOTS,
   locateWorkspaceDsh,
   materializeNestedVersionConflicts,
+  OPTIONAL_INTERNALS_TARGETS,
   packageSupportsTarget,
   REQUIRED_DSH_RUNTIME_PACKAGES,
+  REQUIRE_BUILTIN_NATIVE_BY_TARGET,
+  resolveRequireBuiltinNative,
 } from "./dsh-closure.mjs";
 
 test("locateWorkspaceDsh uses hoisted node_modules when .pnpm has no DSH entry", () => {
@@ -112,6 +115,42 @@ test("flattening preserves a package-local dependency when its version differs",
   assert.equal(result.nestedConflictCount, 1);
   const nested = JSON.parse(readFileSync(join(modules, "package-a", "node_modules", "package-x", "package.json"), "utf8"));
   assert.equal(nested.version, "1.0.0");
+});
+
+test("require-builtin native is required only where npm publishes it", () => {
+  assert.equal(REQUIRE_BUILTIN_NATIVE_BY_TARGET["darwin-aarch64"], "node-addon-require-builtin-darwin-arm64");
+  assert.equal(REQUIRE_BUILTIN_NATIVE_BY_TARGET["darwin-x86_64"], "node-addon-require-builtin-darwin-x64");
+  assert.equal(REQUIRE_BUILTIN_NATIVE_BY_TARGET["win32-x86_64"], "node-addon-require-builtin-win32-x64-msvc");
+  assert.equal("linux-loong64" in REQUIRE_BUILTIN_NATIVE_BY_TARGET, false);
+  assert.deepEqual([...OPTIONAL_INTERNALS_TARGETS], ["linux-loong64"]);
+  const optional = resolveRequireBuiltinNative(resolve("package.json"), "linux-loong64");
+  assert.equal(optional.required, false);
+  assert.equal(optional.name, undefined);
+  const required = resolveRequireBuiltinNative(resolve("package.json"), "darwin-aarch64");
+  assert.equal(required.required, true);
+  assert.equal(required.name, "node-addon-require-builtin-darwin-arm64");
+  assert.throws(
+    () => resolveRequireBuiltinNative(resolve("package.json"), "linux-x64"),
+    /no require-builtin native mapping/,
+  );
+});
+
+test("official loader declares require-builtin as an optional peer", () => {
+  const loader = JSON.parse(
+    readFileSync(resolve("node_modules/@deepseek-ai/cordis-plugin-loader/package.json"), "utf8"),
+  );
+  assert.equal(loader.peerDependencies["node-addon-require-builtin"], "^0.1.4");
+  assert.equal(loader.peerDependenciesMeta["node-addon-require-builtin"].optional, true);
+  const builtin = JSON.parse(
+    readFileSync(resolve("node_modules/node-addon-require-builtin/package.json"), "utf8"),
+  );
+  assert.equal("node-addon-require-builtin-linux-loong64-gnu" in (builtin.optionalDependencies ?? {}), false);
+  const loaderJs = readFileSync(
+    resolve("node_modules/@deepseek-ai/cordis-plugin-loader/lib/index.js"),
+    "utf8",
+  );
+  assert.match(loaderJs, /try \{\s*return require\("node-addon-require-builtin"\)\.requireBuiltin\(id\);\s*\} catch \{\}/);
+  assert.match(loaderJs, /if \(!raw\) return;/);
 });
 
 test("closure fails closed when a required peer cannot be resolved", () => {


### PR DESCRIPTION
Treat `node-addon-require-builtin` as official optional internals probing, not a required linux-loong64 native. Do not invent `node-addon-require-builtin-linux-loong64-gnu`.

Pin the product web profile to official `patchReload: startup` so live HMR (which requires internals) cannot fail frozen boot. Mac/Windows still require published require-builtin natives. Flock, pty, koffi, and sharp stay required.

Not a public release. No native rebuild. UOS native remains OWNER_POST_RELEASE.