### PR TITLE
fix: target-platform layout separators and darwin flatten fixture

### DIFF
--- a/packages/runtime/src/foundation.test.ts
+++ b/packages/runtime/src/foundation.test.ts
@@ -43,6 +43,7 @@ test("R50-DIST-006 generation layout isolates 0.5 and lists legacy", () => {
   assert.equal(linux.logs, "/home/测 试/.local/state/Penglai/0.5/logs");
   assert.equal(linux.cache, "/home/测 试/.cache/Penglai/0.5");
   assert.equal(linux.updates, "/home/测 试/.cache/Penglai/0.5/updates");
+  assert.equal(linux.userData.includes("\\"), false);
   assert.ok(linux.legacyCandidates.some((p) => p.endsWith(".dsh")));
   assert.equal(joinUserData(join(tmpdir(), "Penglai")), join(tmpdir(), "Penglai", "0.5"));
 });

--- a/packages/runtime/src/layout.ts
+++ b/packages/runtime/src/layout.ts
@@ -1,9 +1,21 @@
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { resolve } from "node:path";
 
 export const GENERATION_ID = "penglai-dsh-v0.5";
 
 export type LayoutPlatform = "darwin" | "win32" | "linux";
+
+/** Join layout segments with the target platform's separators, not the builder's. */
+export function joinPlatform(platform: LayoutPlatform, ...parts: string[]): string {
+  const posix = parts.map((part) => String(part).replaceAll("\\", "/"));
+  let out = posix[0] ?? "";
+  for (const part of posix.slice(1)) {
+    const seg = part.replace(/^\/+|\/+$/g, "");
+    if (!seg) continue;
+    out = out.endsWith("/") ? `${out}${seg}` : `${out}/${seg}`;
+  }
+  return platform === "win32" ? out.replaceAll("/", "\\") : out.replace(/\/{2,}/g, "/");
+}
 
 export interface GenerationLayout {
   generationId: string;
@@ -28,53 +40,56 @@ export function resolveGenerationLayout(opts: {
 }): GenerationLayout {
   const home = opts.home ?? homedir();
   if (opts.platform === "linux") {
-    const dataHome = opts.dataHome ?? join(home, ".local", "share");
-    const cacheHome = opts.cacheHome ?? join(home, ".cache");
-    const stateHome = opts.stateHome ?? join(home, ".local", "state");
-    const userData = join(dataHome, "Penglai", "0.5");
+    const dataHome = opts.dataHome ?? joinPlatform("linux", home, ".local", "share");
+    const cacheHome = opts.cacheHome ?? joinPlatform("linux", home, ".cache");
+    const stateHome = opts.stateHome ?? joinPlatform("linux", home, ".local", "state");
+    const userData = joinPlatform("linux", dataHome, "Penglai", "0.5");
     return {
       generationId: GENERATION_ID,
       userData,
-      dshHome: join(userData, "dsh-home"),
-      logs: join(stateHome, "Penglai", "0.5", "logs"),
-      cache: join(cacheHome, "Penglai", "0.5"),
-      updates: join(cacheHome, "Penglai", "0.5", "updates"),
-      im: join(userData, "im"),
-      uninstall: join(userData, "uninstall"),
-      legacyCandidates: [join(home, ".dsh")],
+      dshHome: joinPlatform("linux", userData, "dsh-home"),
+      logs: joinPlatform("linux", stateHome, "Penglai", "0.5", "logs"),
+      cache: joinPlatform("linux", cacheHome, "Penglai", "0.5"),
+      updates: joinPlatform("linux", cacheHome, "Penglai", "0.5", "updates"),
+      im: joinPlatform("linux", userData, "im"),
+      uninstall: joinPlatform("linux", userData, "uninstall"),
+      legacyCandidates: [joinPlatform("linux", home, ".dsh")],
     };
   }
   if (opts.platform === "darwin") {
-    const library = opts.libraryRoot ?? join(home, "Library");
-    const userData = join(library, "Application Support", "Penglai", "0.5");
+    const library = opts.libraryRoot ?? joinPlatform("darwin", home, "Library");
+    const userData = joinPlatform("darwin", library, "Application Support", "Penglai", "0.5");
     return {
       generationId: GENERATION_ID,
       userData,
-      dshHome: join(userData, "dsh-home"),
-      logs: join(library, "Logs", "Penglai", "0.5"),
-      cache: join(library, "Caches", "Penglai", "0.5"),
-      updates: join(library, "Caches", "Penglai", "0.5", "updates"),
-      im: join(userData, "im"),
-      uninstall: join(userData, "uninstall"),
+      dshHome: joinPlatform("darwin", userData, "dsh-home"),
+      logs: joinPlatform("darwin", library, "Logs", "Penglai", "0.5"),
+      cache: joinPlatform("darwin", library, "Caches", "Penglai", "0.5"),
+      updates: joinPlatform("darwin", library, "Caches", "Penglai", "0.5", "updates"),
+      im: joinPlatform("darwin", userData, "im"),
+      uninstall: joinPlatform("darwin", userData, "uninstall"),
       legacyCandidates: [
-        join(library, "Application Support", "Penglai", "penglai-v0.2.0-alpha.3"),
-        join(library, "Application Support", "com.penglai.agent"),
-        join(home, ".dsh"),
+        joinPlatform("darwin", library, "Application Support", "Penglai", "penglai-v0.2.0-alpha.3"),
+        joinPlatform("darwin", library, "Application Support", "com.penglai.agent"),
+        joinPlatform("darwin", home, ".dsh"),
       ],
     };
   }
-  const local = opts.localAppData ?? join(home, "AppData", "Local");
-  const userData = join(local, "Penglai", "0.5");
+  const local = opts.localAppData ?? joinPlatform("win32", home, "AppData", "Local");
+  const userData = joinPlatform("win32", local, "Penglai", "0.5");
   return {
     generationId: GENERATION_ID,
     userData,
-    dshHome: join(userData, "dsh-home"),
-    logs: join(userData, "logs"),
-    cache: join(userData, "cache"),
-    updates: join(userData, "updates"),
-    im: join(userData, "im"),
-    uninstall: join(userData, "uninstall"),
-    legacyCandidates: [join(local, "PenglaiAgent"), join(home, ".dsh")],
+    dshHome: joinPlatform("win32", userData, "dsh-home"),
+    logs: joinPlatform("win32", userData, "logs"),
+    cache: joinPlatform("win32", userData, "cache"),
+    updates: joinPlatform("win32", userData, "updates"),
+    im: joinPlatform("win32", userData, "im"),
+    uninstall: joinPlatform("win32", userData, "uninstall"),
+    legacyCandidates: [
+      joinPlatform("win32", local, "PenglaiAgent"),
+      joinPlatform("win32", home, ".dsh"),
+    ],
   };
 }
 

--- a/scripts/lib/dsh-closure.test.mjs
+++ b/scripts/lib/dsh-closure.test.mjs
@@ -178,6 +178,13 @@ test("linux-loong64 flatten omits unpublished require-builtin native and still r
 test("darwin flatten still embeds the published require-builtin native", () => {
   const work = mkdtempSync(join(tmpdir(), "penglai-dsh-required-int-"));
   writeClosureFixture(work);
+  const nativeName = "node-addon-require-builtin-darwin-arm64";
+  const nativeDir = join(work, "node_modules", nativeName);
+  mkdirSync(nativeDir, { recursive: true });
+  writeFileSync(
+    join(nativeDir, "package.json"),
+    JSON.stringify({ name: nativeName, version: "0.1.4" }),
+  );
   const dest = join(work, "dest");
   const flattened = materializeDshClosure(join(work, "package.json"), dest, "darwin-aarch64");
   assert.equal(flattened.native, "node-addon-require-builtin-darwin-arm64");


### PR DESCRIPTION
## Summary

Native Intel Mac and Windows unit gates on freeze SHA `98103ae5` failed:

- `R50-DIST-006` used host `path.join` for linux XDG paths (`\\home\\...` on Windows).
- `darwin flatten still embeds the published require-builtin native` required the ARM native in the host `node_modules`.

Layout joins now use the requested platform's separators. The darwin flatten test plants the native in the fixture.

Linux `.deb` packaging on `98103ae5` succeeded. Native run 34375138582 was cancelled so all four artifacts rebuild from one SHA.

## Test plan

- [x] foundation + dsh-closure unit tests
- [ ] Source CI
- [ ] After merge: one freeze SHA, re-dispatch `native-release-candidate.yml` `mode=native`