### PR TITLE
fix: fetch linux-loong64 Mnemon without pnpm argv --

### DIFF
--- a/.github/workflows/native-release-candidate.yml
+++ b/.github/workflows/native-release-candidate.yml
@@ -424,7 +424,7 @@ jobs:
       - name: Build source from the clean checkout
         run: pnpm build
       - name: Fetch architecture-built linux-loong64 Mnemon
-        run: pnpm fetch:mnemon-assets -- --target linux-loong64
+        run: node --import tsx scripts/fetch-mnemon-assets.mjs --target linux-loong64
       - name: Package UOS .deb from the staged old-world payload
         env:
           PENGLAI_PACK_TARGET: linux-loong64

--- a/scripts/lib/mnemon-fetch.mjs
+++ b/scripts/lib/mnemon-fetch.mjs
@@ -31,6 +31,7 @@ export function parseFetchArgs(argv) {
   let target;
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
+    if (arg === "--") continue;
     if (arg === "--host-only") hostOnly = true;
     else if (arg === "--all") all = true;
     else if (arg === "--target") {

--- a/scripts/lib/mnemon-fetch.test.mjs
+++ b/scripts/lib/mnemon-fetch.test.mjs
@@ -19,6 +19,15 @@ test("fetch-mnemon rejects unknown arguments", () => {
   assert.throws(() => parseFetchArgs(["--weird"]), /unknown fetch-mnemon argument/);
 });
 
+test("fetch-mnemon ignores argv -- so pnpm extra args can pass --target", () => {
+  const parsed = parseFetchArgs(["--host-only", "--", "--target", "linux-loong64"]);
+  assert.equal(parsed.hostOnly, true);
+  assert.equal(parsed.target, "linux-loong64");
+  const assets = selectAssets(parsed);
+  assert.equal(assets.length, 1);
+  assert.equal(assets[0].target, "linux-loong64");
+});
+
 test("linux-loong64 is a pinned architecture-built mnemon target", () => {
   const parsed = parseFetchArgs(["--target", "linux-loong64"]);
   const assets = selectAssets(parsed);


### PR DESCRIPTION
## Summary

Linux native packaging failed on freeze SHA `21d7397b` because
`pnpm fetch:mnemon-assets -- --target linux-loong64` became
`fetch-mnemon-assets.mjs --host-only -- --target linux-loong64`.

Ignore argv `--` and call the architecture-built fetch with `--target linux-loong64`.

Native run 34373796287 was cancelled so all four artifacts can rebuild from one SHA.

## Test plan

- [x] mnemon-fetch unit test for `--host-only -- --target linux-loong64`
- [ ] Source CI
- [ ] After merge: one freeze SHA, re-dispatch `native-release-candidate.yml` `mode=native`