### PR TITLE
docs: publish verified 0.6.0 downloads and collector path

### DIFF
--- a/.github/workflows/native-release-candidate.yml
+++ b/.github/workflows/native-release-candidate.yml
@@ -489,11 +489,14 @@ jobs:
       - name: Collect only target-bound evidence
         shell: bash
         run: |
-          mkdir -p evidence/generated
+          mkdir -p evidence/generated dist
           find .native -type f \( -name '*-darwin-aarch64.json' -o -name '*-darwin-x86_64.json' -o -name '*-win32-x86_64.json' -o -name '*-linux-loong64.json' \) -exec cp {} evidence/generated/ \;
-          mkdir -p dist
-          test -s .native/linux-loong64/Penglai_0.6.0_uos_loong64.deb
-          cp .native/linux-loong64/Penglai_0.6.0_uos_loong64.deb dist/
+          # Target uploads preserve a dist/ prefix. Collect the .deb from anywhere
+          # under the linux-loong64 artifact rather than requiring a flattened name.
+          deb=$(find .native/linux-loong64 -type f -name 'Penglai_0.6.0_uos_loong64.deb' | head -n 1)
+          test -n "$deb"
+          test -s "$deb"
+          cp "$deb" dist/Penglai_0.6.0_uos_loong64.deb
       - name: Verify complete native evidence set
         run: |
           pnpm verify:native-set -- --command verify:closure

--- a/README.md
+++ b/README.md
@@ -1,50 +1,32 @@
 <p align="center">
-  <img src="website/shots/banner-v1.png" width="100%" alt="Penglai, an island rising from cloud and ink">
+  <img src="website/art/readme-mark.svg" width="100%" alt="Penglai: official DeepSeek Harness, on your computer">
 </p>
 
 # Penglai · 蓬莱
 
-DeepSeek Harness, ready to live on a personal computer.
+Official DeepSeek Harness, installed on a personal computer.
 
-[English](#english) · [中文](#中文) · [Website](https://penglai.pages.dev) · [中文网站](https://penglai.pages.dev/zh/) · [Download 0.5.12](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12) · [Security](SECURITY.md)
+[English](#english) · [中文](#中文) · [Website](https://penglai.pages.dev) · [中文网站](https://penglai.pages.dev/zh/) · [Security](SECURITY.md)
 
-The current public product is **Penglai 0.5.12**, an immutable release built from
-`54a0ef30afa4e3d653e400a637d4aa8eb4abbb75`. It consumes official DeepSeek Harness
-`0.1.3-alpha.2` npm packages, reconciled to tag `dsh-v0.1.3-alpha.2` at
-`82a5fd61a7cf5c293cec4bdff68f455398d685e9`. All 263 package archives, registry
-signatures and pinned source manifests were verified. macOS is ad-hoc signed and
-not notarized; Windows has no Authenticode.
-[Release notes](docs/RELEASE_NOTES_0.5.12.md) ·
-[Verified publication](docs/PUBLICATION_MANIFEST_0.5.12.md)
+**Penglai 0.6.0** puts official DeepSeek Harness `0.1.5-alpha.1` (tag `dsh-v0.1.5-alpha.1`, commit `5dda764ed3aa172535a7967b06ff95d9cbfe536a`, 272 npm packages) on Apple Silicon, Intel Mac, Windows x64, and UnionTech UOS 20 LoongArch. DSH remains the only agent core. Office and Memory start on.
 
-Published v0.5.10 and v0.5.11 tags and assets remain immutable. Public 0.5.12
-ships Mnemon `0.2.8` and was built with Node `22.23.2`. Source tests are not
-live-account evidence.
+The last immutable public installers are [v0.5.12](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12). The [v0.6.0](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0) GitHub Release is the download source for this version once those bytes exist and are read back. Published v0.5.10, v0.5.11, and v0.5.12 tags stay immutable.
+[Release notes](docs/RELEASE_NOTES_0.6.0.md)
 
 <p align="center">
-  <img src="website/shots/0.5.5/plugin-center.png" width="48%" alt="Penglai 0.5.5 Plugin Center in the installed DSH settings">
-  <img src="website/shots/0.5.5/memory.png" width="48%" alt="Penglai Memory in the installed DSH settings">
+  <img src="website/shots/0.5.5/welcome.png" width="78%" alt="Penglai first-run welcome: language, appearance, and a seven-step guide">
 </p>
-<p align="center"><sub>Installed 0.5.5 screens kept as UI references. They are not 0.5.12 screenshots; native 0.5.12 evidence lives in the publication manifest.</sub></p>
+<p align="center"><sub>Installed 0.5.5 first-run welcome, kept as a UI reference. Not a 0.6.0 screenshot.</sub></p>
 
 <a id="english"></a>
 
 # English
 
-## Penglai in one minute
+## What it is
 
-Penglai is a desktop distribution of
-[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness). It puts a
-fixed DSH build, Node, Electron, the official DSH conversation interface, a
-first-run guide, updates, local data controls, and a reviewed set of DSH plugins
-into one installable application.
+Penglai is a desktop distribution of [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness). It puts a fixed DSH build, Node, Electron, the official conversation interface, a first-run guide, updates, local data controls, and a reviewed set of DSH plugins into one installable application.
 
-DSH remains the only agent core. It owns the agent loop, models, tools,
-approvals, Workspace, Session, Turn, and the conversation interface. Penglai
-does the less glamorous work that decides whether a desktop product is actually
-usable: packaging, process supervision, onboarding, local paths, upgrades,
-uninstall, product identity, and plugin distribution. There is no second Penglai
-agent hiding beside DSH, and no replacement chat page.
+DSH owns the agent loop, models, tools, approvals, Workspace, Session, Turn, and the conversation. Penglai owns packaging, process supervision, onboarding, local paths, upgrades, uninstall, product identity, and plugin distribution. There is no second Penglai agent, and no replacement chat page.
 
 ```
 You
@@ -52,288 +34,85 @@ You
        → DeepSeek Harness (models, tools, Workspace, Session, conversation)
 ```
 
-Version 0.5.12 keeps that official Session snapshot path and adds isolation,
-recovery, Memory library, official IM question/approval identity, bounded PDF
-inspect, and redacted Plugin Center diagnostics. Upgrades from 0.5.8, 0.5.9,
-0.5.10 and 0.5.11 use an isolated DSH Home and preserve the previous generation
-for rollback. All three native installers pass credential-free onboarding and plugin
-checks, the four pinned upgrade paths, and default uninstall with user data
-preserved.
+## A day with it
 
-## A day with Penglai
+1. Install the matching Apple Silicon, Intel Mac, Windows x64, or UnionTech UOS 20 LoongArch package.
+2. Finish seven first-run steps until a real model reply arrives. Back, retry, and restart-resume are supported. A failed API key is never recorded as success.
+3. Work in an official Workspace. Office can inspect and edit documents after an action-specific confirmation. Memory may keep safe facts for *this* Workspace only.
+4. Optionally bind Weixin, Feishu, or another supported channel; optionally install local speech models. Ordinary conversation must still work if those plugins are off, offline, or missing weights.
+5. When a signed desktop update appears, you choose to install it. Updates are never silent.
 
-1. Install the matching Apple Silicon, Intel Mac, or Windows x64 package.
-2. Finish seven first-run steps until a real model reply arrives. Back, retry,
-   and restart-resume are supported. A failed API key is never recorded as
-   success.
-3. Work in an official Workspace. Office can inspect and edit documents after
-   an action-specific confirmation. Memory may keep safe facts for *this*
-   Workspace only.
-4. Optionally bind Weixin, Feishu, or another supported channel; optionally
-   install local speech models. Ordinary conversation must still work if those
-   plugins are off, offline, or missing weights.
-5. When a signed desktop update appears, you choose to install it. Updates are
-   never silent.
-
-<p align="center">
-  <img src="website/shots/0.5.5/welcome.png" width="72%" alt="Penglai 0.5.5 first-run welcome step">
-</p>
-<p align="center"><sub>First-run welcome from the 0.5.5 installed UI reference.</sub></p>
-
-## What ships in 0.5.12
+## What starts on
 
 | Product surface | Fresh install | What it does |
 | --- | --- | --- |
 | Penglai Office | On | Inspect, create, edit, preview, and save DOCX, XLSX, PPTX, and PDF |
 | Penglai Memory | On | Automatic current-Workspace memory, explicit personal memory, authorised sources, provenance, and a knowledge graph |
-| Mobile Messaging | Off | Eight platform connectors under one IM control plane; WhatsApp is not exposed or supported in 0.5.12 |
+| Mobile Messaging | Off | Eight platform connectors under one IM control plane; WhatsApp is not a product surface |
 | Speech Recognition | Off | Local SenseVoice transcription; enabling it adds the conversation microphone entry |
 | Voice Generation | Off | Local MOSS-TTS-Nano preview, desktop playback, and supported channel audio |
 | Companion | Off | Opt-in scheduled contact with quiet hours, daily limits, and a bound IM route |
 
-The settings page is deliberately simple. Ordinary users see install/enable or
-disable. Detailed hashes, loader phases, permissions, rollback, and diagnostics
-are still available, but they no longer dominate the normal path.
+Settings stay simple: install and enable, or disable. Hashes, loader phases, permissions, rollback, and diagnostics remain available without dominating the normal path.
 
 <p align="center">
-  <img src="website/shots/0.5.5/office.png" width="32%" alt="Penglai Office settings">
-  <img src="website/shots/0.5.5/mobile-messaging.png" width="32%" alt="Penglai Mobile Messaging settings">
-  <img src="website/shots/0.5.5/speech-recognition.png" width="32%" alt="Penglai local speech recognition settings">
+  <img src="website/shots/0.5.5/plugin-center.png" width="48%" alt="Penglai Plugin Center in official DSH settings">
+  <img src="website/shots/0.5.5/office.png" width="48%" alt="Penglai Office create, inspect, and planned-edit controls">
 </p>
+<p align="center"><sub>Installed 0.5.5 Plugin Center and Office, kept as UI references. UI state is never proof of installation or health.</sub></p>
 
-### Why the installer contains nine plugin packages
+Office writes use host-issued `artifact:<uuid>` handles and wait for a confirmation bound to that action. Memory recall never searches another Workspace. Candidate curation is a model call to the provider you selected; storage and recall stay local. Mnemon `0.2.8` is bundled. Large SenseVoice and MOSS-TTS weights download only after an explicit action.
 
-The package builder emits nine first-party code archives. That does not mean a
-new user must make nine downloads.
+## Download
 
-| Package | Role in the product |
+Use the matching file. Do not mix platforms.
+
+| Computer | Installer |
 | --- | --- |
-| `@penglai/plugin-center` | Required system surface for actual DSH loader state and signed catalog updates |
-| `@penglai/im` | User-facing Mobile Messaging |
-| `@penglai/plugin-reference` | Hidden conformance fixture used to test the plugin lifecycle; never shown as a product |
-| `@penglai/asr` | User-facing local speech recognition |
-| `@penglai/moss-tts` | User-facing local voice generation |
-| `@penglai/memory` | Required Penglai Memory, including authorised local sources |
-| `@penglai/office` | Required Penglai Office |
-| `@penglai/budget` | Hidden advanced token-budget control |
-| `@penglai/companion` | User-facing proactive companion |
+| Apple Silicon, macOS 13+ | [Penglai_0.6.0_macos_aarch64.dmg](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_aarch64.dmg) |
+| Intel Mac, macOS 13+ | [Penglai_0.6.0_macos_x64.dmg](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_x64.dmg) |
+| Windows 10+ x64 | [Penglai_0.6.0_windows_x64_setup.exe](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_windows_x64_setup.exe) |
+| UnionTech UOS 20 LoongArch | [Penglai_0.6.0_uos_loong64.deb](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_uos_loong64.deb) |
 
-All nine code packages are already inside each desktop installer. Office,
-Memory, and Plugin Center are activated for a fresh profile. Optional packages
-are copied from those verified bundled bytes when the user enables them. The
-large SenseVoice and MOSS-TTS model weights are the exception: they download
-only after an explicit action, from pinned revisions with size and SHA-256
-checks. Mnemon and the Office Chinese font are already bundled. LibreOffice is
-neither a product runtime dependency nor a release-gate dependency.
+After the [v0.6.0](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0) Release is public, check the downloaded file against `SHA256SUMS` on that page. GitHub Releases is the authoritative source. Linux amd64 and Windows ARM are not targets. Native UOS install, startup, and function are Owner-tested after publication. That UOS runtime is Loongson Electron 31.7.7 (Chromium 126), not the Mac/Windows Electron 43 train.
 
-## Office that can do work, not just read files
+## Quick start
 
-The old remote Office Reader has been retired. Penglai Office is a required DSH
-plugin with a closed set of typed operations. It can inspect and create office
-files, build a visible edit plan, preview the result, commit after the required
-confirmation, and undo the last committed change. It covers DOCX, XLSX, PPTX,
-and PDF, includes templates, and bundles an OFL Chinese font for PDF output.
+```
+Install the matching package
+  → finish the seven-step wizard (a real model reply)
+      → work in an official Workspace
+          → enable messaging, voice, or Companion only if you need them
+```
 
-Models do not get to invent arbitrary paths or run macros. Source and output
-handles are issued by the host, Workspace boundaries are checked again at the
-operation, and a write or export is not accepted merely because a model asked
-for it. The exact capability matrix and remaining format limits live in
-[the Office capability matrix](docs/0.5.5/OFFICE_CAPABILITY_MATRIX.md).
-
-## Memory that knows which project it belongs to
-
-Penglai Memory stores and recalls records locally and is enabled by default.
-Mnemon 0.2.8 is its only recall engine. The fresh mode intelligently organizes
-safe project facts inside the current official Workspace. A separate no-tools
-official Agent uses the current provider/model after a Turn, so that curation
-request is a model call to the provider rather than an offline-only step. The
-host validates a closed output schema and skips secrets, sensitive content,
-injection-like text, and malformed output. Before a later model step, confirmed
-current-Workspace records and explicitly accepted personal facts can be
-recalled. Workspace A cannot recall Workspace B.
-
-Users can turn memory off or review candidates first. Personal/global memory,
-forgetting, correction, source revocation, import, and reusable SOP changes keep
-a visible action-specific Owner confirmation. The model cannot promote itself
-to personal memory merely by assigning a high confidence score.
-
-Explicitly authorised folders are indexed as sources without changing the
-original files. Search results retain provenance. Revoking a source removes the
-derived index and leaves the source untouched. The graph is a view of these
-records and links, not a second database and not a cloud account.
+Upgrade with the same-platform installer as a manual overlay. Default uninstall removes the application and cache while preserving user data. External Workspaces and the `Penglai/0.5` data generation remain.
 
 <p align="center">
-  <img src="website/shots/0.5.5/companion.png" width="48%" alt="Penglai Companion quiet hours and permission controls">
-  <img src="website/shots/0.5.5/speech-synthesis.png" width="48%" alt="Penglai local voice generation settings">
+  <img src="website/shots/0.5.5/memory.png" width="48%" alt="Penglai Memory Workspace scope and correction">
+  <img src="website/shots/0.5.5/privacy.png" width="48%" alt="Penglai first-run privacy step">
 </p>
+<p align="center"><sub>0.5.5 Memory settings and first-run privacy step. Model calls still send task context to the provider you selected.</sub></p>
 
-## Messaging and local voice
+## Boundaries
 
-One Messaging plugin exposes eight connection entries: Weixin, Feishu, DingTalk,
-WeCom, QQ, Slack, Telegram, and Discord. Text and supported images, files, and
-voice for a live adapter arrive in the bound official DSH Session. Images use
-the official DSH image store. Office files and audio use scoped opaque
-`artifact:<uuid>` references. A mocked webhook is never live evidence.
+- There is no Penglai account, Penglai-operated telemetry backend, or cloud memory sync. Official DSH bundles a dormant DeepSeek OTLP endpoint; Penglai hard-disables it. Model calls still send the context required for a task to the provider you selected.
+- Credentials are stored in app-private YAML through official DSH. That is not Keychain or hardware isolation.
+- macOS is ad-hoc signed and **not notarized**. Windows has **no Authenticode**. Do not disable system security to install.
+- Plugins share the local DSH process. Install only reviewed catalog entries and read their permissions.
+- UOS 20 LoongArch is the fourth packaged target. Native function on that host is not claimed as already tested.
+- Source tests, packaged tests, native installed tests, and live external-account tests are reported separately.
 
-Slack, Telegram, and Discord use official token or manifest flows and do not
-fake QR. QQ is official Bot QR, not personal QQ login. WhatsApp is not a 0.5.12
-product surface: it is not displayed, supported, planned, or bundled.
+## Further reading
 
-SenseVoice and MOSS-TTS stay off until requested because their model files are
-large. Once Speech Recognition is enabled and its model is installed, Penglai
-can expose microphone input in the desktop conversation. Voice Generation can
-preview locally and can send audio only through adapters that genuinely support
-it. Neither plugin is allowed to stop ordinary DSH chat when it is disabled,
-offline, or missing weights.
-
-## A Plugin Center that can outlive a desktop release
-
-Penglai Plugin Center reads versioned, immutable GitHub Releases from the public
-[Penglai Plugin Registry](https://github.com/kevinchennewbee/PenglaiPluginRegistry).
-It verifies the catalog signature, archive identity, SHA-256, DSH compatibility,
-platform, and declared permissions before staging a package. Activation is a
-separate step and failed activation rolls back.
-
-This is why a reviewed DSH `0.1.3-alpha.2`-compatible plugin can join later without
-publishing a new desktop version merely to change a list. The catalog is still
-fail-closed: arbitrary npm names, Git repositories, and download URLs are not
-accepted. A DSH plugin shares the local DSH process permissions; the permission
-list explains review and consent, but it is not an operating-system sandbox.
-
-Reviewed plugin cards may expose signed HTTPS repository, documentation, and
-issue links. Electron Main validates the destination, shows it to the user, and
-opens it externally only after confirmation.
-
-## First run, installation, upgrade, and recovery
-
-The seven-step guide covers language, privacy, the official model catalog,
-credential testing, an official Workspace, and the first real DSH Turn. It can
-go Back, retry a failed credential, resume after restart, and reject the app's
-own data or installation directory as a Workspace. Finishing the wizard means a
-real model reply was received, not merely that a health endpoint answered.
-
-Use the Apple Silicon DMG, Intel Mac DMG, or Windows x64 installer. Do not mix
-them. Upgrade with the same-platform installer as a manual overlay. There is no
-silent update. External Workspaces and the `Penglai/0.5` data generation are
-preserved. Default uninstall removes the application and cache while preserving
-user data.
-
-The immutable [0.5.12 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12)
-contains exactly ten files: three native installers and seven integrity and
-license files. All installers were built from the same source SHA `54a0ef30afa4e3d653e400a637d4aa8eb4abbb75` and passed
-[native installed-product gates](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34293608792)
-and public download readback.
-
-### Apple Silicon, macOS 13+
-
-[`Penglai_0.5.12_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_aarch64.dmg)
-
-284,207,080 bytes · SHA-256 `1f6d7f9ceab13c62a6e31d52a0517c4972a52378e5ce102bf2983f3c32fd8034`
-
-### Intel Mac, macOS 13+
-
-[`Penglai_0.5.12_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_x64.dmg)
-
-293,808,479 bytes · SHA-256 `f82a5d44bccb7d15def176602f8320d1464eae802897e41c5ec39c8d471d61c3`
-
-### Windows 10+ x64
-
-[`Penglai_0.5.12_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_windows_x64_setup.exe)
-
-371,054,561 bytes · SHA-256 `5d926a884ca2b93c43f8ee8d8e8897df636585d449f1810d25ab4bffae3159da`
-
-Check the downloaded installer against `SHA256SUMS` before running it. The
-Beijing mirror has not published 0.5.12; GitHub Releases is the authoritative
-public source.
-
-## Privacy
-
-- There is no Penglai account, Penglai-operated telemetry backend, or cloud
-  memory sync. Official DSH bundles a session-telemetry adapter and a dormant
-  DeepSeek OTLP endpoint, but Penglai's owned DSH process hard-disables the row
-  after profile patches. In that state DSH constructs no SDK provider or upload
-  pipeline.
-- Users bring their own model provider credentials. Official DSH writes them to
-  app-private YAML; this is not Keychain or hardware isolation.
-- Model calls still send the context required for a task to the provider you
-  selected.
-- Diagnostics and evidence exclude secrets, QR data, chat bodies, account
-  identities, private paths, memory bodies, transcripts, and private media.
-
-<p align="center">
-  <img src="website/shots/0.5.5/privacy.png" width="72%" alt="Penglai 0.5.5 local data and privacy step">
-</p>
-<p align="center"><sub>0.5.5 first-run privacy step, kept as a UI reference. Not a 0.5.11 or 0.5.12 screenshot.</sub></p>
-
-See [Security](SECURITY.md), [Product and data contract](docs/PRODUCT.md),
-[Architecture](docs/ARCHITECTURE.md), and [Plugin Center](docs/PLUGIN_CENTER.md)
-for the full boundary.
-
-## FAQ
-
-**Is Penglai another agent?**
-No. Official DeepSeek Harness is the only core. Penglai owns install, lifecycle,
-and first-party plugins.
-
-**Which version should I download?**
-The public installers are 0.5.12. Published 0.5.10 and 0.5.11 remain immutable.
-
-**Why does Gatekeeper or SmartScreen warn?**
-macOS packages are ad-hoc signed and not notarized. Windows packages do not have
-Authenticode. That is a stated limitation, not an OS endorsement. Do not disable
-system security to install.
-
-**Are Office and Memory on by default?**
-Yes. Messaging, speech recognition, voice generation, and Companion stay off
-until you enable them.
-
-**Can memory from one Workspace leak into another?**
-No. Recall never searches or selects another Workspace implicitly.
-
-**What if the API key test fails?**
-Go Back, enter the key again, or resume after restart. A failed test is not
-treated as success.
-
-**Does uninstall delete my work files?**
-Default uninstall keeps user data. Complete delete is a separate, category-bound
-action and must not recursively wipe a Workspace or home directory.
-
-## Honest limits
-
-- macOS is ad-hoc signed and **not notarized**. Windows has **no Authenticode**.
-- Penglai Ed25519 signatures protect updater and plugin bytes. They do not
-  provide Apple or Microsoft publisher identity.
-- Plugins run beside DSH and share that local process. Install only reviewed
-  catalog entries and read their permissions.
-- Source tests, packaged tests, native installed tests, and live
-  external-account tests are reported separately. One never substitutes for
-  another.
-- External model calls and Owner-account messaging journeys are recorded only
-  when actually run. Credential-free installed checks do not establish a real
-  provider reply or message delivery.
-- UOS/LoongArch is not a release target.
+[Product](docs/PRODUCT.md) · [Architecture](docs/ARCHITECTURE.md) · [Plugin Center](docs/PLUGIN_CENTER.md) · [Security](SECURITY.md) · [0.6.0 notes](docs/RELEASE_NOTES_0.6.0.md) · [Acceptance delta](docs/0.6.0/ACCEPTANCE_DELTA.md)
 
 ## Why it is called Penglai
 
-The name comes from the Eight Immortals crossing the sea, each relying on a
-different skill. Models, messaging, local voice, office work, and memory have
-different jobs too, but they meet around one DSH core.
+The name comes from the Eight Immortals crossing the sea, each relying on a different skill. Models, messaging, local voice, office work, and memory have different jobs too, but they meet around one DSH core.
 
-I spent more than ten years around networking, security, and operations. I was
-not a software developer when this project began. What bothered me was not a
-lack of powerful agents. It was the amount of software knowledge an ordinary
-person had to learn before one of those agents became useful.
+I spent more than ten years around networking, security, and operations. I was not a software developer when this project began. What bothered me was not a lack of powerful agents. It was the amount of software knowledge an ordinary person had to learn before one of those agents became useful.
 
-Computers travelled from command lines to windows and then into everyone's
-pocket. Agents should make the same trip. If I can send a message, I should be
-able to reach my own assistant. If it acts for me, I should be able to see what
-it was allowed to do, what actually happened, and what it cost.
-
-Penglai has been rebuilt more than once. Version 0.5 is the clearest decision so
-far: stop building another agent and make the good open-source core easier to
-install, understand, extend, and trust. The older generations remain in Git
-history because they explain the road here; their runtimes are not mixed into
-0.5.
+Penglai has been rebuilt more than once. Version 0.5 was the clear decision: stop building another agent and make the good open-source core easier to install, understand, extend, and trust. 0.6.0 keeps that decision and puts the same product on four computers.
 
 ## Build, contribute, and AI-assisted work
 
@@ -353,56 +132,21 @@ pnpm verify:dependencies
 pnpm audit:secrets
 ```
 
-Native package commands must run on their matching host. A successful
-cross-build is not native installed evidence. Start with
-[CONTRIBUTING.md](CONTRIBUTING.md), and if an AI coding tool is working in the
-repository, give it [AGENTS.md](AGENTS.md) first.
+Native package commands must run on their matching host. Start with [CONTRIBUTING.md](CONTRIBUTING.md). If an AI coding tool is working in the repository, give it [AGENTS.md](AGENTS.md) first.
 
-Penglai is created and maintained by
-[Kevin Chen / 陈克文](https://github.com/kevinchennewbee). Kimi Work, Grok Build,
-Cursor Agent, Claude Code, and OpenAI Codex have all contributed implementation,
-research, review, or release work. Those credits record real collaboration;
-product direction, authorship, acceptance, and release responsibility remain
-human.
+Penglai is created and maintained by [Kevin Chen / 陈克文](https://github.com/kevinchennewbee). Kimi Work, Grok Build, Cursor Agent, Claude Code, and OpenAI Codex have all contributed implementation, research, review, or release work. Those credits record real collaboration; product direction, authorship, acceptance, and release responsibility remain human.
 
-The project stands on the work of
-[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness),
-[Electron](https://github.com/electron/electron),
-[Node.js](https://github.com/nodejs/node),
-[TypeScript](https://github.com/microsoft/TypeScript),
-[pnpm](https://github.com/pnpm/pnpm),
-[SenseVoice](https://github.com/FunAudioLLM/SenseVoice),
-[sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx),
-[MOSS-TTS-Nano](https://github.com/OpenMOSS/MOSS-TTS-Nano),
-[Mnemon](https://github.com/mnemon-dev/mnemon),
-[Lark Node SDK](https://github.com/larksuite/node-sdk), and
-[Tencent openclaw-weixin](https://github.com/Tencent/openclaw-weixin).
-Special thanks also go to [DSH-IM](https://github.com/xmanrui/dsh-im) for
-channel transport and messaging-UX references, and to
-[qqbot-agent-sdk](https://github.com/tencent-connect/qqbot-agent-sdk) for the
-official QQ Bot onboarding reference. Penglai selectively rewrites those ideas
-inside its own IM control plane; neither upstream runtime is bundled. Office
-generation builds on [PPTFast](https://github.com/liustack/pptfast),
-[ExcelJS](https://github.com/exceljs/exceljs),
-[pdf-lib](https://github.com/Hopding/pdf-lib), and
-[Noto CJK](https://github.com/notofonts/noto-cjk).
-Every dependency keeps its own license. Release packages include the exact SBOM
-and third-party notices.
+The project stands on [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness), [Electron](https://github.com/electron/electron), [Node.js](https://github.com/nodejs/node), [TypeScript](https://github.com/microsoft/TypeScript), [pnpm](https://github.com/pnpm/pnpm), [SenseVoice](https://github.com/FunAudioLLM/SenseVoice), [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx), [MOSS-TTS-Nano](https://github.com/OpenMOSS/MOSS-TTS-Nano), [Mnemon](https://github.com/mnemon-dev/mnemon), [Lark Node SDK](https://github.com/larksuite/node-sdk), and [Tencent openclaw-weixin](https://github.com/Tencent/openclaw-weixin). Thanks also to [DSH-IM](https://github.com/xmanrui/dsh-im) and [qqbot-agent-sdk](https://github.com/tencent-connect/qqbot-agent-sdk) for references that Penglai rewrites inside its own IM control plane; neither upstream runtime is bundled. Office generation builds on [PPTFast](https://github.com/liustack/pptfast), [ExcelJS](https://github.com/exceljs/exceljs), [pdf-lib](https://github.com/Hopding/pdf-lib), and [Noto CJK](https://github.com/notofonts/noto-cjk). Every dependency keeps its own license.
 
 <a id="中文"></a>
 
 # 中文
 
-## 一分钟认识蓬莱
+## 它是什么
 
-蓬莱是 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
-的桌面发行版。它把固定版本的 DSH、Node、Electron、官方 DSH 会话界面、首次引导、
-升级、本地数据管理和一组经过审核的 DSH 插件，装进一个普通人可以安装的客户端。
+蓬莱是 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 的桌面发行版。它把固定版本的 DSH、Node、Electron、官方会话界面、首次引导、升级、本地数据管理和一组经过审核的 DSH 插件，装进一个可以安装的客户端。
 
-DSH 始终是唯一的 Agent 核心。Agent loop、模型、工具、审批、Workspace、Session、
-Turn 和会话界面都归 DSH。蓬莱负责那些不太耀眼、却决定桌面产品能不能交给用户的
-事情：打包、进程监管、安装引导、本地目录、升级、卸载、产品身份和插件分发。这里
-没有藏着第二套蓬莱 Agent，也没有另做一张聊天页替代 DSH。
+DSH 始终是唯一的 Agent 核心。Agent loop、模型、工具、审批、Workspace、Session、Turn 和会话界面都归 DSH。蓬莱负责打包、进程监管、安装引导、本地目录、升级、卸载、产品身份和插件分发。这里没有第二套蓬莱 Agent，也没有另做一张聊天页。
 
 ```
 你
@@ -410,242 +154,81 @@ Turn 和会话界面都归 DSH。蓬莱负责那些不太耀眼、却决定桌�
        → DeepSeek Harness（模型、工具、Workspace、Session、会话）
 ```
 
-0.5.12 使用未经修改的官方 DSH `0.1.3-alpha.2` npm 包，并补上隔离、恢复、
-记忆库、官方 IM 提问/审批身份、有界 PDF 检查和脱敏插件诊断。从 0.5.8、0.5.9、
-0.5.10 和 0.5.11 升级时使用独立的数据目录，保留旧代际用于回退。三端安装包均
-通过无需真实账号的引导和插件检查、四条升级路径，以及默认保留用户数据的卸载
-验证。公开的 0.5.12 使用 Mnemon `0.2.8` 与 Node `22.23.2`。已发布的 0.5.10 与
-0.5.11 标签与附件仍不可变。中文网站在
-[penglai.pages.dev/zh](https://penglai.pages.dev/zh/)，英文默认首页在
-[penglai.pages.dev](https://penglai.pages.dev/)。
+**Penglai 0.6.0** 使用官方 DeepSeek Harness `0.1.5-alpha.1`（tag `dsh-v0.1.5-alpha.1`，commit `5dda764ed3aa172535a7967b06ff95d9cbfe536a`，272 包）。办公和记忆默认开启。四个安装包面向 Apple 芯片、Intel Mac、Windows x64 和统信 UOS 20 龙芯。最近的不可变公开安装包仍是 [v0.5.12](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12)。[v0.6.0](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0) 才是本版本的权威下载源，前提是那些字节已经存在并完成回读。
 
 ## 一次完整使用
 
-1. 下载对应芯片的安装包：Apple 芯片、Intel Mac 或 Windows x64，不要混用。
-2. 走完七步引导，直到模型真正回复。可以返回、重试、关掉窗口后续接。密钥失败
-   不会被记成成功。
-3. 在 official Workspace 里工作。办公写入需要与动作绑定的确认；记忆只整理
-   *当前* Workspace 的安全事实。
-4. 需要时再绑定微信、飞书或其他渠道，或下载本地语音模型。这些插件关闭、离线
-   或缺少模型时，普通会话仍应可用。
+1. 下载对应芯片的安装包：Apple 芯片、Intel Mac、Windows x64 或统信 UOS 20 龙芯，不要混用。
+2. 走完七步引导，直到模型真正回复。可以返回、重试、关掉窗口后续接。密钥失败不会被记成成功。
+3. 在 official Workspace 里工作。办公写入需要与动作绑定的确认；记忆只整理 *当前* Workspace 的安全事实。
+4. 需要时再绑定微信、飞书或其他渠道，或下载本地语音模型。这些插件关闭、离线或缺少模型时，普通会话仍应可用。
 5. 出现签名更新时由你确认安装，不会静默升级。
 
-<p align="center">
-  <img src="website/shots/0.5.5/welcome.png" width="72%" alt="蓬莱 0.5.5 首次引导欢迎页">
-</p>
-<p align="center"><sub>0.5.5 安装版首次引导欢迎页，作为界面参考。</sub></p>
-
-## 0.5.12 带来了什么
+## 默认开着什么
 
 | 产品功能 | 全新安装 | 能做什么 |
 | --- | --- | --- |
 | 蓬莱办公 | 默认启用 | 检查、创建、编辑、预览和保存 DOCX、XLSX、PPTX、PDF |
 | 蓬莱记忆 | 默认启用 | 当前 Workspace 自动记忆、明确个人记忆、授权资料、来源追溯和知识图谱 |
-| 消息连接 | 默认关闭 | 八个平台共用一个 IM 控制平面；0.5.12 不展示或支持 WhatsApp |
+| 消息连接 | 默认关闭 | 八个平台共用一个 IM 控制平面；WhatsApp 不是产品能力 |
 | 蓬莱语音识别 | 默认关闭 | 本地 SenseVoice 转写；启用后为电脑会话提供麦克风入口 |
 | 蓬莱语音生成 | 默认关闭 | 本地 MOSS-TTS-Nano 试听、电脑播放和支持渠道的语音输出 |
 | 蓬莱主动陪伴 | 默认关闭 | 安静时段、每日上限、指定 IM 路由下的主动联系 |
 
-普通用户在插件中心看到的是安装并启用，或者停用。摘要、Loader 阶段、权限、回滚
-和诊断仍然保留，但不再把正常操作淹没在一排技术按钮里。
+普通用户在插件中心看到的是安装并启用，或者停用。摘要、Loader 阶段、权限、回滚和诊断仍然保留，但不再淹没正常操作。
 
 <p align="center">
-  <img src="website/shots/0.5.5/office.png" width="32%" alt="蓬莱办公设置">
-  <img src="website/shots/0.5.5/mobile-messaging.png" width="32%" alt="蓬莱消息连接设置">
-  <img src="website/shots/0.5.5/speech-recognition.png" width="32%" alt="蓬莱本地语音识别设置">
+  <img src="website/shots/0.5.5/plugin-center.png" width="48%" alt="官方 DSH 设置里的蓬莱插件中心">
+  <img src="website/shots/0.5.5/office.png" alt="蓬莱办公的创建、查看和目标修改" width="48%">
 </p>
+<p align="center"><sub>0.5.5 安装版插件中心与办公界面，作为参考。界面状态不等于已安装或健康。</sub></p>
 
-### 为什么安装包里有 9 个插件包
+办公写入使用 Host 发出的 `artifact:<uuid>` 句柄，并等待与动作绑定的确认。记忆召回不会搜索另一个 Workspace。整理候选会调用你选择的模型供应商；记录与召回留在本机。Mnemon `0.2.8` 已随包。SenseVoice 和 MOSS-TTS 的大模型要你主动下载。
 
-构建程序会生成 9 个第一方代码包，但这不等于用户要下载 9 次。
+## 下载
 
-| 包 | 在产品里的作用 |
+请使用对应安装包，不要混用。
+
+| 电脑 | 安装包 |
 | --- | --- |
-| `@penglai/plugin-center` | 必需的系统插件，读取真实 DSH Loader 状态并更新签名目录 |
-| `@penglai/im` | 面向用户的消息连接 |
-| `@penglai/plugin-reference` | 隐藏的插件生命周期合规测试件，不会作为产品展示 |
-| `@penglai/asr` | 面向用户的本地语音识别 |
-| `@penglai/moss-tts` | 面向用户的本地语音生成 |
-| `@penglai/memory` | 必需的蓬莱记忆，已融合用户明确授权的本地资料 |
-| `@penglai/office` | 必需的蓬莱办公 |
-| `@penglai/budget` | 隐藏的高级 Token 预算控制 |
-| `@penglai/companion` | 面向用户的蓬莱主动陪伴 |
+| Apple 芯片，macOS 13+ | [Penglai_0.6.0_macos_aarch64.dmg](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_aarch64.dmg) |
+| Intel Mac，macOS 13+ | [Penglai_0.6.0_macos_x64.dmg](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_x64.dmg) |
+| Windows 10+ x64 | [Penglai_0.6.0_windows_x64_setup.exe](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_windows_x64_setup.exe) |
+| 统信 UOS 20 龙芯 | [Penglai_0.6.0_uos_loong64.deb](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_uos_loong64.deb) |
 
-这 9 个代码包都已经放在三个桌面安装包里。全新 profile 会启用插件中心、办公和记忆；
-用户启用可选插件时，客户端从安装包内经过验证的字节安装到 app-private DSH profile。
-唯一需要另行下载的是体积较大的 SenseVoice 和 MOSS-TTS 模型，而且必须由用户主动
-点击，下载时校验固定 revision、大小和 SHA-256。Mnemon 与办公中文字体已经随包。
-LibreOffice 既不是产品运行依赖，也不是正式发布门禁依赖。
+[v0.6.0](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0) 公开发布后，请用该页的 `SHA256SUMS` 核对下载文件。权威公开源是 GitHub Release。Linux amd64 与 Windows ARM 不是目标。UOS 上的安装、启动和功能由 Owner 在发布后测试。该端运行时是龙芯 Electron 31.7.7（Chromium 126），不是 Mac/Windows 的 Electron 43。
 
-## 蓬莱办公不是只读阅读器
+## 快速开始
 
-旧的远程办公阅读器已经退役。新的蓬莱办公是默认启用的 DSH 插件，提供一组封闭的
-typed operation：检查和创建文件、生成可见修改计划、预览、确认后提交，以及撤销
-上一笔提交。它覆盖 DOCX、XLSX、PPTX 和 PDF，包含模板，并为 PDF 输出内置 OFL
-中文字体。
+```
+安装对应安装包
+  → 走完七步引导（等到真实模型回复）
+      → 在 official Workspace 里工作
+          → 需要时再启用消息、语音或主动陪伴
+```
 
-模型不能自己编造任意路径，也不能运行宏。输入和输出都使用 Host 发出的句柄，
-每次操作重新检查 Workspace 边界，写入和导出不会因为模型说了一句请保存就自动
-发生。精确能力和格式限制见
-[蓬莱办公能力矩阵](docs/0.5.5/OFFICE_CAPABILITY_MATRIX.md)。
+升级使用同平台安装包手动覆盖。默认卸载去掉应用和缓存，保留用户数据。外部 Workspace 与 `Penglai/0.5` 数据代际会留下。
 
-## 蓬莱记忆知道自己属于哪个项目
+## 边界
 
-蓬莱记忆在本机保存和召回记录，并且默认启用。Mnemon 0.2.8 是唯一召回引擎。全新
-profile 会智能整理当前 official Workspace 的安全项目事实：Turn 结束后，一个禁用全部
-工具的 official Agent 沿用当前供应商和模型，因此“整理候选”本身会调用模型供应商，
-不是完全离线步骤。Host 再用封闭格式与本地策略过滤密钥、敏感内容、类似提示词注入和
-错误输出。后续步骤只召回当前 Workspace 已确认记录和用户明确保存的个人记忆；
-Workspace A 不能召回 Workspace B。
-
-用户可以关闭记忆，或者改成先看候选。个人/全局记忆、遗忘、更正、资料源撤销、导入
-和 SOP 仍需与动作绑定的可见 Owner 确认；模型不能靠自己给一个高置信度就升级为个人
-长期记忆。
-
-用户明确授权的文件夹会被索引为资料来源，原文件不会被修改。搜索结果保留来源，
-撤销授权只删除派生索引，不碰源文件。知识图谱只是这些记忆和关系的直观视图，不是
-第二个数据库，也不需要蓬莱云账号。
-
-<p align="center">
-  <img src="website/shots/0.5.5/companion.png" width="48%" alt="蓬莱主动陪伴的安静时段和权限设置">
-  <img src="website/shots/0.5.5/speech-synthesis.png" width="48%" alt="蓬莱本地语音生成设置">
-</p>
-
-## 手机消息和本地语音
-
-唯一的「消息连接」插件提供八个平台的连接入口：微信、飞书、钉钉、企业微信、
-QQ、Slack、Telegram、Discord。文字和受支持的图片、文件、语音进入绑定的 official DSH Session。
-图片走 official 图片存储；文件和音频走 `artifact:<uuid>`。
-
-Slack、Telegram、Discord 走官方 Token/Manifest，禁止伪装扫码。QQ 只做官方
-Bot 扫码，不模拟个人号。WhatsApp 不是 0.5.12 的产品能力：不展示、不支持、不列为
-规划，也不捆绑运行时。
-
-SenseVoice 和 MOSS-TTS 默认关闭，是因为模型文件较大。语音识别启用并下载模型后，
-电脑会话可以出现麦克风输入；语音生成可以在本机试听，也只会向真正支持音频的渠道
-发送。插件被停用、离线或没有模型时，普通 DSH 会话仍然必须可用。
-
-## 插件中心可以比桌面版本更新得更快
-
-蓬莱插件中心从公开的
-[Penglai Plugin Registry](https://github.com/kevinchennewbee/PenglaiPluginRegistry)
-读取带版本、不可变的 GitHub Release。安装前会校验目录签名、包身份、SHA-256、DSH
-兼容版本、平台和声明权限。下载与启用是两个阶段，启用失败会回滚。
-
-因此以后审核出一个优秀的 DSH `0.1.3-alpha.2` 兼容插件，可以只发布新一代签名目录，不必为了列表变化
-再打一个桌面客户端。它仍然是 fail-closed：任意 npm 包名、Git 仓库或下载地址都
-不会被接受。DSH 插件与本地 DSH 进程共享权限，权限列表用于审核和确认，不是操作
-系统沙箱。
-
-经过审核的插件卡可以显示签名 HTTPS 仓库、文档和 Issues 链接。Electron Main 校验
-目标、向用户展示地址，并且只有确认后才在外部打开。
-
-## 安装、升级与恢复
-
-七步引导覆盖语言、隐私、official 模型目录、密钥实测、official Workspace 和第一条
-真实 DSH Turn。它支持返回、密钥失败后重试、重启后续接，也会拒绝把应用数据目录
-或安装目录选作 Workspace。只有模型真的回复了，才算完成，不会拿健康接口冒充。
-
-请使用对应平台的安装包，不要混用。升级时使用同平台安装包手动覆盖。它不会静默
-升级；外部 Workspace 与 `Penglai/0.5` 数据代际会保留。默认卸载去掉应用和缓存，
-保留用户数据。
-
-不可变的 [0.5.12 Release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12)
-固定十项附件：三个原生安装包和七项完整性、签名与许可证材料。
-三个安装包来自同一源码提交 `54a0ef30afa4e3d653e400a637d4aa8eb4abbb75`，并已通过
-[三端原生安装门禁](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34293608792)
-和公网下载回读。
-
-### Apple 芯片，macOS 13+
-
-[`Penglai_0.5.12_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_aarch64.dmg)
-
-284,207,080 字节 · SHA-256 `1f6d7f9ceab13c62a6e31d52a0517c4972a52378e5ce102bf2983f3c32fd8034`
-
-### Intel Mac，macOS 13+
-
-[`Penglai_0.5.12_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_x64.dmg)
-
-293,808,479 字节 · SHA-256 `f82a5d44bccb7d15def176602f8320d1464eae802897e41c5ec39c8d471d61c3`
-
-### Windows 10+ x64
-
-[`Penglai_0.5.12_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_windows_x64_setup.exe)
-
-371,054,561 字节 · SHA-256 `5d926a884ca2b93c43f8ee8d8e8897df636585d449f1810d25ab4bffae3159da`
-
-运行前请用 `SHA256SUMS` 核对下载文件。北京镜像尚未发布 0.5.12；权威公开源是
-GitHub Release。
-
-## 隐私
-
-- 没有蓬莱账号、蓬莱运营的遥测后端或云端记忆同步。official DSH 自带的
-  session-telemetry adapter 也包含一个休眠的 DeepSeek OTLP 地址，但蓬莱启动的
-  DSH 会在所有 profile patch 之后硬性禁用该行；此状态下不会创建 SDK provider
-  或上传管线。
-- 用户自备模型供应商密钥。official DSH 把密钥写入 app-private YAML；这不是
-  Keychain 或硬件隔离。
-- 模型调用仍会把当前任务需要的内容发给你选择的供应商。
-- 诊断和证据不含密钥、二维码、聊天正文、账号身份、私人路径、记忆正文、转写和
-  私人媒体。
-
-<p align="center">
-  <img src="website/shots/0.5.5/privacy.png" width="72%" alt="蓬莱 0.5.5 本地数据与隐私说明">
-</p>
-<p align="center"><sub>0.5.5 首次引导中的隐私说明，作为界面参考。不是 0.5.11 或 0.5.12 截图。</sub></p>
-
-完整边界见 [安全说明](SECURITY.md)、[产品与数据契约](docs/PRODUCT.md)、
-[架构](docs/ARCHITECTURE.md) 和 [插件中心](docs/PLUGIN_CENTER.md)。
-
-## 常见问题
-
-**蓬莱是另一个 Agent 吗？**
-不是。官方 DeepSeek Harness 是唯一核心。蓬莱负责安装、生命周期和第一方插件。
-
-**现在该下载哪个版本？**
-公开安装包是 0.5.12。已发布的 0.5.10 与 0.5.11 仍不可变。
-
-**为什么 Gatekeeper 或 SmartScreen 会提示？**
-macOS 是 ad-hoc 签名、未公证；Windows 没有 Authenticode。这是已知限制，不是
-系统背书。请不要为了安装而关闭系统安全功能。
-
-**办公和记忆默认开着吗？**
-是。手机消息、语音识别、语音生成和主动陪伴默认关闭，需要时再开。
-
-**记忆会跨 Workspace 漏出去吗？**
-不会。召回不会隐式搜索或选择另一个 Workspace。
-
-**密钥测试失败怎么办？**
-可以返回、重试，或关掉窗口后续接。失败不会被当成成功。
-
-**卸载会删掉我的工作文件吗？**
-默认卸载保留用户数据。完整删除是单独的分类动作，不会递归清掉 Workspace 或主目录。
-
-## 需要读清楚的限制
-
-- macOS 是 ad-hoc 签名、**未公证**；Windows **没有 Authenticode**。
-- 蓬莱 Ed25519 签名保护升级和插件字节，但不能代替 Apple 或 Microsoft 发布者身份。
+- 没有蓬莱账号、蓬莱运营的遥测后端或云端记忆同步。官方 DSH 自带一个休眠的 DeepSeek OTLP 地址，蓬莱会硬性禁用。模型调用仍会把当前任务需要的内容发给你选择的供应商。
+- 密钥写在 official DSH 的 app-private YAML 里。这不是钥匙串或硬件隔离。
+- macOS 是 ad-hoc 签名、**未公证**；Windows **没有 Authenticode**。请不要为了安装而关闭系统安全功能。
 - 插件和 DSH 在同一本地进程中运行，只应安装经过审核的目录条目并阅读权限。
-- 源码测试、打包测试、原生安装测试、真实外部账号测试分别记录，不能互相冒充。
-- 真实模型调用与 Owner 账号消息旅程仅记录实际执行结果；无凭据安装检查不能证明
-  真实模型回复或消息送达。
-- UOS/LoongArch 不是发布目标。
+- 统信 UOS 20 龙芯是第四个打包目标。该机上的功能验收尚未作为已完成事实声明。
+- 源码测试、打包测试、原生安装测试、真实外部账号测试分别记录。
+
+## 继续阅读
+
+[产品契约](docs/PRODUCT.md) · [架构](docs/ARCHITECTURE.md) · [插件中心](docs/PLUGIN_CENTER.md) · [安全说明](SECURITY.md) · [0.6.0 说明](docs/RELEASE_NOTES_0.6.0.md) · [验收增量](docs/0.6.0/ACCEPTANCE_DELTA.md)
 
 ## 为什么叫蓬莱
 
-蓬莱这个名字借的是八仙过海的故事。模型、手机消息、本地语音、办公和记忆各有本领，
-但最后都围绕同一个 DSH 核心协作。
+蓬莱这个名字借的是八仙过海的故事。模型、手机消息、本地语音、办公和记忆各有本领，但最后都围绕同一个 DSH 核心协作。
 
-我做了十多年网络、安全和运维，开始做这个项目时并不会写软件。真正让我难受的，
-不是没有强大的 Agent，而是普通人要先学会太多软件知识，才能让这些 Agent 有用。
+我做了十多年网络、安全和运维，开始做这个项目时并不会写软件。真正让我难受的，不是没有强大的 Agent，而是普通人要先学会太多软件知识，才能让这些 Agent 有用。
 
-计算机从命令行走进窗口，又走进每个人的口袋。Agent 也应该走完这段路。只要我能
-发一条消息，就应该能找到自己的助理；它替我做事时，我也应该看得见它得到了什么
-权限、究竟做了什么、花了多少成本。
-
-蓬莱重做过不止一次。0.5 是到目前为止最明确的一次选择：不再造另一个 Agent，而是
-把优秀的开源核心变得更容易安装、理解、扩展和信任。旧版本留在 Git 历史里，因为
-它们解释了这条路是怎么走来的；旧运行时不会混进 0.5。
+蓬莱重做过不止一次。0.5 是到目前为止最明确的一次选择：不再造另一个 Agent，而是把优秀的开源核心变得更容易安装、理解、扩展和信任。0.6.0 把这件事做到四台电脑上。
 
 ## 构建、贡献与 AI 协作
 
@@ -665,14 +248,9 @@ pnpm verify:dependencies
 pnpm audit:secrets
 ```
 
-三个原生打包命令必须在对应平台运行，macOS 上交叉生成 Windows payload 不能算
-Windows 真机安装证据。普通贡献者从 [CONTRIBUTING.md](CONTRIBUTING.md) 开始；
-如果让 AI 编程工具进入仓库，请先把 [AGENTS.md](AGENTS.md) 交给它。
+原生打包命令必须在对应平台运行。普通贡献者从 [CONTRIBUTING.md](CONTRIBUTING.md) 开始；如果让 AI 编程工具进入仓库，请先把 [AGENTS.md](AGENTS.md) 交给它。
 
-蓬莱由 [Kevin Chen / 陈克文](https://github.com/kevinchennewbee) 创建并维护。
-Kimi Work、Grok Build、Cursor Agent、Claude Code 和 OpenAI Codex 都参与过实现、
-调研、审查或发布工作。这些署名记录真实协作，但产品方向、作者身份、验收和发布
-责任仍然属于人。
+蓬莱由 [Kevin Chen / 陈克文](https://github.com/kevinchennewbee) 创建并维护。Kimi Work、Grok Build、Cursor Agent、Claude Code 和 OpenAI Codex 都参与过实现、调研、审查或发布工作。这些署名记录真实协作，但产品方向、作者身份、验收和发布责任仍然属于人。
 
 蓬莱站在这些开源项目的肩膀上：
 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)、
@@ -686,12 +264,9 @@ Kimi Work、Grok Build、Cursor Agent、Claude Code 和 OpenAI Codex 都参与�
 [Mnemon](https://github.com/mnemon-dev/mnemon)、
 [Lark Node SDK](https://github.com/larksuite/node-sdk) 和
 [Tencent openclaw-weixin](https://github.com/Tencent/openclaw-weixin)。
-也特别感谢 [DSH-IM](https://github.com/xmanrui/dsh-im) 提供多渠道传输和消息
-交互参考，以及 [qqbot-agent-sdk](https://github.com/tencent-connect/qqbot-agent-sdk)
-提供官方 QQ Bot 扫码接入参考。蓬莱只在自己的 IM 控制平面内选择性重写这些思路，
-不会打包这两个上游运行时。蓬莱办公的生成能力也建立在
+也特别感谢 [DSH-IM](https://github.com/xmanrui/dsh-im) 与 [qqbot-agent-sdk](https://github.com/tencent-connect/qqbot-agent-sdk) 提供参考。蓬莱只在自己的 IM 控制平面内重写这些思路，不会打包这两个上游运行时。蓬莱办公还建立在
 [PPTFast](https://github.com/liustack/pptfast)、
 [ExcelJS](https://github.com/exceljs/exceljs)、
 [pdf-lib](https://github.com/Hopding/pdf-lib) 和
 [Noto CJK](https://github.com/notofonts/noto-cjk) 之上。
-每个依赖保留自己的许可证；Release 会附上精确 SBOM 和第三方声明。
+每个依赖保留自己的许可证。

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Official DeepSeek Harness, installed on a personal computer.
 
 **Penglai 0.6.0** puts official DeepSeek Harness `0.1.5-alpha.1` (tag `dsh-v0.1.5-alpha.1`, commit `5dda764ed3aa172535a7967b06ff95d9cbfe536a`, 272 npm packages) on Apple Silicon, Intel Mac, Windows x64, and UnionTech UOS 20 LoongArch. DSH remains the only agent core. Office and Memory start on.
 
-The last immutable public installers are [v0.5.12](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12). The [v0.6.0](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0) GitHub Release is the download source for this version once those bytes exist and are read back. Published v0.5.10, v0.5.11, and v0.5.12 tags stay immutable.
-[Release notes](docs/RELEASE_NOTES_0.6.0.md)
+Immutable public bytes: [`v0.6.0`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0), built from source `7dd68b4ab08bbe4edf4dfac7f82abb6b164cb316`. Published v0.5.10, v0.5.11, and v0.5.12 tags stay immutable.
+[Release notes](docs/RELEASE_NOTES_0.6.0.md) · [Publication manifest](docs/PUBLICATION_MANIFEST_0.6.0.md)
 
 <p align="center">
   <img src="website/shots/0.5.5/welcome.png" width="78%" alt="Penglai first-run welcome: language, appearance, and a seven-step guide">
@@ -61,20 +61,37 @@ Settings stay simple: install and enable, or disable. Hashes, loader phases, per
 </p>
 <p align="center"><sub>Installed 0.5.5 Plugin Center and Office, kept as UI references. UI state is never proof of installation or health.</sub></p>
 
-Office writes use host-issued `artifact:<uuid>` handles and wait for a confirmation bound to that action. Memory recall never searches another Workspace. Candidate curation is a model call to the provider you selected; storage and recall stay local. Mnemon `0.2.8` is bundled. Large SenseVoice and MOSS-TTS weights download only after an explicit action.
+Office writes use host-issued `artifact:<uuid>` handles and wait for a confirmation bound to that action. Memory recall never searches another Workspace. Candidate curation is a model call to the provider you selected; storage and recall stay local. Memory is required and default-on, including on UOS, with the Mnemon `0.2.8` engine packed. Large SenseVoice weights download only after an explicit action. MOSS-TTS is not available and not enableable on LoongArch.
 
 ## Download
 
-Use the matching file. Do not mix platforms.
+Use the matching file. Do not mix platforms. Check the downloaded installer against `SHA256SUMS` on [`v0.6.0`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0). GitHub Releases is the authoritative source. Linux amd64 and Windows ARM are not targets. All four installers were built from source `7dd68b4ab08bbe4edf4dfac7f82abb6b164cb316`.
 
-| Computer | Installer |
-| --- | --- |
-| Apple Silicon, macOS 13+ | [Penglai_0.6.0_macos_aarch64.dmg](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_aarch64.dmg) |
-| Intel Mac, macOS 13+ | [Penglai_0.6.0_macos_x64.dmg](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_x64.dmg) |
-| Windows 10+ x64 | [Penglai_0.6.0_windows_x64_setup.exe](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_windows_x64_setup.exe) |
-| UnionTech UOS 20 LoongArch | [Penglai_0.6.0_uos_loong64.deb](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_uos_loong64.deb) |
+### Apple Silicon, macOS 13+
 
-After the [v0.6.0](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0) Release is public, check the downloaded file against `SHA256SUMS` on that page. GitHub Releases is the authoritative source. Linux amd64 and Windows ARM are not targets. Native UOS install, startup, and function are Owner-tested after publication. That UOS runtime is Loongson Electron 31.7.7 (Chromium 126), not the Mac/Windows Electron 43 train.
+[`Penglai_0.6.0_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_aarch64.dmg)
+
+284,362,933 bytes · SHA-256 `98d1c0a133d50200c03626d39e225a52ff08d1f1a09fdb1595ab706b70f183cb`
+
+### Intel Mac, macOS 13+
+
+[`Penglai_0.6.0_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_x64.dmg)
+
+293,996,120 bytes · SHA-256 `4c74a4ce9353ccf23aa74471d279237c4b5b9822d118aa2a90e44e16caf16498`
+
+### Windows 10+ x64
+
+[`Penglai_0.6.0_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_windows_x64_setup.exe)
+
+369,849,038 bytes · SHA-256 `6316f623fe877686662b7b3a5641945bc946e2b1dd31bf3d9527c6a17f7c35e9`
+
+### UnionTech UOS 20 LoongArch
+
+[`Penglai_0.6.0_uos_loong64.deb`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_uos_loong64.deb)
+
+292,702,128 bytes · SHA-256 `a541e9fa9b06626750b4a87859cc76ff3df51b5a0eb8960de08e8eba20cad430`
+
+Native UOS install, startup, and function remain Owner post-publication testing (`OWNER_POST_RELEASE`). That UOS runtime is Loongson Electron 31.7.7 (Chromium 126). It is not maintained and is not a Chromium 150 / Electron 43 security equivalent of Mac/Windows.
 
 ## Quick start
 
@@ -99,8 +116,10 @@ Upgrade with the same-platform installer as a manual overlay. Default uninstall 
 - Credentials are stored in app-private YAML through official DSH. That is not Keychain or hardware isolation.
 - macOS is ad-hoc signed and **not notarized**. Windows has **no Authenticode**. Do not disable system security to install.
 - Plugins share the local DSH process. Install only reviewed catalog entries and read their permissions.
-- UOS 20 LoongArch is the fourth packaged target. Native function on that host is not claimed as already tested.
-- Source tests, packaged tests, native installed tests, and live external-account tests are reported separately.
+- UOS 20 LoongArch is the fourth packaged target. Native install, startup, and function on that host remain `OWNER_POST_RELEASE`, not PASS.
+- UOS Electron 31.7.7 / Chromium 126 is not maintained and has no Mac/Windows security parity.
+- Memory stays required/on on UOS with the packed Mnemon engine. MOSS-TTS is not available and not enableable on LoongArch.
+- Source tests, packaged tests, native installed Mac/Windows tests, and live external-account tests are reported separately.
 
 ## Further reading
 
@@ -154,7 +173,7 @@ DSH 始终是唯一的 Agent 核心。Agent loop、模型、工具、审批、Wo
        → DeepSeek Harness（模型、工具、Workspace、Session、会话）
 ```
 
-**Penglai 0.6.0** 使用官方 DeepSeek Harness `0.1.5-alpha.1`（tag `dsh-v0.1.5-alpha.1`，commit `5dda764ed3aa172535a7967b06ff95d9cbfe536a`，272 包）。办公和记忆默认开启。四个安装包面向 Apple 芯片、Intel Mac、Windows x64 和统信 UOS 20 龙芯。最近的不可变公开安装包仍是 [v0.5.12](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12)。[v0.6.0](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0) 才是本版本的权威下载源，前提是那些字节已经存在并完成回读。
+**Penglai 0.6.0** 使用官方 DeepSeek Harness `0.1.5-alpha.1`（tag `dsh-v0.1.5-alpha.1`，commit `5dda764ed3aa172535a7967b06ff95d9cbfe536a`，272 包）。办公和记忆默认开启。四个安装包面向 Apple 芯片、Intel Mac、Windows x64 和统信 UOS 20 龙芯，来自源码 `7dd68b4ab08bbe4edf4dfac7f82abb6b164cb316`。权威公开下载是不可变 [`v0.6.0`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0)。已发布的 v0.5.10、v0.5.11、v0.5.12 保持不可变。
 
 ## 一次完整使用
 
@@ -183,20 +202,37 @@ DSH 始终是唯一的 Agent 核心。Agent loop、模型、工具、审批、Wo
 </p>
 <p align="center"><sub>0.5.5 安装版插件中心与办公界面，作为参考。界面状态不等于已安装或健康。</sub></p>
 
-办公写入使用 Host 发出的 `artifact:<uuid>` 句柄，并等待与动作绑定的确认。记忆召回不会搜索另一个 Workspace。整理候选会调用你选择的模型供应商；记录与召回留在本机。Mnemon `0.2.8` 已随包。SenseVoice 和 MOSS-TTS 的大模型要你主动下载。
+办公写入使用 Host 发出的 `artifact:<uuid>` 句柄，并等待与动作绑定的确认。记忆召回不会搜索另一个 Workspace。整理候选会调用你选择的模型供应商；记录与召回留在本机。记忆必装默认开启，UOS 上也带入 Mnemon `0.2.8` 引擎。SenseVoice 大模型要你主动下载。MOSS-TTS 在龙芯上不可用、不可启用。
 
 ## 下载
 
-请使用对应安装包，不要混用。
+请使用对应安装包，不要混用。下载后用 [`v0.6.0`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0) 页的 `SHA256SUMS` 核对。权威公开源是 GitHub Release。Linux amd64 与 Windows ARM 不是目标。四个安装包来自源码 `7dd68b4ab08bbe4edf4dfac7f82abb6b164cb316`。
 
-| 电脑 | 安装包 |
-| --- | --- |
-| Apple 芯片，macOS 13+ | [Penglai_0.6.0_macos_aarch64.dmg](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_aarch64.dmg) |
-| Intel Mac，macOS 13+ | [Penglai_0.6.0_macos_x64.dmg](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_x64.dmg) |
-| Windows 10+ x64 | [Penglai_0.6.0_windows_x64_setup.exe](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_windows_x64_setup.exe) |
-| 统信 UOS 20 龙芯 | [Penglai_0.6.0_uos_loong64.deb](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_uos_loong64.deb) |
+### Apple 芯片，macOS 13+
 
-[v0.6.0](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0) 公开发布后，请用该页的 `SHA256SUMS` 核对下载文件。权威公开源是 GitHub Release。Linux amd64 与 Windows ARM 不是目标。UOS 上的安装、启动和功能由 Owner 在发布后测试。该端运行时是龙芯 Electron 31.7.7（Chromium 126），不是 Mac/Windows 的 Electron 43。
+[`Penglai_0.6.0_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_aarch64.dmg)
+
+284,362,933 字节 · SHA-256 `98d1c0a133d50200c03626d39e225a52ff08d1f1a09fdb1595ab706b70f183cb`
+
+### Intel Mac，macOS 13+
+
+[`Penglai_0.6.0_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_x64.dmg)
+
+293,996,120 字节 · SHA-256 `4c74a4ce9353ccf23aa74471d279237c4b5b9822d118aa2a90e44e16caf16498`
+
+### Windows 10+ x64
+
+[`Penglai_0.6.0_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_windows_x64_setup.exe)
+
+369,849,038 字节 · SHA-256 `6316f623fe877686662b7b3a5641945bc946e2b1dd31bf3d9527c6a17f7c35e9`
+
+### 统信 UOS 20 龙芯
+
+[`Penglai_0.6.0_uos_loong64.deb`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_uos_loong64.deb)
+
+292,702,128 字节 · SHA-256 `a541e9fa9b06626750b4a87859cc76ff3df51b5a0eb8960de08e8eba20cad430`
+
+UOS 上的安装、启动和功能仍是 Owner 发布后测试（`OWNER_POST_RELEASE`）。该端运行时是龙芯 Electron 31.7.7（Chromium 126），未维持，也不是 Mac/Windows Electron 43 / Chromium 150 的安全等价。
 
 ## 快速开始
 
@@ -215,8 +251,10 @@ DSH 始终是唯一的 Agent 核心。Agent loop、模型、工具、审批、Wo
 - 密钥写在 official DSH 的 app-private YAML 里。这不是钥匙串或硬件隔离。
 - macOS 是 ad-hoc 签名、**未公证**；Windows **没有 Authenticode**。请不要为了安装而关闭系统安全功能。
 - 插件和 DSH 在同一本地进程中运行，只应安装经过审核的目录条目并阅读权限。
-- 统信 UOS 20 龙芯是第四个打包目标。该机上的功能验收尚未作为已完成事实声明。
-- 源码测试、打包测试、原生安装测试、真实外部账号测试分别记录。
+- 统信 UOS 20 龙芯是第四个打包目标。该机上的安装、启动和功能仍是 `OWNER_POST_RELEASE`，不是 PASS。
+- UOS Electron 31.7.7 / Chromium 126 未维持，也没有 Mac/Windows 安全等价。
+- UOS 上记忆必开且带入 Mnemon 引擎。MOSS-TTS 在龙芯上不可用、不可启用。
+- 源码测试、打包测试、Mac/Windows 原生安装测试、真实外部账号测试分别记录。
 
 ## 继续阅读
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,20 +1,21 @@
 # Security Policy
 
-Penglai 0.5.12 is a **community-verified** desktop distribution of official DeepSeek Harness (DSH). This file is the public security entry. The full product contract lives in [`docs/SECURITY.md`](docs/SECURITY.md).
+Penglai 0.6.0 is a **community-verified** desktop distribution of official DeepSeek Harness (DSH). This file is the public security entry. The full product contract lives in [`docs/SECURITY.md`](docs/SECURITY.md).
 
 ## Supported versions
 
 | Version | Status |
 | --- | --- |
-| 0.5.12 | Current immutable public release |
-| 0.5.11 | Historical immutable release; native upgrades to 0.5.12 verified on all three targets |
-| 0.5.10 | Historical immutable release; native upgrades to 0.5.12 verified on all three targets |
-| 0.5.8 and 0.5.9 | Historical releases; native upgrades to 0.5.12 verified on all three targets |
+| 0.6.0 | Current immutable public release |
+| 0.5.12 | Historical immutable release; native Mac/Windows upgrades to 0.6.0 verified |
+| 0.5.11 | Historical immutable release |
+| 0.5.10 | Historical immutable release |
+| 0.5.8 and 0.5.9 | Historical releases |
 | Earlier 0.5.x | Historical releases; use the documented migration path |
 | 0.4.1 and earlier | Unsupported; 0.5 does not silently import or delete old secrets or databases |
 
-The 0.5.12 release contains all ten files in its release contract, including
-signed update metadata, SHA256SUMS, the three-target SBOM and third-party notices.
+The 0.6.0 release contains all eleven files in its release contract, including
+four installers, signed update metadata, SHA256SUMS, the release-set SBOM and third-party notices.
 The immutable 0.5.9 release contains only its three installers; its missing
 metadata is a historical publication defect. Do not infer signed updater
 coverage for that release from its installer availability. The published 0.5.9
@@ -24,6 +25,7 @@ assets have not been changed.
 
 - macOS: ad-hoc sealed, **not notarized**, no Developer ID.
 - Windows: **no Authenticode**.
+- UOS LoongArch: Loongson Electron 31.7.7 / Chromium 126. That train is not maintained and is **not** a Mac/Windows security-parity claim. Native UOS function remains `OWNER_POST_RELEASE`.
 - Penglai Ed25519 signatures protect installer and updater integrity. They are **not** Apple or Microsoft publisher trust.
 - First launch may show an OS reputation warning. Penglai will not tell users to turn off Gatekeeper or SmartScreen.
 - There is **no silent auto-update**. Later 0.5.x upgrades are signed assisted upgrades that the user must confirm.
@@ -36,7 +38,7 @@ On macOS the credentials directory/file use 0700/0600. On Windows they use a cur
 
 0.4.1 credentials and databases are not read, imported, or deleted.
 
-Official DSH 0.1.3-alpha.2 bundles a session-telemetry adapter and a configured DeepSeek
+Official DSH 0.1.5-alpha.1 bundles a session-telemetry adapter and a configured DeepSeek
 OTLP endpoint. Penglai does not operate that backend and does not rely only on
 the adapter's default mode: the owned DSH child receives
 `DSH_TELEMETRY_DISABLED=1` from a closed environment allowlist. DSH applies that
@@ -50,7 +52,7 @@ Adapters cannot call a parallel Agent. `docs/0.5.7/LIVE_IM_MATRIX.md` preserves
 historical account-test requirements; it does not establish current-version live
 results. Current account journeys are claimed only with current evidence. Slack,
 Telegram, and Discord do not fake QR.
-WhatsApp is not displayed, supported, planned, or bundled in 0.5.12.
+WhatsApp is not displayed, supported, planned, or bundled in 0.6.0.
 
 - Weixin: real QR login. The scanner is the only allowed identity unless the user expands the allowlist.
 - Feishu: the official application-registration QR flow is used where available, with manual App ID/Secret setup as a fallback. Penglai does not host the application or invent a login QR.
@@ -68,7 +70,7 @@ owner paths, or updater private keys.
 
 Please include:
 
-- Penglai version and platform (`macos_aarch64`, `macos_x64`, or `windows_x64`)
+- Penglai version and platform (`macos_aarch64`, `macos_x64`, `windows_x64`, or `uos_loong64`)
 - Whether the build is the publication candidate
 - Reproduction without real API keys or account material
 - Impact on credentials, IM routing, update/uninstall, or Electron hardening
@@ -81,12 +83,13 @@ Penglai will not claim notarization, Authenticode, App Store trust, silent auto-
 
 ## 中文
 
-当前正式版本为 0.5.12，使用固定的官方 DSH `0.1.3-alpha.2` npm 包。
-Apple Silicon、Intel Mac 和 Windows x64 均验证从 0.5.8、0.5.9、0.5.10、0.5.11 升级并在默认
-卸载后保留用户数据。旧版 DSH Home 保留，新代际在独立目录通过健康检查后启用。
+当前正式版本为 0.6.0，使用固定的官方 DSH `0.1.5-alpha.1` npm 包。
+Apple Silicon、Intel Mac 和 Windows x64 验证从 0.5.12 升级并在默认
+卸载后保留用户数据。UOS 龙芯包已发布，真机安装/启动/功能为 Owner 发布后测试。
+旧版 DSH Home 保留，新代际在独立目录通过健康检查后启用。
 
-0.5.12 的正式发布包含十项完整附件，包括签名更新清单、校验和、三端 SBOM 与
-第三方声明。0.5.9 历史发布只有三个安装包，缺少元数据属于当时的发布缺陷；
+0.6.0 的正式发布包含十一项完整附件，包括四个安装包、签名更新清单、校验和、
+SBOM 与第三方声明。0.5.9 历史发布只有三个安装包，缺少元数据属于当时的发布缺陷；
 不能据此声称该版签名更新链路完整。原有不可变附件未被修改。
 
 macOS 为社区 ad-hoc 签名、未公证；Windows 无 Authenticode。蓬莱 Ed25519

--- a/docs/0.6.0/ACCEPTANCE_DELTA.md
+++ b/docs/0.6.0/ACCEPTANCE_DELTA.md
@@ -10,8 +10,9 @@ Grok 4.6 xhigh owns implementation and technical review. This supersedes
 the previous no-new-release boundary and the UOS exclusion **for 0.6.0
 only**.
 
-Public README/website download tables remain **0.5.12** until immutable
-`v0.6.0` GitHub Release bytes exist and are read back.
+Public README/website download tables now bind immutable
+`v0.6.0` GitHub Release bytes after public readback. Installer source remains
+`7dd68b4ab08bbe4edf4dfac7f82abb6b164cb316`.
 
 ## In scope
 

--- a/docs/0.6.0/AGGREGATE_COLLECTOR.md
+++ b/docs/0.6.0/AGGREGATE_COLLECTOR.md
@@ -1,0 +1,17 @@
+# 0.6.0 native aggregate collector path
+
+Native run [34376799819](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34376799819) on freeze `7dd68b4ab08bbe4edf4dfac7f82abb6b164cb316`:
+
+| Job | Conclusion |
+| --- | --- |
+| npm cohort | SUCCESS |
+| darwin-aarch64 | SUCCESS |
+| darwin-x86_64 | SUCCESS |
+| win32-x86_64 | SUCCESS |
+| linux-loong64 UOS `.deb` packaging | SUCCESS |
+| Exact four-target evidence aggregate | FAILED |
+| Signed Plugin Center distribution | skipped (`mode: native`) |
+
+The aggregate job failed at `test -s .native/linux-loong64/Penglai_0.6.0_uos_loong64.deb`. Artifact `penglai-0.6.0-linux-loong64` stores `dist/Penglai_0.6.0_uos_loong64.deb` (SHA-256 `a541e9fa9b06626750b4a87859cc76ff3df51b5a0eb8960de08e8eba20cad430`, 292702128 bytes). This is a collector path defect, not a missing installer.
+
+That GitHub aggregate job remains FAILED. It is not PASS and is not waived. Local collection of the four original artifacts produced `verify:release` PASS, `dryRun=false`, bound to the freeze SHA. This commit collects the `.deb` from anywhere under `.native/linux-loong64` so a later native run does not repeat the same collection failure. It does not rebuild 0.6.0 natives.

--- a/docs/0.6.0/TODO.md
+++ b/docs/0.6.0/TODO.md
@@ -141,11 +141,11 @@ public checkout.
 
 ## README, website, installers and release
 
-- [ ] D01 README: English then Chinese; four-target download cards only
-      after public bytes. Honest UOS limits until native evidence.
+- [x] D01 README: English then Chinese; four-target download cards bound
+      to public v0.6.0 bytes after readback. Honest UOS limits retained.
 - [ ] D02 `website/` + gh-pages/pages.dev: desktop 1280 and mobile 390,
       reduced-motion, keyboard, live origin readback after publish.
-      Downloads stay 0.5.12 until v0.6.0 readback.
+      Downloads now bind v0.6.0 public bytes; live origin readback is P05.
 - [ ] D03 macOS DMG presentation (both Mac targets).
 - [ ] D04 Windows NSIS install/upgrade UI.
 - [ ] D05 Electron first-run wizard, including UOS/linux once packaged.
@@ -154,10 +154,11 @@ public checkout.
 - [ ] P01 Acceptance delta, release notes, security, upgrade docs.
 - [ ] P02 Commits, push, PR, merge; exclude Owner files and private
       `.grok` / `pdf-page-preview.png`.
-- [ ] P03 Exact contract asset set from accepted native builds (four
-      installers + metadata).
-- [ ] P04 Immutable publication and public-byte readback. Do not rewrite
-      v0.5.10, v0.5.11, or v0.5.12.
+- [x] P03 Exact contract asset set from freeze `7dd68b4a` (four
+      installers + seven metadata files). GitHub aggregate job on run
+      34376799819 remains FAILED (collector path), not waived.
+- [x] P04 Immutable publication and public-byte readback of `v0.6.0`.
+      v0.5.10, v0.5.11, and v0.5.12 were not rewritten.
 - [ ] P05 Live penglai.pages.dev and GitHub Pages readback for 0.6.0.
 
 ## Notes

--- a/docs/PUBLICATION_0.6.0.md
+++ b/docs/PUBLICATION_0.6.0.md
@@ -1,0 +1,19 @@
+# Penglai 0.6.0 publication
+
+Recorded after immutable public readback of tag `v0.6.0`.
+
+Penglai 0.6.0 publishes four installers and seven required metadata files. [The complete public byte manifest](PUBLICATION_MANIFEST_0.6.0.md) records their sizes and SHA-256 values. [Release notes](RELEASE_NOTES_0.6.0.md) describe the DSH 0.1.5-alpha.1 adaptation, UOS packaging, upgrade behavior and known boundaries.
+
+The installer build source is `7dd68b4ab08bbe4edf4dfac7f82abb6b164cb316`. [Source CI](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34376782684) and [CodeQL](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34376781577) passed on that source. Native run [34376799819](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34376799819) built the four installers (target jobs SUCCESS). Its GitHub aggregate job FAILED while looking for `.native/linux-loong64/Penglai_0.6.0_uos_loong64.deb`; the uploaded artifact stored `dist/Penglai_0.6.0_uos_loong64.deb`. That aggregate job is not PASS and is not waived. Local collection of those unchanged artifacts produced `verify:release` PASS bound to the freeze SHA. The signed mutable draft was then completed, published once, and all eleven immutable public assets were downloaded.
+
+The later README, security entry, bilingual website, collector-path repair and publication documents are documentation and publication-scope changes. Their commit is not the installer's build source. Website deployment independently verifies publication-only changes and exact download facts; its final readback checks every deployed file at both [Cloudflare Pages](https://penglai.pages.dev/) and [GitHub Pages](https://kevinchennewbee.github.io/PenglaiAgent/). Deployment completion is established by that workflow's actual result.
+
+Signed Plugin Center distribution reused live catalog `plugin-catalog-v1.000006` after [catalog mode PASS](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34415171352) against DSH `0.1.5-alpha.1`. This release supplies the complete signed update set with sequence 9. macOS remains not notarized and Windows has no Authenticode. Native UOS remains `OWNER_POST_RELEASE`. Electron 31.7.7 / Chromium 126 is not a Mac/Windows security-parity claim. No private account journey is inferred from automated tests. Published 0.5.10, 0.5.11 and 0.5.12 tags were not rewritten.
+
+## 中文
+
+0.6.0 已公开四个安装器和七项配套文件，精确公开字节见上方清单。安装包源码是 `7dd68b4ab08bbe4edf4dfac7f82abb6b164cb316`。源码 CI、CodeQL、四端目标作业、完整草稿验证和不可变公网回读均绑定该 SHA。GitHub 汇总作业因 UOS 收集路径失败，不能标 PASS。
+
+README、安全入口、双语官网、收集路径修复和发布记录属于随后独立提交的公开文档，不能把文档提交写成安装包来源。官网部署另行核对仅有允许的文档差异、真实下载信息，并逐文件回读两个公网站点；以该部署任务的实际结果确认上线。
+
+macOS 未公证、Windows 无 Authenticode；UOS 真机为 Owner 发布后测试。无凭据自动检查不代表私人账号或真实模型回复已验证。

--- a/docs/PUBLICATION_MANIFEST_0.6.0.md
+++ b/docs/PUBLICATION_MANIFEST_0.6.0.md
@@ -1,0 +1,41 @@
+# PUBLICATION_MANIFEST 0.6.0
+
+Status: `PUBLIC_READBACK_PASS`
+
+All eleven immutable assets were downloaded after publication. Their exact sizes, SHA-256 digests, update signature and installer signatures passed verification. The table records observed public bytes; source templates remain `UNFROZEN` and are not substituted for generated release identities.
+
+| Field | Value |
+| --- | --- |
+| Product | `0.6.0` |
+| DSH | official unmodified npm `0.1.5-alpha.1`; tag `dsh-v0.1.5-alpha.1`; commit `5dda764ed3aa172535a7967b06ff95d9cbfe536a` |
+| Upstream cohort | 272 packages with registry archive, signature and fixed-source manifest verification |
+| Build source SHA | `7dd68b4ab08bbe4edf4dfac7f82abb6b164cb316` |
+| Public export tree | `c385fd9d32d776dd14c2707d5ed0276cf1e8d38f90e7511403f7c39c83b97ea4` |
+| Release | [`v0.6.0`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0), immutable |
+| Four installer targets | native run [34376799819](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34376799819): darwin-aarch64, darwin-x86_64, win32-x86_64, linux-loong64 packaging SUCCESS; GitHub aggregate job FAILED on UOS collector path (not PASS, not waived) |
+| Source CI | [PASS](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34376782684) on the freeze SHA |
+| CodeQL | [PASS](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34376781577) on the freeze SHA |
+| Signed catalog | live [`plugin-catalog-v1.000006`](https://github.com/kevinchennewbee/PenglaiPluginRegistry/releases/tag/plugin-catalog-v1.000006) verified after freeze: [catalog mode PASS](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34415171352) (`verify:live-plugin-catalog`, disabled install, offline recovery, `dshExact` `0.1.5-alpha.1`). No new catalog sequence was published; 000006 remains the immutable live catalog. |
+| Update sequence | `9` |
+| Trust | community-verified; macOS ad-hoc, not notarized; Windows no Authenticode; UOS Electron 31.7.7 / Chromium 126 not maintained, no Mac/Windows security parity |
+| Native UOS | `OWNER_POST_RELEASE` |
+
+| Asset | Bytes | SHA-256 |
+| --- | ---: | --- |
+| [`Penglai_0.6.0_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_aarch64.dmg) | 284,362,933 | `98d1c0a133d50200c03626d39e225a52ff08d1f1a09fdb1595ab706b70f183cb` |
+| [`Penglai_0.6.0_macos_x64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_x64.dmg) | 293,996,120 | `4c74a4ce9353ccf23aa74471d279237c4b5b9822d118aa2a90e44e16caf16498` |
+| [`Penglai_0.6.0_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_windows_x64_setup.exe) | 369,849,038 | `6316f623fe877686662b7b3a5641945bc946e2b1dd31bf3d9527c6a17f7c35e9` |
+| [`Penglai_0.6.0_uos_loong64.deb`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_uos_loong64.deb) | 292,702,128 | `a541e9fa9b06626750b4a87859cc76ff3df51b5a0eb8960de08e8eba20cad430` |
+| [`SBOM.cdx.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/SBOM.cdx.json) | 1,225,591 | `a611ff09c447f1baf27cf9d7c3033c43ee1039fcebf961b5a94a8fa882b8f29c` |
+| [`SHA256SUMS`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/SHA256SUMS) | 926 | `774c16af532cf853188ee0146260578874ce70153ba8e4cbe6efba9d0cfb5581` |
+| [`THIRD_PARTY_NOTICES.txt`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/THIRD_PARTY_NOTICES.txt) | 188,338 | `45b4aa3fc12ee55b0579a7937e5cd392e41a5243f6f1da8714a1daf10bde2d69` |
+| [`public-export-manifest.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/public-export-manifest.json) | 311,512 | `18824ddb84ccbd7cb9d5091fa825c3c1caf56558009ca750232244917a437bef` |
+| [`release-manifest.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/release-manifest.json) | 923 | `34eabe0544b862c911a9ddb51261401e7239b94c4d07e6b1a673247699fc7734` |
+| [`update-manifest-v1.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/update-manifest-v1.json) | 2,014 | `1461b6934da1b2d012b07e823409e4fa3d6358cd1a5ac31dad6eea65281423f8` |
+| [`update-manifest-v1.json.sig`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/update-manifest-v1.json.sig) | 64 | `88a8fa77ead8fc335da3219448ea48585251d43ac868f38cbb6300d94ca70f99` |
+
+Public asset-set seal: `f2a5b3245b6810bc54f2f0c7990daaef66cf2ea2bdc87332c351e324b56daaef`. Native lifecycle verification covers the published 0.5.12 upgrade on matching Mac/Windows hosts, with default uninstall preserving user data. Installed resource UI tests and native executable checks retain their separate evidence classes. Independent PM representative GUI on the exact Apple Silicon bytes passed. Native UOS function remains Owner post-publication. GitHub-hosted Windows runners are not default-OS Defender-on proof. Private account delivery and real provider responses are not inferred from credential-free tests. Published `v0.5.10`, `v0.5.11`, and `v0.5.12` tags and assets were not rewritten.
+
+## 中文
+
+以上十一项附件均已从不可变公开发布下载回读，文件大小、摘要、更新签名及安装器签名通过验证。四端安装包来自同一源码 `7dd68b4ab08bbe4edf4dfac7f82abb6b164cb316`。Mac/Windows 验证从 0.5.12 升级与默认卸载保留用户数据。GitHub 四端汇总作业因 UOS 收集路径失败，不能标 PASS。UOS 真机安装/启动/功能仍为 Owner 发布后测试。macOS 为 ad-hoc 签名、未公证；Windows 无 Authenticode。无凭据测试不代表真实模型回复或私人账号消息送达。已发布的 0.5.10、0.5.11 与 0.5.12 标签与附件未被改写。

--- a/docs/RELEASE_NOTES_0.6.0.md
+++ b/docs/RELEASE_NOTES_0.6.0.md
@@ -1,82 +1,29 @@
 # Penglai 0.6.0
 
-These notes are a **source draft**. They are not a public GitHub Release and
-do not replace the immutable [`v0.5.12`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12)
-download tables. Public README and both websites stay on 0.5.12 until
-immutable `v0.6.0` bytes exist and are read back. Do not copy these notes
-onto the live site before that.
+Penglai 0.6.0 uses the unmodified official DeepSeek Harness `0.1.5-alpha.1` npm packages, fixed to tag `dsh-v0.1.5-alpha.1` and commit `5dda764ed3aa172535a7967b06ff95d9cbfe536a` (272-package cohort). DSH remains the only agent core. Office and Memory stay required and default-on.
 
-Penglai 0.6.0 uses the unmodified official DeepSeek Harness `0.1.5-alpha.1`
-npm packages, fixed to tag `dsh-v0.1.5-alpha.1` and commit
-`5dda764ed3aa172535a7967b06ff95d9cbfe536a` (272-package cohort). DSH remains
-the only agent core. Office and Memory stay required and default-on.
-
-Four installer targets from **one** clean `main` SHA (SHA frozen only after
-UOS payload integration): Apple Silicon, Intel Mac, Windows x64, and
-UnionTech UOS 20 Professional 1070 Loongson old-world
-(`Penglai_0.6.0_uos_loong64.deb`). Native UOS install, startup and function
-are **Owner post-publication** testing (`OWNER_POST_RELEASE`), never PASS
-before that.
+Immutable public bytes: [`v0.6.0`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0). Verified publication: [`docs/PUBLICATION_MANIFEST_0.6.0.md`](PUBLICATION_MANIFEST_0.6.0.md). The four installers were built from source SHA `7dd68b4ab08bbe4edf4dfac7f82abb6b164cb316`. Published **v0.5.10**, **v0.5.11**, and **v0.5.12** tags and assets stay immutable.
 
 ## Changes
 
-- Official DSH `0.1.5-alpha.1` full 272-package cohort. Session V3 copies
-  historical logs and keeps originals. Plugin Agent API follows upstream
-  (`ctx.agent` removed; Inbox is type-only).
-- Lived-in 0.5.12 → 0.6.0 DSH Home copy skips DSH-regenerated
-  `profiles/node_modules` and `profiles/<name>/node_modules` installation
-  links, including `collectHistoricalSessionLogs` skip-before-lstat.
-  `bundle-desktop` rebuilds TypeScript before packing so that skip ships.
-- Wizard: invalid credential classified as auth failure; stale workspace
-  folder error clears on a valid path; custom-model image input uses
-  official DeepSeek `inputModalities` (no model-id regex).
-- Fourth target: actual UOS 20 old-world `.deb` class with Office/Memory
-  required and chrome-sandbox kept. Payload addons are architecture
-  builds in `native/linux-loong64-oldworld/` (koffi `4e19ac67…`, sharp.node
-  `7967795e…`, libvips-cpp `2e9438ad…`, flock `b065bcb1…`, pty `5b5b7386…`),
-  not official npm new-world loong64 wheels. JPEG in this libvips is
-  libjpeg-turbo 3.0.4, not mozjpeg. `node-addon-require-builtin` native is
-  unpublished on loong64; product web uses `patchReload: startup`.
+- Official DSH `0.1.5-alpha.1` full 272-package cohort. Session V3 copies historical logs and keeps originals. Plugin Agent API follows upstream (`ctx.agent` removed; Inbox is type-only).
+- Lived-in 0.5.12 → 0.6.0 DSH Home copy skips DSH-regenerated `profiles/node_modules` installation links.
+- Wizard: invalid credential classified as auth failure; stale workspace folder error clears on a valid path; custom-model image input uses official DeepSeek `inputModalities` (no model-id regex).
+- Fourth packaged target: UnionTech UOS 20 Professional 1070 Loongson old-world `.deb`. Memory remains required/on; the architecture-built Mnemon `0.2.8` engine is packed. MOSS-TTS is not available and not enableable on LoongArch. Native UOS install, startup, and function remain Owner post-publication testing (`OWNER_POST_RELEASE`), not PASS.
+- Publication is the complete eleven-file signed release set. The signed update sequence is 9. Updater platforms remain Apple Silicon, Intel Mac, and Windows x64.
+
+## Downloads and verification
+
+Apple Silicon, Intel Mac, and Windows x64 installers were built on matching native hosts from the same clean main commit: `7dd68b4ab08bbe4edf4dfac7f82abb6b164cb316`. The UOS `.deb` was packaged from that same commit.
+
+[Native target jobs](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34376799819) cover Mac/Windows installed startup, credential-free onboarding/recovery, bundled plugin modes, upgrade from published 0.5.12, and default uninstall with user data preserved (four target jobs SUCCESS). The GitHub four-target aggregate job on that run FAILED while collecting the UOS `.deb` from a flattened path; the installer was present at `dist/Penglai_0.6.0_uos_loong64.deb`. That aggregate job is not PASS. Local collection of the original four artifacts produced complete `verify:release` PASS bound to this source. Independent PM desktop acceptance of the exact Apple Silicon installer bytes passed. Native UOS function is not claimed here.
+
+Check the downloaded installer against `SHA256SUMS` before running it. Office and Memory start enabled. Messaging, speech recognition, voice generation, and Companion start disabled.
 
 ## Known boundaries
 
-- macOS is ad-hoc signed and **not notarized**. Windows has **no
-  Authenticode**.
-- UOS native install/startup/function remain `OWNER_POST_RELEASE`.
-- UOS Electron is Loongson vendor **31.7.7** (Chromium 126.0.6478.234,
-  zip dated 2025-02-06). That train is **not maintained** and is **not**
-  a Chromium 150 / Electron 43 security equivalent of Mac/Windows. PM has
-  not accepted publishing that limitation as a production-security PASS.
-  Options remain: ship 31.7.7 with this disclosure, or do not ship a public
-  old-world 43 recipe. V25 is not requested.
-- Packaged PDF page-image preview / bundled Poppler stay Owner-deferred.
-- WhatsApp is not a product surface.
-- Mnemon 0.2.8 publishes no linux-loong64 archive. The Memory plugin is
-  packed; the mnemon engine is unpublished on UOS. MOSS ONNX native is
-  unpublished on loong64.
-
-## Verification (after freeze)
-
-Installers must match `SHA256SUMS` from the `v0.6.0` release. Upgrade from
-published 0.5.12 on matching Mac/Windows hosts. Default uninstall preserves
-user data. 0.5.10, 0.5.11 and 0.5.12 tags stay immutable.
+macOS is ad-hoc signed and **not notarized**. Windows has **no Authenticode signature**. UOS native install/startup/function remain `OWNER_POST_RELEASE`. Electron 31.7.7 / Chromium 126 on LoongArch is not maintained and is not a Mac/Windows security-parity claim. Packaged PDF page-image preview / bundled Poppler stay Owner-deferred. Private account delivery is not inferred from credential-free tests.
 
 ## 中文
 
-本说明是**源码草稿**，不是 GitHub 公开发布，也不替换不可变的
-[v0.5.12](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12)
-下载表。在 v0.6.0 回读完成前，公开 README 与两个网站仍指向 0.5.12。
-
-蓬莱 0.6.0 使用未经修改的官方 DeepSeek Harness `0.1.5-alpha.1`（tag
-`dsh-v0.1.5-alpha.1`，commit `5dda764e…`，272 包）。DSH 仍是唯一 Agent
-核心。办公与记忆必装默认开启。四个安装包须来自同一干净 main SHA：Apple
-Silicon、Intel Mac、Windows x64，以及统信 UOS 20 专业版 1070 龙芯旧世界
-`.deb`。UOS 上的安装/启动/功能验收为 **Owner 发布后测试**
-（`OWNER_POST_RELEASE`），发布前不得标 PASS。
-
-macOS 为 ad-hoc 签名、未公证；Windows 无 Authenticode。UOS 使用龙芯厂商
-Electron 31.7.7（Chromium 126），**未维持**，也不是 Mac/Windows Electron 43
-/ Chromium 150 的安全等价；PM 尚未把该限制接受为生产安全 PASS。UOS 原生
-koffi/sharp/libvips 为旧世界架构构建（libvips-cpp `2e9438ad…`），不是官方
-npm 新世界包；JPEG 实现为 libjpeg-turbo。Mnemon 无 loong64 二进制。已发布的
-0.5.10 / 0.5.11 / 0.5.12 不被改写。
+蓬莱 0.6.0 使用未经修改的官方 DeepSeek Harness `0.1.5-alpha.1`（tag `dsh-v0.1.5-alpha.1`，commit `5dda764e…`，272 包）。DSH 仍是唯一 Agent 核心。办公与记忆必装默认开启。四个安装包来自同一干净 main 提交 `7dd68b4ab08bbe4edf4dfac7f82abb6b164cb316`。Apple Silicon / Intel Mac / Windows 已做原生安装与从 0.5.12 升级验证；UOS 龙芯包已打包，真机安装/启动/功能为 Owner 发布后测试。UOS 使用龙芯 Electron 31.7.7（Chromium 126），未维持，也不是 Mac/Windows Electron 43 的安全等价。UOS 上 Memory 必开且带入架构构建的 Mnemon 引擎；MOSS 在龙芯上不可用、不可启用。macOS 为 ad-hoc 签名、未公证；Windows 无 Authenticode。已发布的 0.5.10 / 0.5.11 / 0.5.12 不被改写。

--- a/packages/release-identity/src/public-docs.test.ts
+++ b/packages/release-identity/src/public-docs.test.ts
@@ -5,8 +5,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { PRODUCT_VERSION, PINNED_DSH } from "./pins.js";
 
-/** Immutable published 0.5.12 notes/README/website still freeze DSH 0.1.3-alpha.2. */
-const PUBLISHED_DSH = "0.1.3-alpha.2";
+/** Immutable published 0.6.0 notes/README/website freeze the current DSH pin. */
+const PUBLISHED_DSH = PINNED_DSH;
 import {
   assertCommittedTemplateIdentity,
   assertObservedReleaseFacts,
@@ -98,11 +98,13 @@ test("website keeps the full bilingual visual site during publication preparatio
   assert.match(zh, /<html lang="zh-CN">/);
   assert.match(enCompat, /<html lang="en">/);
   for (const html of [zh, en, enCompat]) {
-    assert.match(html, /shots\/banner-v1\.png/);
+    assert.match(html, /shots\/0\.5\.5\/welcome\.png/);
     assert.match(html, /shots\/0\.5\.5\/plugin-center\.png/);
+    assert.match(html, /shots\/0\.5\.5\/office\.png/);
+    assert.match(html, /shots\/0\.5\.5\/memory\.png/);
   }
-  assert.match(css, /\.hero-art/);
-  assert.match(css, /\.gallery/);
+  assert.match(css, /\.download-grid/);
+  assert.match(css, /\.site-nav/);
   assert.ok(css.length > 5000, "website stylesheet is unexpectedly reduced");
 });
 

--- a/packages/release-identity/src/website-publication.test.ts
+++ b/packages/release-identity/src/website-publication.test.ts
@@ -143,7 +143,13 @@ test("website publication permits only the post-readback narrative delta", () =>
     "website/en/index.html",
   ];
   assert.doesNotThrow(() =>
-    assertPublicationOnlyChanges([...required, `docs/${PRODUCT_VERSION}/TODO.md`, "packages/release-identity/src/website-publication.ts"]),
+    assertPublicationOnlyChanges([
+      ...required,
+      `docs/${PRODUCT_VERSION}/TODO.md`,
+      "packages/release-identity/src/website-publication.ts",
+      "scripts/readback-release.mjs",
+      ".github/workflows/native-release-candidate.yml",
+    ]),
   );
   assert.throws(
     () => assertPublicationOnlyChanges([...required, "apps/desktop/src/index.ts"]),

--- a/packages/release-identity/src/website-publication.test.ts
+++ b/packages/release-identity/src/website-publication.test.ts
@@ -147,6 +147,7 @@ test("website publication permits only the post-readback narrative delta", () =>
       ...required,
       `docs/${PRODUCT_VERSION}/TODO.md`,
       "packages/release-identity/src/website-publication.ts",
+      "packages/release-identity/src/public-docs.test.ts",
       "scripts/readback-release.mjs",
       ".github/workflows/native-release-candidate.yml",
     ]),

--- a/packages/release-identity/src/website-publication.ts
+++ b/packages/release-identity/src/website-publication.ts
@@ -74,7 +74,9 @@ function publicationPath(path: string, version: string): boolean {
     path.startsWith("packages/release-identity/src/website-publication") ||
     path === "scripts/verify-website-release.mjs" ||
     path === "scripts/readback-website.mjs" ||
-    path === ".github/workflows/deploy-website.yml"
+    path === "scripts/readback-release.mjs" ||
+    path === ".github/workflows/deploy-website.yml" ||
+    path === ".github/workflows/native-release-candidate.yml"
   );
 }
 

--- a/packages/release-identity/src/website-publication.ts
+++ b/packages/release-identity/src/website-publication.ts
@@ -72,6 +72,7 @@ function publicationPath(path: string, version: string): boolean {
     path.startsWith(`docs/${version}/`) ||
     path.startsWith("website/") ||
     path.startsWith("packages/release-identity/src/website-publication") ||
+    path === "packages/release-identity/src/public-docs.test.ts" ||
     path === "scripts/verify-website-release.mjs" ||
     path === "scripts/readback-website.mjs" ||
     path === "scripts/readback-release.mjs" ||

--- a/scripts/readback-release.mjs
+++ b/scripts/readback-release.mjs
@@ -187,7 +187,7 @@ if (
 }
 
 const releaseArtifacts = Array.isArray(releaseManifest.artifacts) ? releaseManifest.artifacts : [];
-const installerNames = expected.filter((name) => name.endsWith(".dmg") || name.endsWith(".exe")).sort();
+const installerNames = expected.filter((name) => name.endsWith(".dmg") || name.endsWith(".exe") || name.endsWith(".deb")).sort();
 if (JSON.stringify(releaseArtifacts.map((row) => row.name).sort()) !== JSON.stringify(installerNames)) {
   finish("FAIL", { command, reason: "release manifest installer set mismatch" });
 }

--- a/website/art/readme-mark.svg
+++ b/website/art/readme-mark.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 420" role="img" aria-labelledby="title desc">
+  <title id="title">Penglai</title>
+  <desc id="desc">Editorial mark for Penglai: a quiet ink island, the cinnabar seal, and the product name. Drawn as original vector art for this repository.</desc>
+  <rect width="1280" height="420" fill="#F3EEE4"/>
+  <rect x="48" y="36" width="1184" height="348" fill="none" stroke="#DDD4C6" stroke-width="1"/>
+  <path d="M48 292 C 180 268 250 250 340 252 C 430 254 490 276 620 286 C 760 296 900 278 1232 292 L 1232 384 L 48 384 Z" fill="#E7E0D2"/>
+  <path d="M48 318 C 200 304 320 298 470 306 C 640 316 820 300 1232 314 L 1232 384 L 48 384 Z" fill="#DED6C6"/>
+  <path d="M120 300 C 170 240 210 210 268 206 C 310 204 338 228 372 250 C 400 228 430 214 470 218 C 520 224 548 250 580 268 C 610 250 650 238 700 248 C 748 258 776 286 820 300 C 700 312 430 328 120 300 Z" fill="#2A3A34"/>
+  <path d="M210 268 C 236 232 258 214 292 214 C 324 214 344 236 366 258 C 390 238 418 228 450 234 C 486 242 508 264 528 280 C 500 292 360 304 210 268 Z" fill="#1A1714"/>
+  <g fill="#1A1714">
+    <rect x="286" y="168" width="22" height="10"/>
+    <rect x="282" y="176" width="30" height="8"/>
+    <rect x="288" y="184" width="18" height="28"/>
+    <rect x="283" y="212" width="28" height="6"/>
+  </g>
+  <path d="M276 176 L 314 148 L 352 176 Z" fill="#1A1714"/>
+  <path d="M294 148 L 314 128 L 334 148 Z" fill="#C45C26"/>
+  <path d="M160 304 C 178 298 196 298 210 304 C 196 310 178 310 160 304 Z" fill="#1A1714"/>
+  <rect x="178" y="292" width="14" height="8" fill="#1A1714"/>
+  <circle cx="1088" cy="96" r="18" fill="#C4A56A" fill-opacity="0.35"/>
+  <rect x="932" y="148" width="72" height="72" fill="#C45C26" stroke="#C4A56A" stroke-width="1.5"/>
+  <text x="968" y="198" text-anchor="middle" font-size="42" font-family="Georgia, 'Songti SC', 'Noto Serif SC', serif" fill="#F3EEE4">蓬</text>
+  <text x="1020" y="186" font-size="42" font-family="Georgia, 'Iowan Old Style', Palatino, serif" fill="#1A1714">Penglai</text>
+  <text x="1022" y="214" font-size="13" letter-spacing="5" font-family="Avenir Next, Segoe UI, PingFang SC, sans-serif" fill="#6A6258">PENG LAI</text>
+  <rect x="1020" y="232" width="48" height="1" fill="#C4A56A"/>
+  <text x="1020" y="256" font-size="15" font-family="Georgia, Palatino, serif" fill="#3A342C">DeepSeek Harness</text>
+  <text x="1020" y="278" font-size="15" font-family="Georgia, Palatino, serif" fill="#3A342C">on your computer</text>
+</svg>

--- a/website/en/index.html
+++ b/website/en/index.html
@@ -4,17 +4,17 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Penglai 0.5.12 | DeepSeek Harness, ready for a personal computer</title>
-  <meta name="description" content="Penglai 0.5.12 is an installable desktop distribution of official DeepSeek Harness 0.1.3-alpha.2, with Office, Memory, messaging, and local voice.">
-  <meta property="og:title" content="Penglai 0.5.12">
-  <meta property="og:description" content="DeepSeek Harness, ready to install. Office, Memory, mobile messaging, and local voice in one desktop distribution.">
-  <meta name="theme-color" content="#0B1C2C">
+  <title>Penglai 0.6.0 | Make room for the work that matters</title>
+  <meta name="description" content="Penglai 0.6.0 installs official DeepSeek Harness 0.1.5-alpha.1 on a personal computer, with Office, Memory, messaging, and local voice. Apple Silicon, Intel Mac, Windows x64, and UnionTech UOS 20 LoongArch.">
+  <meta property="og:title" content="Penglai 0.6.0">
+  <meta property="og:description" content="Official DeepSeek Harness, installed on your computer. Office and Memory start on. You finish setup after the first real reply.">
+  <meta name="theme-color" content="#F3EEE4">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://penglai.pages.dev/">
   <meta property="og:locale" content="en_US">
   <meta property="og:locale:alternate" content="zh_CN">
-  <meta property="og:image" content="https://penglai.pages.dev/shots/0.5.5/plugin-center.png">
-  <meta property="og:image:alt" content="Penglai 0.5.5 Plugin Center, kept as a historical UI reference">
+  <meta property="og:image" content="https://penglai.pages.dev/shots/0.5.5/welcome.png">
+  <meta property="og:image:alt" content="Penglai first-run welcome from the installed 0.5.5 UI, kept as a historical reference">
   <link rel="icon" href="../favicon.svg" type="image/svg+xml">
   <link rel="canonical" href="https://penglai.pages.dev/">
   <link rel="alternate" hreflang="en" href="https://penglai.pages.dev/">
@@ -31,11 +31,8 @@
       <span></span>
     </button>
     <nav id="navLinks" aria-label="Main navigation">
-      <a href="#new">Product</a>
-      <a href="#inside">Inside</a>
+      <a href="#product">Product</a>
       <a href="#setup">Setup</a>
-      <a href="#privacy">Privacy</a>
-      <a href="#faq">FAQ</a>
       <a href="#download">Download</a>
       <a href="../zh/" hreflang="zh-CN" lang="zh-CN">中文</a>
       <a class="github" href="https://github.com/kevinchennewbee/PenglaiAgent">GitHub</a>
@@ -44,160 +41,203 @@
 
   <main id="main">
     <section class="hero" id="top">
-      <div class="hero-clouds" aria-hidden="true">
-        <span class="cloud c1"></span>
-        <span class="cloud c2"></span>
-        <span class="cloud c3"></span>
-      </div>
-      <canvas id="hero-canvas" class="hero-canvas" aria-hidden="true"></canvas>
-      <img class="hero-art" src="../shots/banner-v1.png" alt="The island of Penglai rising above a sea of clouds">
-      <div class="hero-shade"></div>
-      <div class="hero-copy">
-        <p class="eyebrow">Penglai 0.5.12 · DeepSeek Harness 0.1.3-alpha.2</p>
-        <h1>Not another agent.<br>Official DeepSeek Harness,<br>installed on your computer.</h1>
-        <p class="lead">Penglai puts official DeepSeek Harness, Node, Electron, first-run setup, updates, uninstall, and a reviewed set of DSH plugins into one desktop app. You do not need to learn a terminal first, or move daily work into another cloud account.</p>
-        <div class="actions">
-          <a class="button primary" href="#download">Download 0.5.12</a>
-          <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent">Read the source</a>
+      <div class="hero-inner">
+        <div class="hero-copy">
+          <p class="eyebrow">Penglai 0.6.0</p>
+          <h1>Make room for the work that matters.</h1>
+          <p class="lead">Penglai installs official DeepSeek Harness on a personal computer. You bring a model key, choose a Workspace, and finish setup only after the first real reply. Office and Memory start on. The rest waits until you ask.</p>
+          <div class="actions">
+            <a class="button primary" href="#download">Choose your computer</a>
+            <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent">Read the source</a>
+          </div>
+          <p class="meta-row">
+            <span>Apple Silicon</span>
+            <span>Intel Mac</span>
+            <span>Windows x64</span>
+            <span>UOS 20 LoongArch</span>
+            <span>MIT</span>
+          </p>
         </div>
-        <p class="quiet">MIT licensed · Local first · Apple Silicon / Intel Mac / Windows x64</p>
+        <figure>
+          <div class="app-frame">
+            <div class="app-chrome" aria-hidden="true"><i></i><i></i><i></i><span>Penglai</span></div>
+            <img src="../shots/0.5.5/welcome.png" alt="Penglai first-run welcome: language, appearance, and a seven-step guide">
+          </div>
+          <figcaption>Installed 0.5.5 first-run welcome, kept as a UI reference. This is not a 0.6.0 screenshot.</figcaption>
+        </figure>
       </div>
     </section>
 
-    <section class="intro" id="new" data-reveal>
+    <section class="use-band wrap" data-reveal>
+      <div class="use-grid">
+        <article>
+          <h3>Edit the file in front of you</h3>
+          <p>Office can inspect, create, preview, and save DOCX, XLSX, PPTX, and PDF. A write waits for a confirmation bound to that action.</p>
+        </article>
+        <article>
+          <h3>Remember this project only</h3>
+          <p>Memory organizes safe facts inside the current Workspace. The next Workspace cannot peek. Storage stays on this computer.</p>
+        </article>
+        <article>
+          <h3>Message when you need it</h3>
+          <p>Weixin, Feishu, and six other channels can join the same official Session. WhatsApp is not a product surface.</p>
+        </article>
+        <article>
+          <h3>Speak only if you install it</h3>
+          <p>Speech recognition and voice generation stay off until you download their models. Ordinary chat still works without them.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section core" id="product" data-reveal>
       <div>
-        <p class="eyebrow">DSH remains the only core</p>
-        <h2>Penglai owns install and boundaries. The conversation still belongs to DeepSeek Harness.</h2>
+        <p class="eyebrow">The core does not change</p>
+        <h2>DeepSeek Harness still owns the conversation.</h2>
         <div class="gold-rule" aria-hidden="true"></div>
       </div>
-      <p>Official DeepSeek Harness owns models, tools, approvals, Workspace, Session, Turn, and the conversation interface. Penglai 0.5.12 consumes the exact official <code>0.1.3-alpha.2</code> npm packages, tag <code>dsh-v0.1.3-alpha.2</code>, commit <code>82a5fd61a7cf5c293cec4bdff68f455398d685e9</code>. Message recovery, budget reconciliation and Companion replay use its Session snapshot API. Upgrades from 0.5.8, 0.5.9, 0.5.10 and 0.5.11 prepare a separate data generation and keep the previous one for rollback. All three native installers come from source <code>54a0ef30afa4e3d653e400a637d4aa8eb4abbb75</code>.</p>
-    </section>
-
-    <figure class="feature-shot wide-shot" data-reveal>
-      <img src="../shots/0.5.5/plugin-center.png" alt="The real Penglai 0.5.5 Plugin Center running in installed DSH settings">
-      <figcaption>An installed 0.5.5 screen kept as a UI reference. Native installation and public-byte evidence for 0.5.12 is recorded in its publication manifest; these frames are not 0.5.12 screenshots.</figcaption>
-    </figure>
-
-    <section class="section" id="inside" data-reveal>
-      <p class="eyebrow">Already in the installer</p>
-      <h2>Office and Memory start on. Everything else waits for you.</h2>
-      <div class="cards">
-        <article>
-          <span class="state on">On by default</span>
-          <h3>Penglai Office</h3>
-          <p>Inspect, create, edit, preview, and save DOCX, XLSX, PPTX, and PDF. Writes have a plan and confirmation. PDF output includes a Chinese font. LibreOffice is not a user dependency.</p>
-        </article>
-        <article>
-          <span class="state on">On by default</span>
-          <h3>Penglai Memory</h3>
-          <p>Safe project facts can be organized inside the current Workspace. Candidate curation calls your selected model provider; storage and recall stay local. Personal facts still need an explicit save, and recall never crosses Workspaces.</p>
-        </article>
-        <article>
-          <span class="state">Opt in</span>
-          <h3>Messaging</h3>
-          <p>Weixin, Feishu, DingTalk, WeCom, QQ, Slack, Telegram, and Discord enter one <code>@penglai/im</code> control plane, using each platform's QR, device-registration, or official-token flow. WhatsApp is not displayed, supported, or bundled in 0.5.12.</p>
-        </article>
-        <article>
-          <span class="state">Opt in</span>
-          <h3>Local voice</h3>
-          <p>SenseVoice handles speech recognition; MOSS-TTS handles voice generation. Conversation Read speaks the original reply rather than translating it. Plugin code ships in the app. Large model weights explain themselves before downloading.</p>
-        </article>
-        <article>
-          <span class="state">Opt in</span>
-          <h3>Companion</h3>
-          <p>It contacts you only after you turn it on, and stays within quiet hours, a daily cap, and one chosen messaging route. Fresh installations keep it off.</p>
-        </article>
-        <article>
-          <span class="state">Independent updates</span>
-          <h3>Signed Plugin Center</h3>
-          <p>The catalog comes from immutable GitHub Releases. A reviewed DSH 0.1.3-alpha.2-compatible plugin can join later without shipping a new desktop version merely to change a list. UI state is never proof of installation or health.</p>
-        </article>
+      <div>
+        <p>Official DeepSeek Harness is the only agent core. It owns models, tools, approvals, Workspace, Session, Turn, and the conversation interface. Penglai owns the installer, first-run, process supervision, updates, uninstall, local paths, and a reviewed plugin set. There is no second Penglai agent and no replacement chat page. Session history upgrades copy logs into new files and keep the originals. Upgrades from 0.5.12 copy a lived-in DSH Home without regenerating installation links.</p>
+        <p class="identity">Penglai 0.6.0 · DSH <code>0.1.5-alpha.1</code> · tag <code>dsh-v0.1.5-alpha.1</code> · commit <code>5dda764ed3aa172535a7967b06ff95d9cbfe536a</code> · 272 packages</p>
       </div>
     </section>
 
-    <section class="gallery" aria-label="Installed Penglai 0.5.5 UI references" data-reveal>
-      <figure>
-        <img src="../shots/0.5.5/office.png" alt="Penglai Office settings">
-        <figcaption>Office: create, inspect, and confirmed edits</figcaption>
-      </figure>
-      <figure>
-        <img src="../shots/0.5.5/memory.png" alt="Penglai Memory settings">
-        <figcaption>Memory: Workspace isolation, graph, correction, migration</figcaption>
-      </figure>
-      <figure>
-        <img src="../shots/0.5.5/mobile-messaging.png" alt="Penglai Mobile Messaging settings">
-        <figcaption>Messaging: Weixin and Feishu in one IM plugin</figcaption>
-      </figure>
-      <figure>
-        <img src="../shots/0.5.5/speech-recognition.png" alt="Penglai speech recognition settings">
-        <figcaption>Speech recognition: the microphone appears after setup</figcaption>
-      </figure>
-    </section>
+    <figure class="wide-shot" data-reveal>
+      <img src="../shots/0.5.5/plugin-center.png" alt="Penglai Plugin Center inside official DSH settings, showing Office, Memory, messaging, and voice">
+      <figcaption>Installed 0.5.5 Plugin Center, running in official DSH settings. UI state is never proof that a plugin is installed or healthy. Not a 0.6.0 screenshot.</figcaption>
+    </figure>
 
     <section class="section split" data-reveal>
       <div class="copy">
-        <p class="eyebrow">A real office path</p>
-        <h2>Files enter a Workspace. Writes wait for confirmation.</h2>
-        <p>Penglai Office is a closed set of typed operations: inspect, create, build a visible edit plan, preview, commit after confirmation, and undo the last commit. Models cannot invent host paths or run macros. Inputs and outputs are host-issued <code>artifact:&lt;uuid&gt;</code> handles, and Workspace bounds are checked again at the operation.</p>
+        <p class="eyebrow">Penglai Office · on by default</p>
+        <h2>Files enter a Workspace. Writes wait.</h2>
+        <p>Office is a closed set of typed operations: inspect, create, build a visible edit plan, preview, commit after confirmation, and undo the last commit. Models cannot invent host paths or run macros. Inputs and outputs are host-issued <code>artifact:&lt;uuid&gt;</code> handles, checked again at the operation.</p>
         <ul class="workflow-list">
           <li>DOCX, XLSX, PPTX, and PDF share one product path.</li>
-          <li>PDF output bundles an OFL Chinese font.</li>
-          <li>Save, export, and return bind the exact action — not a casual “ok” in chat.</li>
+          <li>PDF output bundles an OFL Chinese font. LibreOffice is not a user dependency.</li>
+          <li>Save, export, and return bind the exact action, not a casual yes in chat.</li>
         </ul>
       </div>
-      <img src="../shots/0.5.5/office.png" alt="Penglai Office create, inspect, and planned-edit controls">
+      <img src="../shots/0.5.5/office.png" alt="Penglai Office settings: create, inspect, and planned edits for a DOCX file">
     </section>
 
     <section class="section split reverse" data-reveal>
       <div class="copy">
-        <p class="eyebrow">Memory that knows its project</p>
-        <h2>This Workspace can remember. The next one cannot peek.</h2>
-        <p>A fresh install organizes safe project facts inside the current Workspace. After a Turn, a no-tools official Agent uses your current provider and model; the host validates a closed schema and skips secrets, sensitive text, and injection-like output. Later steps recall only confirmed records from this Workspace, plus personal facts you explicitly saved.</p>
+        <p class="eyebrow">Penglai Memory · on by default</p>
+        <h2>This Workspace can remember. The next one cannot.</h2>
+        <p>After a Turn, a no-tools official Agent uses your current provider and model to propose safe project facts. The host validates a closed schema and skips secrets, sensitive text, and injection-like output. Later steps recall only confirmed records from this Workspace, plus personal facts you explicitly saved.</p>
         <ul class="workflow-list">
           <li>You can turn memory off, or review candidates first.</li>
           <li>Authorised folders are indexed without changing the originals.</li>
-          <li>Mnemon 0.2.8 is the only recall engine and is already bundled.</li>
+          <li>Candidate curation is a model call to the provider you selected. Storage and recall stay local. Mnemon 0.2.8 is bundled.</li>
         </ul>
       </div>
-      <img src="../shots/0.5.5/memory.png" alt="Penglai Memory scope, graph, and correction">
+      <img src="../shots/0.5.5/memory.png" alt="Penglai Memory settings: Workspace scope, graph, correction, and migration">
     </section>
 
-    <section class="section split first-run" id="setup" data-reveal>
+    <section class="section" data-reveal>
+      <p class="eyebrow">Waiting until you ask</p>
+      <h2>Optional tools stay out of the way.</h2>
+      <div class="opt-list">
+        <article>
+          <div>
+            <span class="state">Opt in</span>
+            <h3>Messaging</h3>
+          </div>
+          <p>Weixin, Feishu, DingTalk, WeCom, QQ, Slack, Telegram, and Discord enter one <code>@penglai/im</code> control plane, using each platform's QR, device-registration, or official-token flow. WhatsApp is not displayed, supported, or bundled.</p>
+        </article>
+        <article>
+          <div>
+            <span class="state">Opt in</span>
+            <h3>Local voice</h3>
+          </div>
+          <p>SenseVoice handles speech recognition. MOSS-TTS handles voice generation. Plugin code ships in the app. Large model weights explain themselves before downloading. Conversation Read speaks the original reply rather than translating it.</p>
+        </article>
+        <article>
+          <div>
+            <span class="state">Opt in</span>
+            <h3>Companion</h3>
+          </div>
+          <p>It contacts you only after you turn it on, and stays within quiet hours, a daily cap, and one chosen messaging route. Fresh installations keep it off.</p>
+        </article>
+        <article>
+          <div>
+            <span class="state">Independent updates</span>
+            <h3>Plugin Center</h3>
+          </div>
+          <p>The catalog comes from immutable GitHub Releases. A reviewed DSH 0.1.5-alpha.1-compatible plugin can join later without shipping a new desktop version merely to change a list. Signatures, hashes, permissions, and rollback protect distribution. Plugins still share the local DSH process.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section split" id="setup" data-reveal>
       <div class="copy">
-        <p class="eyebrow">First launch should not be a wall</p>
-        <h2>Seven steps, complete only after the first real reply.</h2>
+        <p class="eyebrow">First launch</p>
+        <h2>Seven steps, complete only after a real reply.</h2>
         <p>Choose language and appearance, read the local-data boundary, pick a provider and model from the official catalog, test your own API key, choose a real Workspace, then send the first message. You can go back, retry, and resume after restart. A failed request is never dressed up as success. The app data directory and the install directory cannot be Workspaces.</p>
         <ul class="workflow-list">
-          <li>Use the matching Apple Silicon, Intel Mac, or Windows x64 installer. Do not mix them.</li>
+          <li>Use the matching installer. Do not mix Apple Silicon, Intel, Windows, or UOS packages.</li>
           <li>Upgrade with the same-platform installer as a manual overlay. Updates are never silent.</li>
           <li>Default uninstall keeps user data. External Workspaces and the <code>Penglai/0.5</code> generation remain.</li>
         </ul>
       </div>
-      <img src="../shots/0.5.5/welcome.png" alt="Penglai 0.5.5 first-run welcome screen">
+      <img src="../shots/0.5.5/privacy.png" alt="Penglai first-run privacy step, explaining local YAML credentials and what is not logged">
     </section>
 
-    <section class="sea section" id="privacy" data-reveal>
-      <p class="eyebrow">Privacy and trust</p>
-      <h2>No Penglai account. A community distribution, without pretending its signature is an OS endorsement.</h2>
-      <div class="trust-grid">
-        <p><strong>No Penglai cloud sync.</strong> Official DSH bundles a session-telemetry adapter and a dormant DeepSeek OTLP endpoint. Penglai hard-disables that row after profile patches, so the owned DSH process constructs no SDK provider or upload pipeline. Model calls still send the context needed for that task to the provider you selected.</p>
-        <p><strong>Writes and outbound delivery need their own confirmation.</strong> Office save/return, personal Memory, and plugin install use product confirmation bound to that action. Diagnostic export must not contain credentials, chat bodies, QR codes, or private absolute paths.</p>
-        <p><strong>macOS is not notarized.</strong> The DMGs are ad-hoc signed; Windows has no Authenticode. Gatekeeper or SmartScreen may warn. Penglai Ed25519 signatures protect updater and plugin bytes; they are not Apple or Microsoft publisher identity.</p>
-        <p><strong>Plugins are not a sandbox.</strong> Signatures, hashes, permissions, and rollback protect distribution, but DSH plugins still share the local DSH process. Credential-free checks do not prove an external model reply or account message delivery.</p>
+    <section class="section limits" id="privacy" data-reveal>
+      <p class="eyebrow">Boundaries, in plain language</p>
+      <h2>No Penglai account. Model calls still leave the computer.</h2>
+      <div class="limit-grid">
+        <p><strong>Where data goes</strong> There is no Penglai account, Penglai-operated telemetry backend, or cloud memory sync. Official DSH bundles a dormant DeepSeek OTLP endpoint; Penglai hard-disables it. Model calls still send the context needed for that task to the provider you selected.</p>
+        <p><strong>What needs a confirmation</strong> Office save and return, personal Memory, plugin install, and outbound messaging use a confirmation bound to that action. Diagnostics must not contain credentials, chat bodies, QR codes, or private absolute paths.</p>
+        <p><strong>Signatures are not an OS endorsement</strong> macOS packages are ad-hoc signed and not notarized. Windows has no Authenticode. Gatekeeper or SmartScreen may warn. Penglai Ed25519 signatures protect updater and plugin bytes; they are not Apple or Microsoft publisher identity.</p>
+        <p><strong>UOS is a fourth target, not a finished native claim</strong> UnionTech UOS 20 LoongArch is packaged as <code>Penglai_0.6.0_uos_loong64.deb</code>. Native install, startup, and function on that host are Owner-tested after publication. That UOS runtime is Loongson Electron 31.7.7 (Chromium 126), not the Mac/Windows Electron 43 train.</p>
       </div>
     </section>
 
-    <section class="story section" id="story" data-reveal>
+    <section class="section download" id="download" data-reveal>
+      <p class="eyebrow">Penglai 0.6.0</p>
+      <h2>Choose the installer that matches the machine.</h2>
+      <p class="download-hint" id="downloadHint" hidden data-mac="This browser looks like a Mac. Apple Silicon is the usual choice on M-series machines; use Intel if About This Mac still says Intel." data-windows="This browser looks like Windows. Use the 64-bit installer." data-linux="This browser looks like Linux. The public Linux package is UnionTech UOS 20 LoongArch only."></p>
+      <div class="download-grid">
+        <a data-family="mac" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_aarch64.dmg">
+          <strong>macOS · Apple Silicon</strong>
+          <span>macOS 13+ · M1 and later</span>
+          <em>Penglai_0.6.0_macos_aarch64.dmg</em>
+        </a>
+        <a data-family="mac" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_x64.dmg">
+          <strong>macOS · Intel</strong>
+          <span>macOS 13+ · x86_64 Mac</span>
+          <em>Penglai_0.6.0_macos_x64.dmg</em>
+        </a>
+        <a data-family="windows" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_windows_x64_setup.exe">
+          <strong>Windows · x64</strong>
+          <span>Windows 10+ · 64-bit installer</span>
+          <em>Penglai_0.6.0_windows_x64_setup.exe</em>
+        </a>
+        <a data-family="linux" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_uos_loong64.deb">
+          <strong>UOS 20 · LoongArch</strong>
+          <span>UnionTech UOS 20 Professional 1070, old-world. Native function is Owner-tested after publication.</span>
+          <em>Penglai_0.6.0_uos_loong64.deb</em>
+        </a>
+      </div>
+      <p class="note-panel">The immutable GitHub Release is the authoritative public download source: <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0">v0.6.0</a>. Until those bytes exist and are read back, the last public installers remain <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12">v0.5.12</a>. After publication, check the file against <code>SHA256SUMS</code> on that page. Linux amd64 and Windows ARM are not targets. Updates are never silent.</p>
+      <div class="actions">
+        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/RELEASE_NOTES_0.6.0.md">Release notes draft</a>
+        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">Security notes</a>
+      </div>
+    </section>
+
+    <section class="section story" id="story" data-reveal>
       <p class="eyebrow">Why Penglai</p>
-      <blockquote>I spent more than ten years around networking, security, and operations, but I was not a software developer. Penglai began with one stubborn idea: in the age of AI, ordinary people should be able to build tools for themselves.</blockquote>
+      <blockquote>I spent more than ten years around networking, security, and operations, but I was not a software developer. Penglai began with one stubborn idea: ordinary people should be able to reach a real assistant from the computer they already have.</blockquote>
       <p>Computers travelled from command lines to windows and then into everyone's pocket. Agents should make the same trip. If I can send a message, I should be able to reach my own assistant. If it acts for me, I should be able to see what it was allowed to do, what actually happened, and what it cost.</p>
-      <p>Penglai has been rebuilt more than once. The important decision in 0.5 was to stop building another agent and stand on DeepSeek Harness instead, then do installation, Office, Memory, messaging, and local voice properly. Older generations remain in Git history because they explain the journey; their runtimes are not mixed into the new DSH core.</p>
+      <p>Penglai has been rebuilt more than once. The important decision in 0.5 was to stop building another agent and stand on DeepSeek Harness instead. 0.6.0 keeps that decision and puts the same product on four computers, including UnionTech UOS 20 LoongArch. Older generations remain in Git history; their runtimes are not mixed into this core.</p>
       <p class="signature">Kevin Chen / 陈克文</p>
     </section>
 
     <section class="section" id="faq" data-reveal>
       <p class="eyebrow">FAQ</p>
-      <h2>The limits, before the download buttons.</h2>
+      <h2>Short answers before you install.</h2>
       <div class="faq-grid">
         <article>
           <h3>Is Penglai another agent?</h3>
@@ -205,7 +245,7 @@
         </article>
         <article>
           <h3>Which version should I download?</h3>
-          <p>The public installers are 0.5.12. Published 0.5.10 and 0.5.11 remain immutable historical releases.</p>
+          <p>This page describes Penglai 0.6.0. Until the v0.6.0 Release is public, the last immutable installers are 0.5.12. Published 0.5.10 and 0.5.11 remain historical.</p>
         </article>
         <article>
           <h3>Why does Gatekeeper warn?</h3>
@@ -217,46 +257,25 @@
         </article>
         <article>
           <h3>What if the API key fails?</h3>
-          <p>The wizard supports Back, retry, and resume after restart. A failed credential test is never recorded as success. You can enter the key again or return to model selection.</p>
+          <p>The wizard supports Back, retry, and resume after restart. A failed credential test is never recorded as success.</p>
         </article>
         <article>
           <h3>Does uninstall delete my files?</h3>
           <p>Default uninstall removes the application and cache while preserving user data. Complete delete uses a separate category plan and must not recursively wipe a Workspace or home directory.</p>
         </article>
       </div>
-    </section>
-
-    <section class="download section" id="download" data-reveal>
-      <p class="eyebrow">Penglai 0.5.12</p>
-      <h2>Choose your computer.</h2>
-      <div class="download-grid">
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_aarch64.dmg">
-          <strong>macOS · Apple Silicon</strong>
-          <span>GitHub · 271.0 MiB · M1 / M2 / M3 / M4 / M5</span>
-          <code>1f6d7f9ceab13c62a6e31d52a0517c4972a52378e5ce102bf2983f3c32fd8034</code>
-        </a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_x64.dmg">
-          <strong>macOS · Intel</strong>
-          <span>GitHub · 280.2 MiB · x86_64 Mac</span>
-          <code>f82a5d44bccb7d15def176602f8320d1464eae802897e41c5ec39c8d471d61c3</code>
-        </a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_windows_x64_setup.exe">
-          <strong>Windows · x64</strong>
-          <span>GitHub · 353.9 MiB · 64-bit installer</span>
-          <code>5d926a884ca2b93c43f8ee8d8e8897df636585d449f1810d25ab4bffae3159da</code>
-        </a>
-      </div>
-      <p class="note-panel">The current public download is published 0.5.12. Published 0.5.10 and 0.5.11 remain immutable. The immutable GitHub Release is the sole authoritative public download source; the Beijing mirror has not published 0.5.12. All three installers come from source <code>54a0ef30afa4e3d653e400a637d4aa8eb4abbb75</code>. Full SHA256SUMS, SBOM, third-party notices, and signed update metadata are on the same page. Updates are never silent.</p>
-      <div class="actions centered">
-        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12">Bilingual release notes</a>
-        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">Security notes</a>
-      </div>
+      <p class="docs-row">
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/PRODUCT.md">Product contract</a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/PLUGIN_CENTER.md">Plugin Center</a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/0.6.0/ACCEPTANCE_DELTA.md">0.6.0 acceptance delta</a>
+      </p>
     </section>
   </main>
 
   <footer>
     <p>Penglai is created and maintained by <a href="https://github.com/kevinchennewbee">Kevin Chen / 陈克文</a>, built on <a href="https://github.com/deepseek-ai/deepseek-harness">DeepSeek Harness</a>, and released under MIT.</p>
-    <p>Multi-channel engineering references came from the <a href="https://github.com/xmanrui/dsh-im">DSH-IM</a> community, while official QQ Bot onboarding references came from <a href="https://github.com/tencent-connect/qqbot-agent-sdk">qqbot-agent-sdk</a>. Neither upstream runtime is bundled wholesale.</p>
+    <p>Multi-channel engineering references came from the <a href="https://github.com/xmanrui/dsh-im">DSH-IM</a> community. Official QQ Bot onboarding references came from <a href="https://github.com/tencent-connect/qqbot-agent-sdk">qqbot-agent-sdk</a>. Neither upstream runtime is bundled wholesale.</p>
     <p>Thanks to Electron, Node.js, TypeScript, pnpm, SenseVoice, sherpa-onnx, MOSS-TTS-Nano, Mnemon, Lark SDK, openclaw-weixin, and every contributor.</p>
     <p><span lang="en">English</span> · <a href="../zh/" hreflang="zh-CN" lang="zh-CN">中文</a></p>
   </footer>

--- a/website/en/index.html
+++ b/website/en/index.html
@@ -128,7 +128,7 @@
         <ul class="workflow-list">
           <li>You can turn memory off, or review candidates first.</li>
           <li>Authorised folders are indexed without changing the originals.</li>
-          <li>Candidate curation is a model call to the provider you selected. Storage and recall stay local. Mnemon 0.2.8 is bundled.</li>
+          <li>Candidate curation is a model call to the provider you selected. Storage and recall stay local. Memory is required and default-on, including on UOS, with the Mnemon 0.2.8 engine packed.</li>
         </ul>
       </div>
       <img src="../shots/0.5.5/memory.png" alt="Penglai Memory settings: Workspace scope, graph, correction, and migration">
@@ -150,7 +150,7 @@
             <span class="state">Opt in</span>
             <h3>Local voice</h3>
           </div>
-          <p>SenseVoice handles speech recognition. MOSS-TTS handles voice generation. Plugin code ships in the app. Large model weights explain themselves before downloading. Conversation Read speaks the original reply rather than translating it.</p>
+          <p>SenseVoice handles speech recognition. MOSS-TTS handles voice generation on Mac and Windows. Plugin code ships in the app. Large SenseVoice weights explain themselves before downloading. MOSS-TTS is not available and not enableable on LoongArch. Conversation Read speaks the original reply rather than translating it.</p>
         </article>
         <article>
           <div>
@@ -190,7 +190,7 @@
         <p><strong>Where data goes</strong> There is no Penglai account, Penglai-operated telemetry backend, or cloud memory sync. Official DSH bundles a dormant DeepSeek OTLP endpoint; Penglai hard-disables it. Model calls still send the context needed for that task to the provider you selected.</p>
         <p><strong>What needs a confirmation</strong> Office save and return, personal Memory, plugin install, and outbound messaging use a confirmation bound to that action. Diagnostics must not contain credentials, chat bodies, QR codes, or private absolute paths.</p>
         <p><strong>Signatures are not an OS endorsement</strong> macOS packages are ad-hoc signed and not notarized. Windows has no Authenticode. Gatekeeper or SmartScreen may warn. Penglai Ed25519 signatures protect updater and plugin bytes; they are not Apple or Microsoft publisher identity.</p>
-        <p><strong>UOS is a fourth target, not a finished native claim</strong> UnionTech UOS 20 LoongArch is packaged as <code>Penglai_0.6.0_uos_loong64.deb</code>. Native install, startup, and function on that host are Owner-tested after publication. That UOS runtime is Loongson Electron 31.7.7 (Chromium 126), not the Mac/Windows Electron 43 train.</p>
+        <p><strong>UOS is a fourth target, not a finished native claim</strong> UnionTech UOS 20 LoongArch is packaged as <code>Penglai_0.6.0_uos_loong64.deb</code>. Native install, startup, and function on that host remain Owner post-publication testing (<code>OWNER_POST_RELEASE</code>), not PASS. That UOS runtime is Loongson Electron 31.7.7 (Chromium 126). It is not maintained and is not a Chromium 150 / Electron 43 security equivalent of Mac/Windows. Memory stays required/on with the packed Mnemon engine. MOSS-TTS is not available and not enableable on LoongArch.</p>
       </div>
     </section>
 
@@ -201,28 +201,32 @@
       <div class="download-grid">
         <a data-family="mac" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_aarch64.dmg">
           <strong>macOS · Apple Silicon</strong>
-          <span>macOS 13+ · M1 and later</span>
+          <span>GitHub · 271.2 MiB · macOS 13+ · M1 and later</span>
           <em>Penglai_0.6.0_macos_aarch64.dmg</em>
+          <code>98d1c0a133d50200c03626d39e225a52ff08d1f1a09fdb1595ab706b70f183cb</code>
         </a>
         <a data-family="mac" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_x64.dmg">
           <strong>macOS · Intel</strong>
-          <span>macOS 13+ · x86_64 Mac</span>
+          <span>GitHub · 280.4 MiB · x86_64 Mac</span>
           <em>Penglai_0.6.0_macos_x64.dmg</em>
+          <code>4c74a4ce9353ccf23aa74471d279237c4b5b9822d118aa2a90e44e16caf16498</code>
         </a>
         <a data-family="windows" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_windows_x64_setup.exe">
           <strong>Windows · x64</strong>
-          <span>Windows 10+ · 64-bit installer</span>
+          <span>GitHub · 352.7 MiB · 64-bit installer</span>
           <em>Penglai_0.6.0_windows_x64_setup.exe</em>
+          <code>6316f623fe877686662b7b3a5641945bc946e2b1dd31bf3d9527c6a17f7c35e9</code>
         </a>
         <a data-family="linux" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_uos_loong64.deb">
           <strong>UOS 20 · LoongArch</strong>
-          <span>UnionTech UOS 20 Professional 1070, old-world. Native function is Owner-tested after publication.</span>
+          <span>GitHub · 279.1 MiB · UOS 20 Professional 1070, old-world. Native function is Owner post-publication.</span>
           <em>Penglai_0.6.0_uos_loong64.deb</em>
+          <code>a541e9fa9b06626750b4a87859cc76ff3df51b5a0eb8960de08e8eba20cad430</code>
         </a>
       </div>
-      <p class="note-panel">The immutable GitHub Release is the authoritative public download source: <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0">v0.6.0</a>. Until those bytes exist and are read back, the last public installers remain <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12">v0.5.12</a>. After publication, check the file against <code>SHA256SUMS</code> on that page. Linux amd64 and Windows ARM are not targets. Updates are never silent.</p>
+      <p class="note-panel">The immutable GitHub Release is the authoritative public download source: <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0">v0.6.0</a>. All four installers come from source <code>7dd68b4ab08bbe4edf4dfac7f82abb6b164cb316</code>. Check the file against <code>SHA256SUMS</code> on that page. Linux amd64 and Windows ARM are not targets. Updates are never silent. Published 0.5.10, 0.5.11, and 0.5.12 remain immutable.</p>
       <div class="actions">
-        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/RELEASE_NOTES_0.6.0.md">Release notes draft</a>
+        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/RELEASE_NOTES_0.6.0.md">Release notes</a>
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">Security notes</a>
       </div>
     </section>
@@ -245,7 +249,7 @@
         </article>
         <article>
           <h3>Which version should I download?</h3>
-          <p>This page describes Penglai 0.6.0. Until the v0.6.0 Release is public, the last immutable installers are 0.5.12. Published 0.5.10 and 0.5.11 remain historical.</p>
+          <p>This page describes published Penglai 0.6.0. Download the matching installer from the immutable <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0">v0.6.0</a> GitHub Release. Published 0.5.10, 0.5.11, and 0.5.12 remain historical and immutable.</p>
         </article>
         <article>
           <h3>Why does Gatekeeper warn?</h3>

--- a/website/favicon.svg
+++ b/website/favicon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" fill="#0B1C2C"/>
-  <rect x="6" y="6" width="52" height="52" fill="#C45C26" stroke="#C9A36A" stroke-width="1.5"/>
-  <text x="32" y="46" text-anchor="middle" font-size="36" font-family="Georgia, serif" fill="#F6F1E8">蓬</text>
+  <rect width="64" height="64" fill="#F3EEE4"/>
+  <rect x="8" y="8" width="48" height="48" fill="#C45C26" stroke="#C4A56A" stroke-width="1.5"/>
+  <text x="32" y="46" text-anchor="middle" font-size="32" font-family="Georgia, 'Songti SC', serif" fill="#F3EEE4">蓬</text>
 </svg>

--- a/website/index.html
+++ b/website/index.html
@@ -127,7 +127,7 @@
         <ul class="workflow-list">
           <li>You can turn memory off, or review candidates first.</li>
           <li>Authorised folders are indexed without changing the originals.</li>
-          <li>Candidate curation is a model call to the provider you selected. Storage and recall stay local. Mnemon 0.2.8 is bundled.</li>
+          <li>Candidate curation is a model call to the provider you selected. Storage and recall stay local. Memory is required and default-on, including on UOS, with the Mnemon 0.2.8 engine packed.</li>
         </ul>
       </div>
       <img src="./shots/0.5.5/memory.png" alt="Penglai Memory settings: Workspace scope, graph, correction, and migration">
@@ -149,7 +149,7 @@
             <span class="state">Opt in</span>
             <h3>Local voice</h3>
           </div>
-          <p>SenseVoice handles speech recognition. MOSS-TTS handles voice generation. Plugin code ships in the app. Large model weights explain themselves before downloading. Conversation Read speaks the original reply rather than translating it.</p>
+          <p>SenseVoice handles speech recognition. MOSS-TTS handles voice generation on Mac and Windows. Plugin code ships in the app. Large SenseVoice weights explain themselves before downloading. MOSS-TTS is not available and not enableable on LoongArch. Conversation Read speaks the original reply rather than translating it.</p>
         </article>
         <article>
           <div>
@@ -189,7 +189,7 @@
         <p><strong>Where data goes</strong> There is no Penglai account, Penglai-operated telemetry backend, or cloud memory sync. Official DSH bundles a dormant DeepSeek OTLP endpoint; Penglai hard-disables it. Model calls still send the context needed for that task to the provider you selected.</p>
         <p><strong>What needs a confirmation</strong> Office save and return, personal Memory, plugin install, and outbound messaging use a confirmation bound to that action. Diagnostics must not contain credentials, chat bodies, QR codes, or private absolute paths.</p>
         <p><strong>Signatures are not an OS endorsement</strong> macOS packages are ad-hoc signed and not notarized. Windows has no Authenticode. Gatekeeper or SmartScreen may warn. Penglai Ed25519 signatures protect updater and plugin bytes; they are not Apple or Microsoft publisher identity.</p>
-        <p><strong>UOS is a fourth target, not a finished native claim</strong> UnionTech UOS 20 LoongArch is packaged as <code>Penglai_0.6.0_uos_loong64.deb</code>. Native install, startup, and function on that host are Owner-tested after publication. That UOS runtime is Loongson Electron 31.7.7 (Chromium 126), not the Mac/Windows Electron 43 train.</p>
+        <p><strong>UOS is a fourth target, not a finished native claim</strong> UnionTech UOS 20 LoongArch is packaged as <code>Penglai_0.6.0_uos_loong64.deb</code>. Native install, startup, and function on that host remain Owner post-publication testing (<code>OWNER_POST_RELEASE</code>), not PASS. That UOS runtime is Loongson Electron 31.7.7 (Chromium 126). It is not maintained and is not a Chromium 150 / Electron 43 security equivalent of Mac/Windows. Memory stays required/on with the packed Mnemon engine. MOSS-TTS is not available and not enableable on LoongArch.</p>
       </div>
     </section>
 
@@ -200,28 +200,32 @@
       <div class="download-grid">
         <a data-family="mac" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_aarch64.dmg">
           <strong>macOS · Apple Silicon</strong>
-          <span>macOS 13+ · M1 and later</span>
+          <span>GitHub · 271.2 MiB · macOS 13+ · M1 and later</span>
           <em>Penglai_0.6.0_macos_aarch64.dmg</em>
+          <code>98d1c0a133d50200c03626d39e225a52ff08d1f1a09fdb1595ab706b70f183cb</code>
         </a>
         <a data-family="mac" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_x64.dmg">
           <strong>macOS · Intel</strong>
-          <span>macOS 13+ · x86_64 Mac</span>
+          <span>GitHub · 280.4 MiB · x86_64 Mac</span>
           <em>Penglai_0.6.0_macos_x64.dmg</em>
+          <code>4c74a4ce9353ccf23aa74471d279237c4b5b9822d118aa2a90e44e16caf16498</code>
         </a>
         <a data-family="windows" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_windows_x64_setup.exe">
           <strong>Windows · x64</strong>
-          <span>Windows 10+ · 64-bit installer</span>
+          <span>GitHub · 352.7 MiB · 64-bit installer</span>
           <em>Penglai_0.6.0_windows_x64_setup.exe</em>
+          <code>6316f623fe877686662b7b3a5641945bc946e2b1dd31bf3d9527c6a17f7c35e9</code>
         </a>
         <a data-family="linux" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_uos_loong64.deb">
           <strong>UOS 20 · LoongArch</strong>
-          <span>UnionTech UOS 20 Professional 1070, old-world. Native function is Owner-tested after publication.</span>
+          <span>GitHub · 279.1 MiB · UOS 20 Professional 1070, old-world. Native function is Owner post-publication.</span>
           <em>Penglai_0.6.0_uos_loong64.deb</em>
+          <code>a541e9fa9b06626750b4a87859cc76ff3df51b5a0eb8960de08e8eba20cad430</code>
         </a>
       </div>
-      <p class="note-panel">The immutable GitHub Release is the authoritative public download source: <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0">v0.6.0</a>. Until those bytes exist and are read back, the last public installers remain <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12">v0.5.12</a>. After publication, check the file against <code>SHA256SUMS</code> on that page. Linux amd64 and Windows ARM are not targets. Updates are never silent.</p>
+      <p class="note-panel">The immutable GitHub Release is the authoritative public download source: <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0">v0.6.0</a>. All four installers come from source <code>7dd68b4ab08bbe4edf4dfac7f82abb6b164cb316</code>. Check the file against <code>SHA256SUMS</code> on that page. Linux amd64 and Windows ARM are not targets. Updates are never silent. Published 0.5.10, 0.5.11, and 0.5.12 remain immutable.</p>
       <div class="actions">
-        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/RELEASE_NOTES_0.6.0.md">Release notes draft</a>
+        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/RELEASE_NOTES_0.6.0.md">Release notes</a>
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">Security notes</a>
       </div>
     </section>
@@ -244,7 +248,7 @@
         </article>
         <article>
           <h3>Which version should I download?</h3>
-          <p>This page describes Penglai 0.6.0. Until the v0.6.0 Release is public, the last immutable installers are 0.5.12. Published 0.5.10 and 0.5.11 remain historical.</p>
+          <p>This page describes published Penglai 0.6.0. Download the matching installer from the immutable <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0">v0.6.0</a> GitHub Release. Published 0.5.10, 0.5.11, and 0.5.12 remain historical and immutable.</p>
         </article>
         <article>
           <h3>Why does Gatekeeper warn?</h3>

--- a/website/index.html
+++ b/website/index.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Penglai 0.5.12 | DeepSeek Harness, ready for a personal computer</title>
-  <meta name="description" content="Penglai 0.5.12 is an installable desktop distribution of official DeepSeek Harness 0.1.3-alpha.2, with Office, Memory, messaging, and local voice.">
-  <meta property="og:title" content="Penglai 0.5.12">
-  <meta property="og:description" content="DeepSeek Harness, ready to install. Office, Memory, mobile messaging, and local voice in one desktop distribution.">
-  <meta name="theme-color" content="#0B1C2C">
+  <title>Penglai 0.6.0 | Make room for the work that matters</title>
+  <meta name="description" content="Penglai 0.6.0 installs official DeepSeek Harness 0.1.5-alpha.1 on a personal computer, with Office, Memory, messaging, and local voice. Apple Silicon, Intel Mac, Windows x64, and UnionTech UOS 20 LoongArch.">
+  <meta property="og:title" content="Penglai 0.6.0">
+  <meta property="og:description" content="Official DeepSeek Harness, installed on your computer. Office and Memory start on. You finish setup after the first real reply.">
+  <meta name="theme-color" content="#F3EEE4">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://penglai.pages.dev/">
   <meta property="og:locale" content="en_US">
   <meta property="og:locale:alternate" content="zh_CN">
-  <meta property="og:image" content="https://penglai.pages.dev/shots/0.5.5/plugin-center.png">
-  <meta property="og:image:alt" content="Penglai 0.5.5 Plugin Center, kept as a historical UI reference">
+  <meta property="og:image" content="https://penglai.pages.dev/shots/0.5.5/welcome.png">
+  <meta property="og:image:alt" content="Penglai first-run welcome from the installed 0.5.5 UI, kept as a historical reference">
   <link rel="icon" href="./favicon.svg" type="image/svg+xml">
   <link rel="canonical" href="https://penglai.pages.dev/">
   <link rel="alternate" hreflang="en" href="https://penglai.pages.dev/">
@@ -30,11 +30,8 @@
       <span></span>
     </button>
     <nav id="navLinks" aria-label="Main navigation">
-      <a href="#new">Product</a>
-      <a href="#inside">Inside</a>
+      <a href="#product">Product</a>
       <a href="#setup">Setup</a>
-      <a href="#privacy">Privacy</a>
-      <a href="#faq">FAQ</a>
       <a href="#download">Download</a>
       <a href="./zh/" hreflang="zh-CN" lang="zh-CN">中文</a>
       <a class="github" href="https://github.com/kevinchennewbee/PenglaiAgent">GitHub</a>
@@ -43,160 +40,203 @@
 
   <main id="main">
     <section class="hero" id="top">
-      <div class="hero-clouds" aria-hidden="true">
-        <span class="cloud c1"></span>
-        <span class="cloud c2"></span>
-        <span class="cloud c3"></span>
-      </div>
-      <canvas id="hero-canvas" class="hero-canvas" aria-hidden="true"></canvas>
-      <img class="hero-art" src="./shots/banner-v1.png" alt="The island of Penglai rising above a sea of clouds">
-      <div class="hero-shade"></div>
-      <div class="hero-copy">
-        <p class="eyebrow">Penglai 0.5.12 · DeepSeek Harness 0.1.3-alpha.2</p>
-        <h1>Not another agent.<br>Official DeepSeek Harness,<br>installed on your computer.</h1>
-        <p class="lead">Penglai puts official DeepSeek Harness, Node, Electron, first-run setup, updates, uninstall, and a reviewed set of DSH plugins into one desktop app. You do not need to learn a terminal first, or move daily work into another cloud account.</p>
-        <div class="actions">
-          <a class="button primary" href="#download">Download 0.5.12</a>
-          <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent">Read the source</a>
+      <div class="hero-inner">
+        <div class="hero-copy">
+          <p class="eyebrow">Penglai 0.6.0</p>
+          <h1>Make room for the work that matters.</h1>
+          <p class="lead">Penglai installs official DeepSeek Harness on a personal computer. You bring a model key, choose a Workspace, and finish setup only after the first real reply. Office and Memory start on. The rest waits until you ask.</p>
+          <div class="actions">
+            <a class="button primary" href="#download">Choose your computer</a>
+            <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent">Read the source</a>
+          </div>
+          <p class="meta-row">
+            <span>Apple Silicon</span>
+            <span>Intel Mac</span>
+            <span>Windows x64</span>
+            <span>UOS 20 LoongArch</span>
+            <span>MIT</span>
+          </p>
         </div>
-        <p class="quiet">MIT licensed · Local first · Apple Silicon / Intel Mac / Windows x64</p>
+        <figure>
+          <div class="app-frame">
+            <div class="app-chrome" aria-hidden="true"><i></i><i></i><i></i><span>Penglai</span></div>
+            <img src="./shots/0.5.5/welcome.png" alt="Penglai first-run welcome: language, appearance, and a seven-step guide">
+          </div>
+          <figcaption>Installed 0.5.5 first-run welcome, kept as a UI reference. This is not a 0.6.0 screenshot.</figcaption>
+        </figure>
       </div>
     </section>
 
-    <section class="intro" id="new" data-reveal>
+    <section class="use-band wrap" data-reveal>
+      <div class="use-grid">
+        <article>
+          <h3>Edit the file in front of you</h3>
+          <p>Office can inspect, create, preview, and save DOCX, XLSX, PPTX, and PDF. A write waits for a confirmation bound to that action.</p>
+        </article>
+        <article>
+          <h3>Remember this project only</h3>
+          <p>Memory organizes safe facts inside the current Workspace. The next Workspace cannot peek. Storage stays on this computer.</p>
+        </article>
+        <article>
+          <h3>Message when you need it</h3>
+          <p>Weixin, Feishu, and six other channels can join the same official Session. WhatsApp is not a product surface.</p>
+        </article>
+        <article>
+          <h3>Speak only if you install it</h3>
+          <p>Speech recognition and voice generation stay off until you download their models. Ordinary chat still works without them.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section core" id="product" data-reveal>
       <div>
-        <p class="eyebrow">DSH remains the only core</p>
-        <h2>Penglai owns install and boundaries. The conversation still belongs to DeepSeek Harness.</h2>
+        <p class="eyebrow">The core does not change</p>
+        <h2>DeepSeek Harness still owns the conversation.</h2>
         <div class="gold-rule" aria-hidden="true"></div>
       </div>
-      <p>Official DeepSeek Harness owns models, tools, approvals, Workspace, Session, Turn, and the conversation interface. Penglai 0.5.12 consumes the exact official <code>0.1.3-alpha.2</code> npm packages, tag <code>dsh-v0.1.3-alpha.2</code>, commit <code>82a5fd61a7cf5c293cec4bdff68f455398d685e9</code>. Message recovery, budget reconciliation and Companion replay use its Session snapshot API. Upgrades from 0.5.8, 0.5.9, 0.5.10 and 0.5.11 prepare a separate data generation and keep the previous one for rollback. All three native installers come from source <code>54a0ef30afa4e3d653e400a637d4aa8eb4abbb75</code>.</p>
-    </section>
-
-    <figure class="feature-shot wide-shot" data-reveal>
-      <img src="./shots/0.5.5/plugin-center.png" alt="The real Penglai 0.5.5 Plugin Center running in installed DSH settings">
-      <figcaption>An installed 0.5.5 screen kept as a UI reference. Native installation and public-byte evidence for 0.5.12 is recorded in its publication manifest; these frames are not 0.5.12 screenshots.</figcaption>
-    </figure>
-
-    <section class="section" id="inside" data-reveal>
-      <p class="eyebrow">Already in the installer</p>
-      <h2>Office and Memory start on. Everything else waits for you.</h2>
-      <div class="cards">
-        <article>
-          <span class="state on">On by default</span>
-          <h3>Penglai Office</h3>
-          <p>Inspect, create, edit, preview, and save DOCX, XLSX, PPTX, and PDF. Writes have a plan and confirmation. PDF output includes a Chinese font. LibreOffice is not a user dependency.</p>
-        </article>
-        <article>
-          <span class="state on">On by default</span>
-          <h3>Penglai Memory</h3>
-          <p>Safe project facts can be organized inside the current Workspace. Candidate curation calls your selected model provider; storage and recall stay local. Personal facts still need an explicit save, and recall never crosses Workspaces.</p>
-        </article>
-        <article>
-          <span class="state">Opt in</span>
-          <h3>Messaging</h3>
-          <p>Weixin, Feishu, DingTalk, WeCom, QQ, Slack, Telegram, and Discord enter one <code>@penglai/im</code> control plane, using each platform's QR, device-registration, or official-token flow. WhatsApp is not displayed, supported, or bundled in 0.5.12.</p>
-        </article>
-        <article>
-          <span class="state">Opt in</span>
-          <h3>Local voice</h3>
-          <p>SenseVoice handles speech recognition; MOSS-TTS handles voice generation. Conversation Read speaks the original reply rather than translating it. Plugin code ships in the app. Large model weights explain themselves before downloading.</p>
-        </article>
-        <article>
-          <span class="state">Opt in</span>
-          <h3>Companion</h3>
-          <p>It contacts you only after you turn it on, and stays within quiet hours, a daily cap, and one chosen messaging route. Fresh installations keep it off.</p>
-        </article>
-        <article>
-          <span class="state">Independent updates</span>
-          <h3>Signed Plugin Center</h3>
-          <p>The catalog comes from immutable GitHub Releases. A reviewed DSH 0.1.3-alpha.2-compatible plugin can join later without shipping a new desktop version merely to change a list. UI state is never proof of installation or health.</p>
-        </article>
+      <div>
+        <p>Official DeepSeek Harness is the only agent core. It owns models, tools, approvals, Workspace, Session, Turn, and the conversation interface. Penglai owns the installer, first-run, process supervision, updates, uninstall, local paths, and a reviewed plugin set. There is no second Penglai agent and no replacement chat page. Session history upgrades copy logs into new files and keep the originals. Upgrades from 0.5.12 copy a lived-in DSH Home without regenerating installation links.</p>
+        <p class="identity">Penglai 0.6.0 · DSH <code>0.1.5-alpha.1</code> · tag <code>dsh-v0.1.5-alpha.1</code> · commit <code>5dda764ed3aa172535a7967b06ff95d9cbfe536a</code> · 272 packages</p>
       </div>
     </section>
 
-    <section class="gallery" aria-label="Installed Penglai 0.5.5 UI references" data-reveal>
-      <figure>
-        <img src="./shots/0.5.5/office.png" alt="Penglai Office settings">
-        <figcaption>Office: create, inspect, and confirmed edits</figcaption>
-      </figure>
-      <figure>
-        <img src="./shots/0.5.5/memory.png" alt="Penglai Memory settings">
-        <figcaption>Memory: Workspace isolation, graph, correction, migration</figcaption>
-      </figure>
-      <figure>
-        <img src="./shots/0.5.5/mobile-messaging.png" alt="Penglai Mobile Messaging settings">
-        <figcaption>Messaging: Weixin and Feishu in one IM plugin</figcaption>
-      </figure>
-      <figure>
-        <img src="./shots/0.5.5/speech-recognition.png" alt="Penglai speech recognition settings">
-        <figcaption>Speech recognition: the microphone appears after setup</figcaption>
-      </figure>
-    </section>
+    <figure class="wide-shot" data-reveal>
+      <img src="./shots/0.5.5/plugin-center.png" alt="Penglai Plugin Center inside official DSH settings, showing Office, Memory, messaging, and voice">
+      <figcaption>Installed 0.5.5 Plugin Center, running in official DSH settings. UI state is never proof that a plugin is installed or healthy. Not a 0.6.0 screenshot.</figcaption>
+    </figure>
 
     <section class="section split" data-reveal>
       <div class="copy">
-        <p class="eyebrow">A real office path</p>
-        <h2>Files enter a Workspace. Writes wait for confirmation.</h2>
-        <p>Penglai Office is a closed set of typed operations: inspect, create, build a visible edit plan, preview, commit after confirmation, and undo the last commit. Models cannot invent host paths or run macros. Inputs and outputs are host-issued <code>artifact:&lt;uuid&gt;</code> handles, and Workspace bounds are checked again at the operation.</p>
+        <p class="eyebrow">Penglai Office · on by default</p>
+        <h2>Files enter a Workspace. Writes wait.</h2>
+        <p>Office is a closed set of typed operations: inspect, create, build a visible edit plan, preview, commit after confirmation, and undo the last commit. Models cannot invent host paths or run macros. Inputs and outputs are host-issued <code>artifact:&lt;uuid&gt;</code> handles, checked again at the operation.</p>
         <ul class="workflow-list">
           <li>DOCX, XLSX, PPTX, and PDF share one product path.</li>
-          <li>PDF output bundles an OFL Chinese font.</li>
-          <li>Save, export, and return bind the exact action — not a casual “ok” in chat.</li>
+          <li>PDF output bundles an OFL Chinese font. LibreOffice is not a user dependency.</li>
+          <li>Save, export, and return bind the exact action, not a casual yes in chat.</li>
         </ul>
       </div>
-      <img src="./shots/0.5.5/office.png" alt="Penglai Office create, inspect, and planned-edit controls">
+      <img src="./shots/0.5.5/office.png" alt="Penglai Office settings: create, inspect, and planned edits for a DOCX file">
     </section>
 
     <section class="section split reverse" data-reveal>
       <div class="copy">
-        <p class="eyebrow">Memory that knows its project</p>
-        <h2>This Workspace can remember. The next one cannot peek.</h2>
-        <p>A fresh install organizes safe project facts inside the current Workspace. After a Turn, a no-tools official Agent uses your current provider and model; the host validates a closed schema and skips secrets, sensitive text, and injection-like output. Later steps recall only confirmed records from this Workspace, plus personal facts you explicitly saved.</p>
+        <p class="eyebrow">Penglai Memory · on by default</p>
+        <h2>This Workspace can remember. The next one cannot.</h2>
+        <p>After a Turn, a no-tools official Agent uses your current provider and model to propose safe project facts. The host validates a closed schema and skips secrets, sensitive text, and injection-like output. Later steps recall only confirmed records from this Workspace, plus personal facts you explicitly saved.</p>
         <ul class="workflow-list">
           <li>You can turn memory off, or review candidates first.</li>
           <li>Authorised folders are indexed without changing the originals.</li>
-          <li>Mnemon 0.2.8 is the only recall engine and is already bundled.</li>
+          <li>Candidate curation is a model call to the provider you selected. Storage and recall stay local. Mnemon 0.2.8 is bundled.</li>
         </ul>
       </div>
-      <img src="./shots/0.5.5/memory.png" alt="Penglai Memory scope, graph, and correction">
+      <img src="./shots/0.5.5/memory.png" alt="Penglai Memory settings: Workspace scope, graph, correction, and migration">
     </section>
 
-    <section class="section split first-run" id="setup" data-reveal>
+    <section class="section" data-reveal>
+      <p class="eyebrow">Waiting until you ask</p>
+      <h2>Optional tools stay out of the way.</h2>
+      <div class="opt-list">
+        <article>
+          <div>
+            <span class="state">Opt in</span>
+            <h3>Messaging</h3>
+          </div>
+          <p>Weixin, Feishu, DingTalk, WeCom, QQ, Slack, Telegram, and Discord enter one <code>@penglai/im</code> control plane, using each platform's QR, device-registration, or official-token flow. WhatsApp is not displayed, supported, or bundled.</p>
+        </article>
+        <article>
+          <div>
+            <span class="state">Opt in</span>
+            <h3>Local voice</h3>
+          </div>
+          <p>SenseVoice handles speech recognition. MOSS-TTS handles voice generation. Plugin code ships in the app. Large model weights explain themselves before downloading. Conversation Read speaks the original reply rather than translating it.</p>
+        </article>
+        <article>
+          <div>
+            <span class="state">Opt in</span>
+            <h3>Companion</h3>
+          </div>
+          <p>It contacts you only after you turn it on, and stays within quiet hours, a daily cap, and one chosen messaging route. Fresh installations keep it off.</p>
+        </article>
+        <article>
+          <div>
+            <span class="state">Independent updates</span>
+            <h3>Plugin Center</h3>
+          </div>
+          <p>The catalog comes from immutable GitHub Releases. A reviewed DSH 0.1.5-alpha.1-compatible plugin can join later without shipping a new desktop version merely to change a list. Signatures, hashes, permissions, and rollback protect distribution. Plugins still share the local DSH process.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section split" id="setup" data-reveal>
       <div class="copy">
-        <p class="eyebrow">First launch should not be a wall</p>
-        <h2>Seven steps, complete only after the first real reply.</h2>
+        <p class="eyebrow">First launch</p>
+        <h2>Seven steps, complete only after a real reply.</h2>
         <p>Choose language and appearance, read the local-data boundary, pick a provider and model from the official catalog, test your own API key, choose a real Workspace, then send the first message. You can go back, retry, and resume after restart. A failed request is never dressed up as success. The app data directory and the install directory cannot be Workspaces.</p>
         <ul class="workflow-list">
-          <li>Use the matching Apple Silicon, Intel Mac, or Windows x64 installer. Do not mix them.</li>
+          <li>Use the matching installer. Do not mix Apple Silicon, Intel, Windows, or UOS packages.</li>
           <li>Upgrade with the same-platform installer as a manual overlay. Updates are never silent.</li>
           <li>Default uninstall keeps user data. External Workspaces and the <code>Penglai/0.5</code> generation remain.</li>
         </ul>
       </div>
-      <img src="./shots/0.5.5/welcome.png" alt="Penglai 0.5.5 first-run welcome screen">
+      <img src="./shots/0.5.5/privacy.png" alt="Penglai first-run privacy step, explaining local YAML credentials and what is not logged">
     </section>
 
-    <section class="sea section" id="privacy" data-reveal>
-      <p class="eyebrow">Privacy and trust</p>
-      <h2>No Penglai account. A community distribution, without pretending its signature is an OS endorsement.</h2>
-      <div class="trust-grid">
-        <p><strong>No Penglai cloud sync.</strong> Official DSH bundles a session-telemetry adapter and a dormant DeepSeek OTLP endpoint. Penglai hard-disables that row after profile patches, so the owned DSH process constructs no SDK provider or upload pipeline. Model calls still send the context needed for that task to the provider you selected.</p>
-        <p><strong>Writes and outbound delivery need their own confirmation.</strong> Office save/return, personal Memory, and plugin install use product confirmation bound to that action. Diagnostic export must not contain credentials, chat bodies, QR codes, or private absolute paths.</p>
-        <p><strong>macOS is not notarized.</strong> The DMGs are ad-hoc signed; Windows has no Authenticode. Gatekeeper or SmartScreen may warn. Penglai Ed25519 signatures protect updater and plugin bytes; they are not Apple or Microsoft publisher identity.</p>
-        <p><strong>Plugins are not a sandbox.</strong> Signatures, hashes, permissions, and rollback protect distribution, but DSH plugins still share the local DSH process. Credential-free checks do not prove an external model reply or account message delivery.</p>
+    <section class="section limits" id="privacy" data-reveal>
+      <p class="eyebrow">Boundaries, in plain language</p>
+      <h2>No Penglai account. Model calls still leave the computer.</h2>
+      <div class="limit-grid">
+        <p><strong>Where data goes</strong> There is no Penglai account, Penglai-operated telemetry backend, or cloud memory sync. Official DSH bundles a dormant DeepSeek OTLP endpoint; Penglai hard-disables it. Model calls still send the context needed for that task to the provider you selected.</p>
+        <p><strong>What needs a confirmation</strong> Office save and return, personal Memory, plugin install, and outbound messaging use a confirmation bound to that action. Diagnostics must not contain credentials, chat bodies, QR codes, or private absolute paths.</p>
+        <p><strong>Signatures are not an OS endorsement</strong> macOS packages are ad-hoc signed and not notarized. Windows has no Authenticode. Gatekeeper or SmartScreen may warn. Penglai Ed25519 signatures protect updater and plugin bytes; they are not Apple or Microsoft publisher identity.</p>
+        <p><strong>UOS is a fourth target, not a finished native claim</strong> UnionTech UOS 20 LoongArch is packaged as <code>Penglai_0.6.0_uos_loong64.deb</code>. Native install, startup, and function on that host are Owner-tested after publication. That UOS runtime is Loongson Electron 31.7.7 (Chromium 126), not the Mac/Windows Electron 43 train.</p>
       </div>
     </section>
 
-    <section class="story section" id="story" data-reveal>
+    <section class="section download" id="download" data-reveal>
+      <p class="eyebrow">Penglai 0.6.0</p>
+      <h2>Choose the installer that matches the machine.</h2>
+      <p class="download-hint" id="downloadHint" hidden data-mac="This browser looks like a Mac. Apple Silicon is the usual choice on M-series machines; use Intel if About This Mac still says Intel." data-windows="This browser looks like Windows. Use the 64-bit installer." data-linux="This browser looks like Linux. The public Linux package is UnionTech UOS 20 LoongArch only."></p>
+      <div class="download-grid">
+        <a data-family="mac" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_aarch64.dmg">
+          <strong>macOS · Apple Silicon</strong>
+          <span>macOS 13+ · M1 and later</span>
+          <em>Penglai_0.6.0_macos_aarch64.dmg</em>
+        </a>
+        <a data-family="mac" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_x64.dmg">
+          <strong>macOS · Intel</strong>
+          <span>macOS 13+ · x86_64 Mac</span>
+          <em>Penglai_0.6.0_macos_x64.dmg</em>
+        </a>
+        <a data-family="windows" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_windows_x64_setup.exe">
+          <strong>Windows · x64</strong>
+          <span>Windows 10+ · 64-bit installer</span>
+          <em>Penglai_0.6.0_windows_x64_setup.exe</em>
+        </a>
+        <a data-family="linux" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_uos_loong64.deb">
+          <strong>UOS 20 · LoongArch</strong>
+          <span>UnionTech UOS 20 Professional 1070, old-world. Native function is Owner-tested after publication.</span>
+          <em>Penglai_0.6.0_uos_loong64.deb</em>
+        </a>
+      </div>
+      <p class="note-panel">The immutable GitHub Release is the authoritative public download source: <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0">v0.6.0</a>. Until those bytes exist and are read back, the last public installers remain <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12">v0.5.12</a>. After publication, check the file against <code>SHA256SUMS</code> on that page. Linux amd64 and Windows ARM are not targets. Updates are never silent.</p>
+      <div class="actions">
+        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/RELEASE_NOTES_0.6.0.md">Release notes draft</a>
+        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">Security notes</a>
+      </div>
+    </section>
+
+    <section class="section story" id="story" data-reveal>
       <p class="eyebrow">Why Penglai</p>
-      <blockquote>I spent more than ten years around networking, security, and operations, but I was not a software developer. Penglai began with one stubborn idea: in the age of AI, ordinary people should be able to build tools for themselves.</blockquote>
+      <blockquote>I spent more than ten years around networking, security, and operations, but I was not a software developer. Penglai began with one stubborn idea: ordinary people should be able to reach a real assistant from the computer they already have.</blockquote>
       <p>Computers travelled from command lines to windows and then into everyone's pocket. Agents should make the same trip. If I can send a message, I should be able to reach my own assistant. If it acts for me, I should be able to see what it was allowed to do, what actually happened, and what it cost.</p>
-      <p>Penglai has been rebuilt more than once. The important decision in 0.5 was to stop building another agent and stand on DeepSeek Harness instead, then do installation, Office, Memory, messaging, and local voice properly. Older generations remain in Git history because they explain the journey; their runtimes are not mixed into the new DSH core.</p>
+      <p>Penglai has been rebuilt more than once. The important decision in 0.5 was to stop building another agent and stand on DeepSeek Harness instead. 0.6.0 keeps that decision and puts the same product on four computers, including UnionTech UOS 20 LoongArch. Older generations remain in Git history; their runtimes are not mixed into this core.</p>
       <p class="signature">Kevin Chen / 陈克文</p>
     </section>
 
     <section class="section" id="faq" data-reveal>
       <p class="eyebrow">FAQ</p>
-      <h2>The limits, before the download buttons.</h2>
+      <h2>Short answers before you install.</h2>
       <div class="faq-grid">
         <article>
           <h3>Is Penglai another agent?</h3>
@@ -204,7 +244,7 @@
         </article>
         <article>
           <h3>Which version should I download?</h3>
-          <p>The public installers are 0.5.12. Published 0.5.10 and 0.5.11 remain immutable historical releases.</p>
+          <p>This page describes Penglai 0.6.0. Until the v0.6.0 Release is public, the last immutable installers are 0.5.12. Published 0.5.10 and 0.5.11 remain historical.</p>
         </article>
         <article>
           <h3>Why does Gatekeeper warn?</h3>
@@ -216,46 +256,25 @@
         </article>
         <article>
           <h3>What if the API key fails?</h3>
-          <p>The wizard supports Back, retry, and resume after restart. A failed credential test is never recorded as success. You can enter the key again or return to model selection.</p>
+          <p>The wizard supports Back, retry, and resume after restart. A failed credential test is never recorded as success.</p>
         </article>
         <article>
           <h3>Does uninstall delete my files?</h3>
           <p>Default uninstall removes the application and cache while preserving user data. Complete delete uses a separate category plan and must not recursively wipe a Workspace or home directory.</p>
         </article>
       </div>
-    </section>
-
-    <section class="download section" id="download" data-reveal>
-      <p class="eyebrow">Penglai 0.5.12</p>
-      <h2>Choose your computer.</h2>
-      <div class="download-grid">
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_aarch64.dmg">
-          <strong>macOS · Apple Silicon</strong>
-          <span>GitHub · 271.0 MiB · M1 / M2 / M3 / M4 / M5</span>
-          <code>1f6d7f9ceab13c62a6e31d52a0517c4972a52378e5ce102bf2983f3c32fd8034</code>
-        </a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_x64.dmg">
-          <strong>macOS · Intel</strong>
-          <span>GitHub · 280.2 MiB · x86_64 Mac</span>
-          <code>f82a5d44bccb7d15def176602f8320d1464eae802897e41c5ec39c8d471d61c3</code>
-        </a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_windows_x64_setup.exe">
-          <strong>Windows · x64</strong>
-          <span>GitHub · 353.9 MiB · 64-bit installer</span>
-          <code>5d926a884ca2b93c43f8ee8d8e8897df636585d449f1810d25ab4bffae3159da</code>
-        </a>
-      </div>
-      <p class="note-panel">The current public download is published 0.5.12. Published 0.5.10 and 0.5.11 remain immutable. The immutable GitHub Release is the sole authoritative public download source; the Beijing mirror has not published 0.5.12. All three installers come from source <code>54a0ef30afa4e3d653e400a637d4aa8eb4abbb75</code>. Full SHA256SUMS, SBOM, third-party notices, and signed update metadata are on the same page. Updates are never silent.</p>
-      <div class="actions centered">
-        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12">Bilingual release notes</a>
-        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">Security notes</a>
-      </div>
+      <p class="docs-row">
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/PRODUCT.md">Product contract</a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/ARCHITECTURE.md">Architecture</a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/PLUGIN_CENTER.md">Plugin Center</a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/0.6.0/ACCEPTANCE_DELTA.md">0.6.0 acceptance delta</a>
+      </p>
     </section>
   </main>
 
   <footer>
     <p>Penglai is created and maintained by <a href="https://github.com/kevinchennewbee">Kevin Chen / 陈克文</a>, built on <a href="https://github.com/deepseek-ai/deepseek-harness">DeepSeek Harness</a>, and released under MIT.</p>
-    <p>Multi-channel engineering references came from the <a href="https://github.com/xmanrui/dsh-im">DSH-IM</a> community, while official QQ Bot onboarding references came from <a href="https://github.com/tencent-connect/qqbot-agent-sdk">qqbot-agent-sdk</a>. Neither upstream runtime is bundled wholesale.</p>
+    <p>Multi-channel engineering references came from the <a href="https://github.com/xmanrui/dsh-im">DSH-IM</a> community. Official QQ Bot onboarding references came from <a href="https://github.com/tencent-connect/qqbot-agent-sdk">qqbot-agent-sdk</a>. Neither upstream runtime is bundled wholesale.</p>
     <p>Thanks to Electron, Node.js, TypeScript, pnpm, SenseVoice, sherpa-onnx, MOSS-TTS-Nano, Mnemon, Lark SDK, openclaw-weixin, and every contributor.</p>
     <p><span lang="en">English</span> · <a href="./zh/" hreflang="zh-CN" lang="zh-CN">中文</a></p>
   </footer>

--- a/website/scripts/site.js
+++ b/website/scripts/site.js
@@ -26,11 +26,48 @@
     hairline.style.transform = "scaleX(" + progress + ")";
   }
 
+  function computerFamily() {
+    var ua = navigator.userAgent || "";
+    var platform = navigator.platform || "";
+    var ch = navigator.userAgentData && navigator.userAgentData.platform;
+    var token = String(ch || platform || ua).toLowerCase();
+    if (token.indexOf("win") >= 0) return "windows";
+    if (token.indexOf("mac") >= 0) return "mac";
+    if (token.indexOf("linux") >= 0 || token.indexOf("cros") >= 0) return "linux";
+    if (/Windows/i.test(ua)) return "windows";
+    if (/Mac OS|Macintosh/i.test(ua)) return "mac";
+    if (/Linux/i.test(ua) && !/Android/i.test(ua)) return "linux";
+    return "";
+  }
+
+  function hintDownloads() {
+    var family = computerFamily();
+    if (!family) return;
+    var cards = document.querySelectorAll("[data-family]");
+    if (!cards.length) return;
+    var matched = [];
+    cards.forEach(function (card) {
+      if (card.getAttribute("data-family") === family) {
+        card.classList.add("is-likely");
+        matched.push(card);
+      }
+    });
+    if (!matched.length) return;
+    var note = document.getElementById("downloadHint");
+    if (!note) return;
+    var copy = note.getAttribute("data-" + family);
+    if (copy) {
+      note.hidden = false;
+      note.textContent = copy;
+    }
+  }
+
   setMotionFlag();
   updateScroll();
+  hintDownloads();
   window.addEventListener("scroll", updateScroll, { passive: true });
   window.addEventListener("resize", function () {
-    if (window.innerWidth > 860) closeNav();
+    if (window.innerWidth > 880) closeNav();
     updateScroll();
   });
   reduce.addEventListener("change", setMotionFlag);
@@ -66,7 +103,7 @@
           }
         });
       },
-      { rootMargin: "0px 0px -8% 0px", threshold: 0.12 },
+      { rootMargin: "0px 0px -6% 0px", threshold: 0.08 },
     );
     document.querySelectorAll("[data-reveal]").forEach(function (node) {
       observer.observe(node);
@@ -76,79 +113,4 @@
       node.classList.add("is-in");
     });
   }
-
-  if (reduce.matches) return;
-
-  var canvas = document.getElementById("hero-canvas");
-  if (!canvas || !canvas.getContext) return;
-  var context = canvas.getContext("2d");
-  if (!context) return;
-
-  var width = 0;
-  var height = 0;
-  var grain = document.createElement("canvas");
-  var grainContext = grain.getContext("2d");
-  var clouds = [
-    { x: 0.12, y: 0.22, r: 0.28, speed: 0.000012, tint: [246, 241, 232], alpha: 0.08 },
-    { x: 0.62, y: 0.18, r: 0.34, speed: -0.000008, tint: [201, 163, 106], alpha: 0.07 },
-    { x: 0.38, y: 0.68, r: 0.4, speed: 0.000006, tint: [196, 92, 38], alpha: 0.05 },
-  ];
-  var start = performance.now();
-  var frame = 0;
-
-  function paintGrain() {
-    grain.width = 160;
-    grain.height = 160;
-    var pixels = grainContext.createImageData(160, 160);
-    for (var i = 0; i < pixels.data.length; i += 4) {
-      var value = 180 + Math.random() * 50;
-      pixels.data[i] = value;
-      pixels.data[i + 1] = value - 4;
-      pixels.data[i + 2] = value - 10;
-      pixels.data[i + 3] = 28 + Math.random() * 18;
-    }
-    grainContext.putImageData(pixels, 0, 0);
-  }
-
-  function resize() {
-    var ratio = Math.min(window.devicePixelRatio || 1, 2);
-    width = canvas.clientWidth || window.innerWidth;
-    height = canvas.clientHeight || Math.min(window.innerHeight, 860);
-    canvas.width = Math.floor(width * ratio);
-    canvas.height = Math.floor(height * ratio);
-    context.setTransform(ratio, 0, 0, ratio, 0, 0);
-  }
-
-  function draw(now) {
-    frame = window.requestAnimationFrame(draw);
-    var t = now - start;
-    context.clearRect(0, 0, width, height);
-    clouds.forEach(function (cloud) {
-      var x = ((cloud.x + t * cloud.speed) % 1.4) * width - 0.2 * width;
-      var y = cloud.y * height;
-      var radius = cloud.r * Math.max(width, height);
-      var wash = context.createRadialGradient(x, y, radius * 0.12, x, y, radius);
-      wash.addColorStop(0, "rgba(" + cloud.tint.join(",") + "," + cloud.alpha + ")");
-      wash.addColorStop(1, "rgba(" + cloud.tint.join(",") + ",0)");
-      context.fillStyle = wash;
-      context.beginPath();
-      context.arc(x, y, radius, 0, Math.PI * 2);
-      context.fill();
-    });
-    context.globalAlpha = 0.18;
-    context.fillStyle = context.createPattern(grain, "repeat");
-    context.fillRect(0, 0, width, height);
-    context.globalAlpha = 1;
-  }
-
-  paintGrain();
-  resize();
-  window.addEventListener("resize", resize);
-  reduce.addEventListener("change", function () {
-    if (reduce.matches) {
-      window.cancelAnimationFrame(frame);
-      context.clearRect(0, 0, width, height);
-    }
-  });
-  draw(start);
 })();

--- a/website/styles/main.css
+++ b/website/styles/main.css
@@ -614,6 +614,13 @@ html[lang="zh-CN"] h2 {
   font-size: 0.8rem;
 }
 
+.download-grid code {
+  margin-top: 0.35rem;
+  color: var(--ink-soft);
+  font-size: 0.72rem;
+  word-break: break-all;
+}
+
 .note-panel {
   max-width: 46rem;
   margin: 0 0 1.4rem;

--- a/website/styles/main.css
+++ b/website/styles/main.css
@@ -1,23 +1,26 @@
 :root {
-  --ink: #0b1c2c;
-  --ink-deep: #07131e;
-  --ink-soft: #143044;
-  --paper: #f6f1e8;
-  --paper-2: #efe8db;
-  --hall: #fff9f0;
+  --ink: #1a1714;
+  --ink-soft: #3a342c;
+  --paper: #f3eee4;
+  --paper-2: #e8e0d2;
+  --hall: #faf7f0;
+  --muted: #534e46;
+  --line: #ddd4c6;
+  --line-quiet: #e8e0d3;
+  --jade: #2f5a4a;
+  --jade-deep: #24473a;
+  --jade-wash: #e4eee8;
+  --gold: #a4844a;
+  --gold-soft: #c4a56a;
   --cinnabar: #c45c26;
-  --cinnabar-dark: #a44a1c;
-  --cinnabar-ink: #9a4318;
-  --gold: #c9a36a;
-  --gold-deep: #8a6a32;
-  --stone: #2c333a;
-  --muted: #3e474f;
-  --line: #d6ccbb;
-  --focus: #8a6a32;
+  --cinnabar-deep: #9a4318;
+  --focus: #2f5a4a;
+  --shadow: 0 28px 64px color-mix(in srgb, var(--ink) 14%, transparent);
   --serif: "Iowan Old Style", "Palatino Linotype", Palatino, "Songti SC", "Noto Serif SC", "Source Han Serif SC", Georgia, serif;
   --sans: "Avenir Next", "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Noto Sans SC", "Microsoft YaHei UI", ui-sans-serif, sans-serif;
-  --measure: 72rem;
-  --gutter: clamp(1.15rem, 4vw, 2.5rem);
+  --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  --measure: 74rem;
+  --gutter: clamp(1.15rem, 4vw, 2.75rem);
 }
 
 * { box-sizing: border-box; }
@@ -31,7 +34,7 @@ html[data-motion="reduce"] { scroll-behavior: auto; }
 
 body {
   margin: 0;
-  color: var(--stone);
+  color: var(--ink);
   background: var(--paper);
   font-family: var(--serif);
   font-size: 1.125rem;
@@ -44,15 +47,16 @@ body::before {
   inset: 0;
   z-index: 40;
   pointer-events: none;
-  opacity: 0.045;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.85' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 .04  0 0 0 0 .07  0 0 0 0 .1  0 0 0 .55 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  opacity: 0.035;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.8' numOctaves='3' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 .08  0 0 0 0 .07  0 0 0 0 .05  0 0 0 .5 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
 }
 
 img { display: block; max-width: 100%; height: auto; }
 a { color: inherit; }
 code {
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-family: var(--mono);
   font-size: 0.86em;
+  overflow-wrap: anywhere;
 }
 
 h1, h2, h3, blockquote {
@@ -61,7 +65,20 @@ h1, h2, h3, blockquote {
   letter-spacing: -0.03em;
 }
 
-.sans, .brand, nav, .button, .eyebrow, .state, .nav-toggle, .download-grid, footer {
+.sans,
+.brand,
+nav,
+.button,
+.eyebrow,
+.state,
+.nav-toggle,
+.download-grid,
+.use-grid,
+.opt-list,
+footer,
+.meta-row,
+.app-chrome,
+.download-hint {
   font-family: var(--sans);
 }
 
@@ -77,16 +94,13 @@ h1, h2, h3, blockquote {
   top: -4rem;
   z-index: 80;
   padding: 0.55rem 0.9rem;
-  color: var(--paper);
+  color: var(--hall);
   background: var(--ink);
-  border: 1px solid var(--gold);
+  border: 1px solid var(--gold-soft);
   text-decoration: none;
 }
 
-.skip-link:focus {
-  top: 0.85rem;
-  outline-color: var(--gold);
-}
+.skip-link:focus { top: 0.85rem; }
 
 .scroll-hairline {
   position: fixed;
@@ -97,7 +111,7 @@ h1, h2, h3, blockquote {
   height: 2px;
   transform: scaleX(0);
   transform-origin: 0 50%;
-  background: linear-gradient(90deg, var(--cinnabar), var(--gold));
+  background: var(--jade);
   pointer-events: none;
 }
 
@@ -109,16 +123,17 @@ h1, h2, h3, blockquote {
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  min-height: 4.25rem;
-  padding: 0.65rem var(--gutter);
-  color: var(--paper);
-  background: color-mix(in srgb, var(--ink) 92%, transparent);
-  border-bottom: 1px solid color-mix(in srgb, var(--gold) 38%, transparent);
-  backdrop-filter: blur(18px);
+  min-height: 4rem;
+  padding: 0.55rem var(--gutter);
+  color: var(--ink);
+  background: color-mix(in srgb, var(--paper) 88%, transparent);
+  border-bottom: 1px solid transparent;
+  backdrop-filter: blur(16px);
 }
 
 .site-nav.scrolled {
-  background: color-mix(in srgb, var(--ink) 97%, transparent);
+  border-bottom-color: var(--line-quiet);
+  background: color-mix(in srgb, var(--paper) 94%, transparent);
 }
 
 .brand {
@@ -127,27 +142,26 @@ h1, h2, h3, blockquote {
   gap: 0.7rem;
   text-decoration: none;
   font-weight: 650;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.03em;
 }
 
 .brand small {
   display: block;
-  color: color-mix(in srgb, var(--paper) 62%, var(--gold));
+  color: var(--muted);
   font-size: 0.62rem;
-  letter-spacing: 0.22em;
+  letter-spacing: 0.2em;
 }
 
 .seal {
   display: grid;
-  width: 2.15rem;
-  height: 2.15rem;
+  width: 2rem;
+  height: 2rem;
   place-items: center;
-  color: var(--paper);
+  color: var(--hall);
   background: var(--cinnabar);
-  border: 1px solid var(--gold);
-  border-radius: 0.2rem;
+  border: 1px solid var(--gold-soft);
   font-family: var(--serif);
-  font-size: 1.15rem;
+  font-size: 1.05rem;
   font-weight: 700;
 }
 
@@ -156,9 +170,9 @@ h1, h2, h3, blockquote {
   width: 2.6rem;
   height: 2.6rem;
   padding: 0;
-  color: var(--paper);
+  color: var(--ink);
   background: transparent;
-  border: 1px solid color-mix(in srgb, var(--gold) 55%, transparent);
+  border: 1px solid var(--line);
   cursor: pointer;
 }
 
@@ -169,7 +183,7 @@ h1, h2, h3, blockquote {
   width: 1.05rem;
   height: 1px;
   margin: 0 auto;
-  background: var(--paper);
+  background: var(--ink);
   content: "";
 }
 
@@ -183,287 +197,272 @@ h1, h2, h3, blockquote {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 1.15rem 1.35rem;
+  gap: 0.35rem 1.35rem;
 }
 
 #navLinks a {
-  color: color-mix(in srgb, var(--paper) 78%, transparent);
+  color: var(--ink-soft);
   text-decoration: none;
   font-size: 0.92rem;
 }
 
 #navLinks a:hover,
-#navLinks a:focus-visible { color: var(--paper); }
-
-#navLinks a:focus-visible { outline-color: var(--gold); }
+#navLinks a:focus-visible { color: var(--ink); }
 
 #navLinks .github {
-  padding: 0.38rem 0.85rem;
-  color: var(--paper);
-  border: 1px solid color-mix(in srgb, var(--gold) 55%, transparent);
+  padding: 0.35rem 0.8rem;
+  border: 1px solid var(--line);
 }
 
 main { overflow: hidden; }
 
+.wrap,
+.section,
+.hero-inner,
+.wide-shot {
+  width: min(var(--measure), calc(100% - 2 * var(--gutter)));
+  margin-inline: auto;
+}
+
 .hero {
   position: relative;
-  min-height: min(100vh, 54rem);
-  color: var(--paper);
-  background:
-    radial-gradient(ellipse at 18% 88%, color-mix(in srgb, var(--cinnabar) 18%, transparent), transparent 32%),
-    radial-gradient(ellipse at 80% 12%, color-mix(in srgb, var(--gold) 14%, transparent), transparent 28%),
-    var(--ink);
+  padding: 4.5rem 0 3.5rem;
 }
 
-.hero-canvas,
-.hero-clouds,
-.hero-art,
-.hero-shade {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-}
-
-.hero-canvas { width: 100%; height: 100%; }
-
-.hero-art {
-  width: 58%;
-  left: auto;
-  object-fit: cover;
-  object-position: 42% 46%;
-  opacity: 0.78;
-  mask-image: linear-gradient(90deg, transparent 0%, #000 28%, #000 100%);
-}
-
-.hero-shade {
-  background:
-    linear-gradient(90deg, var(--ink) 0%, color-mix(in srgb, var(--ink) 88%, transparent) 42%, color-mix(in srgb, var(--ink) 18%, transparent) 78%),
-    linear-gradient(180deg, color-mix(in srgb, var(--ink) 28%, transparent), transparent 34%, color-mix(in srgb, var(--ink-deep) 82%, transparent) 100%);
-}
-
-.hero-clouds .cloud {
-  position: absolute;
-  border-radius: 70% 60% 80% 50%;
-  filter: blur(42px);
-  background: color-mix(in srgb, var(--paper) 16%, transparent);
-  animation: cloud-drift 48s linear infinite;
-}
-
-.hero-clouds .c1 { width: 42vw; height: 18vw; left: -8%; top: 12%; opacity: 0.45; }
-.hero-clouds .c2 { width: 34vw; height: 14vw; right: 8%; top: 38%; animation-duration: 62s; animation-direction: reverse; opacity: 0.28; }
-.hero-clouds .c3 { width: 50vw; height: 20vw; left: 18%; bottom: -8%; animation-duration: 80s; opacity: 0.22; background: color-mix(in srgb, var(--gold) 18%, transparent); }
-
-@keyframes cloud-drift {
-  from { transform: translateX(-4%); }
-  to { transform: translateX(8%); }
-}
-
-.hero-copy {
-  position: relative;
-  z-index: 1;
-  width: min(58rem, calc(100% - 2 * var(--gutter)));
-  margin: 0 auto 0 max(var(--gutter), calc((100vw - var(--measure)) / 2));
-  padding: 8.5rem 0 6.5rem;
+.hero-inner {
+  display: grid;
+  grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+  gap: clamp(2rem, 5vw, 4.5rem);
+  align-items: center;
 }
 
 .eyebrow {
-  margin: 0 0 1rem;
-  color: var(--cinnabar);
+  margin: 0 0 0.85rem;
+  color: var(--jade);
   font-size: 0.74rem;
   font-weight: 700;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
 }
 
-.hero .eyebrow { color: var(--gold); }
-
 h1 {
   margin: 0;
-  max-width: 100%;
-  font-size: clamp(2.5rem, 6.4vw, 4.7rem);
-  line-height: 1.08;
+  max-width: 14ch;
+  font-size: clamp(2.35rem, 5.4vw, 4.15rem);
+  line-height: 1.12;
+  text-wrap: balance;
+}
+
+html[lang="zh-CN"] h1 {
+  max-width: 10em;
   line-break: strict;
   word-break: keep-all;
-  overflow-wrap: normal;
-  white-space: nowrap;
 }
 
 .lead {
-  max-width: 38rem;
-  margin: 1.5rem 0 0;
-  color: color-mix(in srgb, var(--paper) 78%, transparent);
-  font-size: clamp(1.05rem, 1.7vw, 1.28rem);
+  max-width: 36rem;
+  margin: 1.25rem 0 0;
+  color: var(--muted);
+  font-size: clamp(1.05rem, 1.6vw, 1.22rem);
 }
 
 .actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-top: 2rem;
+  gap: 0.7rem;
+  margin-top: 1.8rem;
 }
 
 .button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 2.9rem;
-  padding: 0 1.2rem;
-  border-radius: 0.15rem;
+  min-height: 2.85rem;
+  padding: 0 1.15rem;
+  border-radius: 0.2rem;
   text-decoration: none;
-  font-size: 1.05rem;
+  font-size: 1rem;
   font-weight: 650;
 }
 
 .button.primary {
-  color: #fffaf4;
-  background: var(--cinnabar-ink);
-  border: 1px solid color-mix(in srgb, var(--gold) 55%, var(--cinnabar-ink));
+  color: #faf7f0;
+  background: var(--jade);
+  border: 1px solid var(--jade-deep);
 }
 
-.button.primary:hover { background: #8f3d16; }
+.button.primary:hover { background: var(--jade-deep); }
 
 .button.ghost {
-  color: var(--stone);
-  border: 1px solid var(--stone);
+  color: var(--ink);
+  border: 1px solid var(--ink-soft);
+  background: transparent;
 }
 
-.hero .button.ghost {
-  color: var(--paper);
-  border-color: color-mix(in srgb, var(--paper) 42%, transparent);
-}
+.button.ghost:hover { background: color-mix(in srgb, var(--ink) 5%, transparent); }
 
-.quiet {
+.meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem 0.7rem;
+  margin-top: 1.35rem;
   color: var(--muted);
-  font-size: 0.92rem;
+  font-size: 0.84rem;
 }
 
-.hero .quiet {
-  margin-top: 1.15rem;
-  color: color-mix(in srgb, var(--paper) 55%, transparent);
+.meta-row span {
+  padding: 0.18rem 0.55rem;
+  border: 1px solid var(--line-quiet);
+  background: color-mix(in srgb, var(--hall) 70%, transparent);
 }
 
-.wrap,
-.intro,
-.section,
-.wide-shot,
-.gallery {
-  width: min(var(--measure), calc(100% - 2 * var(--gutter)));
-  margin-inline: auto;
+.app-frame {
+  position: relative;
+  overflow: hidden;
+  background: var(--hall);
+  border: 1px solid var(--line);
+  border-radius: 0.7rem;
+  box-shadow: var(--shadow);
 }
 
-.intro,
-.section { padding: 6.2rem 0; }
+.app-chrome {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-height: 2.35rem;
+  padding: 0 0.9rem;
+  color: var(--muted);
+  background: color-mix(in srgb, var(--paper-2) 55%, var(--hall));
+  border-bottom: 1px solid var(--line-quiet);
+  font-size: 0.78rem;
+}
 
-.intro {
+.app-chrome i {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: #d8cfc0;
+}
+
+.app-chrome i:nth-child(1) { background: #c9897a; }
+.app-chrome i:nth-child(2) { background: #c4a56a; }
+.app-chrome i:nth-child(3) { background: #7fa08c; }
+
+.app-frame img {
+  width: 100%;
+  background: #f6f1ea;
+}
+
+.hero .app-frame img {
+  aspect-ratio: 5 / 4;
+  object-fit: cover;
+  object-position: center 38%;
+}
+
+.hero figure { margin: 0; }
+
+figcaption {
+  margin-top: 0.8rem;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.use-band {
+  padding: 1.5rem 0 4.5rem;
+}
+
+.use-grid {
   display: grid;
-  grid-template-columns: 1.05fr 0.95fr;
-  gap: 4.5rem;
-  align-items: start;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--line);
 }
+
+.use-grid article {
+  padding: 1.35rem 1.2rem 1.2rem 0;
+  border-right: 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.use-grid article:not(:last-child) { padding-right: 1.4rem; margin-right: 1.4rem; border-right: 1px solid var(--line); }
+
+.use-grid h3 {
+  margin: 0 0 0.45rem;
+  font-size: 1.05rem;
+  letter-spacing: -0.02em;
+}
+
+.use-grid p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.section { padding: 5.4rem 0; }
 
 h2 {
   margin: 0;
   max-width: 18ch;
-  font-size: clamp(2rem, 4.4vw, 3.4rem);
-  line-height: 1.16;
+  font-size: clamp(1.85rem, 3.8vw, 2.85rem);
+  line-height: 1.18;
+  text-wrap: balance;
 }
 
-.intro > p,
-.split p:not(.eyebrow),
-.prose p {
-  margin: 1.4rem 0 0;
+html[lang="zh-CN"] h2 {
+  max-width: 14em;
+  word-break: keep-all;
+}
+
+.core {
+  display: grid;
+  grid-template-columns: 0.95fr 1.05fr;
+  gap: clamp(2rem, 5vw, 4.2rem);
+  align-items: start;
+}
+
+.core p {
+  margin: 1.15rem 0 0;
   color: var(--muted);
+}
+
+.identity {
+  font-family: var(--sans);
+  font-size: 0.92rem;
+  line-height: 1.55;
 }
 
 .gold-rule {
-  width: 4.2rem;
+  width: 3.2rem;
   height: 1px;
-  margin: 1.35rem 0 0;
+  margin: 1.2rem 0 0;
   background: var(--gold);
 }
 
-.feature-shot { margin: 0 auto 1rem; }
-.feature-shot img,
-.gallery img,
-.split img,
-.frame img {
-  border: 1px solid color-mix(in srgb, var(--ink) 18%, var(--line));
-  border-radius: 0.2rem;
-  box-shadow: 0 28px 70px color-mix(in srgb, var(--ink) 16%, transparent);
-  background: var(--ink);
-}
-
-figcaption {
-  margin-top: 0.85rem;
-  color: var(--muted);
-  font-size: 0.9rem;
-  text-align: center;
-}
-
-.cards {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1rem;
-  margin-top: 2.6rem;
-}
-
-.cards article {
-  min-height: 16.5rem;
-  padding: 1.5rem 1.4rem 1.35rem;
-  background: color-mix(in srgb, var(--hall) 86%, transparent);
-  border: 1px solid var(--line);
-  border-top: 1px solid var(--gold);
-}
-
-.cards h3 {
-  margin: 1.05rem 0 0.45rem;
-  font-size: 1.45rem;
-}
-
-.cards p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 1rem;
-}
-
-.state {
-  display: inline-block;
-  padding: 0.18rem 0.55rem;
-  color: var(--gold-deep);
-  background: color-mix(in srgb, var(--gold) 14%, transparent);
-  font-size: 0.72rem;
-  font-weight: 750;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.state.on {
-  color: var(--cinnabar-dark);
-  background: color-mix(in srgb, var(--cinnabar) 12%, transparent);
-}
-
-.gallery {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1.5rem 1.35rem;
-  padding: 0 0 5rem;
-}
-
-.gallery figure { margin: 0; }
-.gallery img { aspect-ratio: 16 / 10; object-fit: cover; object-position: top center; }
-
 .split {
   display: grid;
-  grid-template-columns: 0.9fr 1.1fr;
-  gap: 3.4rem;
+  grid-template-columns: 0.88fr 1.12fr;
+  gap: clamp(1.8rem, 4vw, 3.6rem);
   align-items: center;
 }
 
-.split.reverse { grid-template-columns: 1.1fr 0.9fr; }
+.split.reverse { grid-template-columns: 1.12fr 0.88fr; }
 .split.reverse .copy { order: 2; }
 
+.split p:not(.eyebrow) {
+  margin: 1.1rem 0 0;
+  color: var(--muted);
+}
+
+.split img,
+.wide-shot img {
+  border: 1px solid var(--line);
+  border-radius: 0.45rem;
+  box-shadow: 0 18px 40px color-mix(in srgb, var(--ink) 10%, transparent);
+  background: var(--ink);
+}
+
 .workflow-list {
-  margin: 1.3rem 0 0;
+  margin: 1.2rem 0 0;
   padding: 0;
   list-style: none;
   color: var(--muted);
@@ -471,58 +470,186 @@ figcaption {
 
 .workflow-list li {
   position: relative;
-  padding: 0.55rem 0 0.55rem 1.3rem;
-  border-top: 1px solid var(--line);
+  padding: 0.5rem 0 0.5rem 1.15rem;
+  border-top: 1px solid var(--line-quiet);
 }
 
 .workflow-list li::before {
   content: "";
   position: absolute;
   left: 0;
-  top: 1.15rem;
-  width: 0.55rem;
+  top: 1.05rem;
+  width: 0.45rem;
   height: 1px;
-  background: var(--cinnabar);
+  background: var(--jade);
 }
 
-.sea {
+.opt-list {
+  display: grid;
+  gap: 0;
+  margin-top: 2.2rem;
+  border-top: 1px solid var(--line);
+}
+
+.opt-list article {
+  display: grid;
+  grid-template-columns: 8.5rem minmax(0, 1fr);
+  gap: 1.2rem;
+  padding: 1.15rem 0;
+  border-bottom: 1px solid var(--line-quiet);
+}
+
+.opt-list h3 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.opt-list p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1rem;
+}
+
+.state {
+  display: inline-block;
+  margin-bottom: 0.35rem;
+  padding: 0.14rem 0.5rem;
+  color: var(--ink-soft);
+  background: var(--paper-2);
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.state.on {
+  color: var(--jade-deep);
+  background: var(--jade-wash);
+}
+
+.limits {
+  background: var(--ink);
+  color: var(--hall);
   width: 100%;
   max-width: none;
   padding-inline: max(var(--gutter), calc((100vw - var(--measure)) / 2));
-  color: var(--paper);
-  background:
-    radial-gradient(ellipse at 88% 0%, color-mix(in srgb, var(--gold) 12%, transparent), transparent 28%),
-    var(--ink);
 }
 
-.sea .eyebrow { color: var(--gold); }
-.sea h2 { color: var(--paper); }
-.sea p { color: color-mix(in srgb, var(--paper) 72%, transparent); }
+.limits .eyebrow { color: var(--gold-soft); }
+.limits h2 { color: var(--hall); max-width: 22ch; }
 
-.trust-grid,
+.limit-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem 2.5rem;
+  margin-top: 2rem;
+}
+
+.limit-grid p {
+  margin: 0;
+  padding: 0.2rem 0 0.85rem;
+  color: color-mix(in srgb, var(--hall) 74%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--gold-soft) 22%, transparent);
+}
+
+.limit-grid strong {
+  display: block;
+  margin-bottom: 0.3rem;
+  color: var(--hall);
+  font-family: var(--sans);
+  font-size: 0.92rem;
+}
+
+.download h2 { max-width: none; }
+
+.download-hint {
+  min-height: 1.4rem;
+  margin: 0.85rem 0 0;
+  color: var(--jade-deep);
+  font-size: 0.92rem;
+}
+
+.download-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.85rem;
+  margin: 1.8rem 0 1.2rem;
+}
+
+.download-grid a {
+  display: flex;
+  flex-direction: column;
+  min-height: 9.5rem;
+  padding: 1.2rem 1.2rem 1.1rem;
+  background: var(--hall);
+  border: 1px solid var(--line);
+  text-decoration: none;
+}
+
+.download-grid a:hover,
+.download-grid a.is-likely {
+  border-color: var(--jade);
+}
+
+.download-grid a.is-likely {
+  box-shadow: inset 0 0 0 1px var(--jade);
+}
+
+.download-grid strong {
+  font-size: 1.08rem;
+  letter-spacing: -0.02em;
+}
+
+.download-grid span {
+  margin-top: 0.4rem;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.download-grid em {
+  margin-top: auto;
+  padding-top: 0.9rem;
+  color: var(--ink-soft);
+  font-style: normal;
+  font-size: 0.8rem;
+}
+
+.note-panel {
+  max-width: 46rem;
+  margin: 0 0 1.4rem;
+  color: var(--muted);
+  font-size: 0.98rem;
+}
+
+.centered { justify-content: center; }
+
+.story { max-width: 42rem; }
+
+.story blockquote {
+  margin: 1.1rem 0 1.6rem;
+  font-size: clamp(1.45rem, 2.8vw, 2.05rem);
+  line-height: 1.4;
+}
+
+.signature {
+  margin-top: 1.5rem;
+  color: var(--cinnabar-deep);
+  font-family: var(--sans);
+  font-weight: 700;
+}
+
 .faq-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1rem;
-  margin-top: 2.4rem;
+  gap: 1.5rem 2rem;
+  margin-top: 2rem;
 }
 
-.trust-grid p,
-.faq-grid article {
-  margin: 0;
-  padding: 1.3rem 1.25rem;
-  border: 1px solid color-mix(in srgb, var(--gold) 28%, transparent);
-}
-
-.faq-grid article {
-  background: var(--hall);
-  border-color: var(--line);
-  border-top: 1px solid var(--gold);
-}
+.faq-grid article { margin: 0; }
 
 .faq-grid h3 {
-  margin: 0 0 0.45rem;
-  font-size: 1.2rem;
+  margin: 0 0 0.4rem;
+  font-size: 1.12rem;
 }
 
 .faq-grid p {
@@ -531,95 +658,60 @@ figcaption {
   font-size: 1rem;
 }
 
-.trust-grid strong { color: var(--paper); }
-
-.story { max-width: 46rem; }
-
-.story blockquote {
-  margin: 1.2rem 0 2rem;
-  font-size: clamp(1.55rem, 3.2vw, 2.35rem);
-  line-height: 1.4;
-}
-
-.signature {
-  margin-top: 1.8rem;
-  color: var(--cinnabar-dark);
-  font-family: var(--sans);
-  font-weight: 700;
-}
-
-.download { text-align: center; }
-.download h2 { max-width: none; margin-inline: auto; }
-
-.download-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1rem;
-  margin: 2.4rem 0 1.4rem;
-  text-align: left;
-}
-
-.download-grid a {
+.docs-row {
   display: flex;
-  flex-direction: column;
-  min-height: 11.5rem;
-  padding: 1.35rem 1.25rem 1.2rem;
-  background: var(--hall);
-  border: 1px solid var(--line);
-  border-top: 2px solid var(--cinnabar);
-  text-decoration: none;
-}
-
-.download-grid a:hover { border-color: var(--cinnabar); }
-.download-grid a:focus-visible { outline-color: var(--cinnabar); }
-.download-grid strong { font-size: 1.12rem; }
-.download-grid span {
-  margin-top: 0.35rem;
-  color: var(--muted);
+  flex-wrap: wrap;
+  gap: 0.6rem 1.1rem;
+  margin-top: 1.6rem;
+  font-family: var(--sans);
   font-size: 0.92rem;
 }
-.download-grid code {
-  display: block;
-  margin-top: auto;
-  padding-top: 1rem;
-  color: var(--muted);
-  font-size: 0.68rem;
-  line-height: 1.5;
-  overflow-wrap: anywhere;
-}
 
-.centered { justify-content: center; }
-
-.note-panel {
-  max-width: 46rem;
-  margin: 0 auto 1.6rem;
-  color: var(--muted);
-  font-size: 0.98rem;
-}
+.docs-row a { color: var(--jade-deep); }
 
 footer {
-  padding: 2.6rem var(--gutter) 3rem;
-  color: color-mix(in srgb, var(--paper) 62%, transparent);
-  background: var(--ink-deep);
+  padding: 2.4rem var(--gutter) 2.8rem;
+  color: var(--muted);
+  background: color-mix(in srgb, var(--paper-2) 55%, var(--paper));
+  border-top: 1px solid var(--line-quiet);
   font-size: 0.88rem;
-  text-align: center;
 }
 
-footer p { margin: 0.4rem 0; }
-footer a { color: var(--paper); }
+footer p { margin: 0.35rem 0; }
+footer a { color: var(--ink); }
 
 [data-reveal] {
   opacity: 0;
-  transform: translateY(1.15rem);
+  transform: translateY(0.7rem);
 }
 
 [data-reveal].is-in {
   opacity: 1;
   transform: none;
-  transition: opacity 0.9s ease, transform 0.9s ease;
+  transition: opacity 0.55s ease, transform 0.55s ease;
 }
 
-@media (max-width: 860px) {
+@media (max-width: 960px) {
+  .hero-inner,
+  .core,
+  .split,
+  .split.reverse { grid-template-columns: 1fr; gap: 1.6rem; }
+  .split.reverse .copy { order: 0; }
+  .use-grid { grid-template-columns: 1fr 1fr; }
+  .use-grid article:not(:last-child) {
+    margin-right: 0;
+    padding-right: 1.2rem;
+    border-right: 0;
+  }
+  .use-grid article:nth-child(odd) {
+    padding-right: 1.2rem;
+    margin-right: 1.2rem;
+    border-right: 1px solid var(--line);
+  }
+  h1 { max-width: none; }
+}
+
+@media (max-width: 880px) {
   .nav-toggle { display: grid; place-items: center; }
   #navLinks {
     display: none;
@@ -627,61 +719,44 @@ footer a { color: var(--paper); }
     top: 100%;
     right: var(--gutter);
     left: var(--gutter);
-    padding: 0.85rem;
-    background: var(--ink);
-    border: 1px solid color-mix(in srgb, var(--gold) 40%, transparent);
+    padding: 0.7rem;
+    background: var(--hall);
+    border: 1px solid var(--line);
   }
-  #navLinks.open { display: grid; gap: 0.35rem; }
-  #navLinks a { padding: 0.55rem 0.4rem; }
-  .hero { min-height: 42rem; }
-  .hero-art {
-    width: 100%;
-    opacity: 0.42;
-    mask-image: linear-gradient(180deg, #000 0%, #000 42%, transparent 88%);
+  #navLinks.open { display: grid; gap: 0.15rem; }
+  #navLinks a {
+    display: flex;
+    align-items: center;
+    min-height: 2.75rem;
+    padding: 0.45rem 0.55rem;
   }
-  .hero-shade {
-    background:
-      linear-gradient(180deg, color-mix(in srgb, var(--ink) 35%, transparent), color-mix(in srgb, var(--ink) 88%, transparent) 72%, var(--ink));
-  }
-  .hero-copy {
-    margin: 0 auto;
-    padding: 8rem 0 4.5rem;
-  }
-  .intro,
-  .split,
-  .split.reverse { grid-template-columns: 1fr; gap: 1.8rem; }
-  .split.reverse .copy { order: 0; }
-  .cards { grid-template-columns: 1fr 1fr; }
-  .trust-grid,
-  .download-grid { grid-template-columns: 1fr; }
+  .hero { padding-top: 2.6rem; }
+  .opt-list article { grid-template-columns: 1fr; gap: 0.35rem; }
 }
 
-@media (max-width: 560px) {
-  body { font-size: 1.02rem; }
-  .site-nav { padding-inline: 1rem; }
+@media (max-width: 640px) {
+  body { font-size: 1.04rem; }
   .brand small { display: none; }
-  .hero { min-height: 38rem; }
-  .hero-copy,
   .wrap,
-  .intro,
   .section,
-  .wide-shot,
-  .gallery { width: calc(100% - 2rem); }
-  .intro,
-  .section { padding: 4.2rem 0; }
-  .cards,
-  .gallery,
+  .hero-inner,
+  .wide-shot { width: calc(100% - 2rem); }
+  .section { padding: 3.6rem 0; }
+  .use-grid,
+  .limit-grid,
+  .download-grid,
   .faq-grid { grid-template-columns: 1fr; }
-  .cards article { min-height: 0; }
-  h1 {
-    max-width: none;
-    white-space: normal;
+  .use-grid article:nth-child(odd) {
+    margin-right: 0;
+    border-right: 0;
   }
+  .hero { padding: 2.2rem 0 1.5rem; }
+  .actions .button { flex: 1 1 12rem; }
+  .hero .app-frame img { aspect-ratio: 4 / 3; }
 }
 
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
-  .hero-clouds .cloud,
   [data-reveal],
   .scroll-hairline { animation: none; transition: none; }
   [data-reveal] {
@@ -691,7 +766,13 @@ footer a { color: var(--paper); }
 }
 
 @media (prefers-contrast: more) {
-  body { color: #12161a; }
-  .muted, .quiet, .cards p, figcaption { color: #1c242c; }
-  .button.primary { background: #8f3d16; }
+  body { color: #14110e; }
+  .lead,
+  .muted,
+  figcaption,
+  .use-grid p,
+  .faq-grid p,
+  .note-panel { color: #2a251f; }
+  .button.primary { background: #1e3f34; }
+  .site-nav { border-bottom-color: #2a251f; }
 }

--- a/website/zh/index.html
+++ b/website/zh/index.html
@@ -3,17 +3,17 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>蓬莱 0.5.12 | 把 DeepSeek Harness 装进你的电脑</title>
-  <meta name="description" content="蓬莱 0.5.12 是官方 DeepSeek Harness 0.1.3-alpha.2 的桌面发行版：办公、记忆、消息连接与本地语音装在同一个可安装的客户端里。">
-  <meta property="og:title" content="蓬莱 0.5.12">
-  <meta property="og:description" content="DeepSeek Harness，装好就能用。办公、记忆、手机消息和本地语音都在一个桌面发行版里。">
-  <meta name="theme-color" content="#0B1C2C">
+  <title>蓬莱 0.6.0 | 把该做的事，留在自己的电脑上</title>
+  <meta name="description" content="蓬莱 0.6.0 把官方 DeepSeek Harness 0.1.5-alpha.1 装进个人电脑，办公、记忆、消息连接与本地语音都在同一个客户端里。支持 Apple 芯片、Intel Mac、Windows x64 与统信 UOS 20 龙芯。">
+  <meta property="og:title" content="蓬莱 0.6.0">
+  <meta property="og:description" content="官方 DeepSeek Harness，装进你的电脑。办公和记忆默认开启。第一条真实回复之后，引导才算完成。">
+  <meta name="theme-color" content="#F3EEE4">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://penglai.pages.dev/zh/">
   <meta property="og:locale" content="zh_CN">
   <meta property="og:locale:alternate" content="en_US">
-  <meta property="og:image" content="https://penglai.pages.dev/shots/0.5.5/plugin-center.png">
-  <meta property="og:image:alt" content="蓬莱 0.5.5 插件中心，作为历史界面参考">
+  <meta property="og:image" content="https://penglai.pages.dev/shots/0.5.5/welcome.png">
+  <meta property="og:image:alt" content="蓬莱 0.5.5 首次引导欢迎页，作为历史界面参考">
   <link rel="icon" href="../favicon.svg" type="image/svg+xml">
   <link rel="canonical" href="https://penglai.pages.dev/zh/">
   <link rel="alternate" hreflang="en" href="https://penglai.pages.dev/">
@@ -30,11 +30,8 @@
       <span></span>
     </button>
     <nav id="navLinks" aria-label="主导航">
-      <a href="#new">产品</a>
-      <a href="#inside">能力</a>
+      <a href="#product">产品</a>
       <a href="#setup">安装</a>
-      <a href="#privacy">隐私</a>
-      <a href="#faq">问答</a>
       <a href="#download">下载</a>
       <a href="../" hreflang="en" lang="en">EN</a>
       <a class="github" href="https://github.com/kevinchennewbee/PenglaiAgent">GitHub</a>
@@ -43,160 +40,203 @@
 
   <main id="main">
     <section class="hero" id="top">
-      <div class="hero-clouds" aria-hidden="true">
-        <span class="cloud c1"></span>
-        <span class="cloud c2"></span>
-        <span class="cloud c3"></span>
-      </div>
-      <canvas id="hero-canvas" class="hero-canvas" aria-hidden="true"></canvas>
-      <img class="hero-art" src="../shots/banner-v1.png" alt="云海中的蓬莱仙山，原版产品画">
-      <div class="hero-shade"></div>
-      <div class="hero-copy">
-        <p class="eyebrow">Penglai 0.5.12 · DeepSeek Harness 0.1.3-alpha.2</p>
-        <h1>不是另一个 Agent。<br>官方 DeepSeek Harness，<br>装进你的电脑。</h1>
-        <p class="lead">蓬莱把官方 DeepSeek Harness、Node、Electron、首次引导、更新、卸载和一组经过审核的 DSH 插件放进一个桌面客户端。你不用先学终端，也不用把日常交给一个新的云账号。</p>
-        <div class="actions">
-          <a class="button primary" href="#download">下载 0.5.12</a>
-          <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent">查看源代码</a>
+      <div class="hero-inner">
+        <div class="hero-copy">
+          <p class="eyebrow">Penglai 0.6.0</p>
+          <h1>把该做的事，留在自己的电脑上。</h1>
+          <p class="lead">蓬莱把官方 DeepSeek Harness 装进个人电脑。你自备模型密钥，选好 Workspace，收到第一条真实回复，引导才算完成。办公和记忆默认开启。消息、语音和主动陪伴要你开口才来。</p>
+          <div class="actions">
+            <a class="button primary" href="#download">选择你的电脑</a>
+            <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent">查看源代码</a>
+          </div>
+          <p class="meta-row">
+            <span>Apple 芯片</span>
+            <span>Intel Mac</span>
+            <span>Windows x64</span>
+            <span>UOS 20 龙芯</span>
+            <span>MIT</span>
+          </p>
         </div>
-        <p class="quiet">MIT 开源 · 本地优先 · Apple Silicon / Intel Mac / Windows x64</p>
+        <figure>
+          <div class="app-frame">
+            <div class="app-chrome" aria-hidden="true"><i></i><i></i><i></i><span>蓬莱</span></div>
+            <img src="../shots/0.5.5/welcome.png" alt="蓬莱首次引导欢迎页：语言、外观和七步引导">
+          </div>
+          <figcaption>0.5.5 安装版首次引导欢迎页，作为界面参考。这不是 0.6.0 截图。</figcaption>
+        </figure>
       </div>
     </section>
 
-    <section class="intro" id="new" data-reveal>
+    <section class="use-band wrap" data-reveal>
+      <div class="use-grid">
+        <article>
+          <h3>改眼前这份文件</h3>
+          <p>办公可以检查、创建、预览和保存 DOCX、XLSX、PPTX 与 PDF。写入前要有与动作绑定的确认。</p>
+        </article>
+        <article>
+          <h3>只记住当前项目</h3>
+          <p>记忆整理当前 Workspace 里的安全事实。隔壁 Workspace 看不见。记录留在这台电脑上。</p>
+        </article>
+        <article>
+          <h3>需要时再接消息</h3>
+          <p>微信、飞书和另外六个渠道可以进入同一个 official Session。WhatsApp 不是产品能力。</p>
+        </article>
+        <article>
+          <h3>语音要你先安装</h3>
+          <p>语音识别和语音生成默认关闭，模型要你主动下载。没有它们，普通会话仍然可用。</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section core" id="product" data-reveal>
       <div>
-        <p class="eyebrow">DSH 仍是唯一核心</p>
-        <h2>蓬莱负责安装与边界，会话仍归 DeepSeek Harness。</h2>
+        <p class="eyebrow">核心没有换</p>
+        <h2>会话仍归 DeepSeek Harness。</h2>
         <div class="gold-rule" aria-hidden="true"></div>
       </div>
-      <p>模型、工具、审批、Workspace、Session、Turn 和会话界面都由官方 DeepSeek Harness 拥有。Penglai 0.5.12 消费精确固定的官方 <code>0.1.3-alpha.2</code> npm 包，对应 tag <code>dsh-v0.1.3-alpha.2</code>、commit <code>82a5fd61a7cf5c293cec4bdff68f455398d685e9</code>。消息恢复、预算结算和主动陪伴回放走官方 Session 快照。从 0.5.8、0.5.9、0.5.10 和 0.5.11 升级时准备独立数据代际，并保留旧版以便回退。三端安装包来自源码 <code>54a0ef30afa4e3d653e400a637d4aa8eb4abbb75</code>。</p>
-    </section>
-
-    <figure class="feature-shot wide-shot" data-reveal>
-      <img src="../shots/0.5.5/plugin-center.png" alt="真实安装的蓬莱 0.5.5 插件中心，运行在官方 DSH 设置里">
-      <figcaption>0.5.5 安装版截图，作为界面参考。0.5.12 的原生安装与公开字节证据记录在发布清单中，这些画面不是 0.5.12 新截图。</figcaption>
-    </figure>
-
-    <section class="section" id="inside" data-reveal>
-      <p class="eyebrow">安装包里已经有</p>
-      <h2>办公和记忆默认启用，其余能力需要时再开。</h2>
-      <div class="cards">
-        <article>
-          <span class="state on">默认启用</span>
-          <h3>蓬莱办公</h3>
-          <p>读取、创建、修改、预览和保存 DOCX、XLSX、PPTX 与 PDF。写入前有计划和确认，PDF 自带中文字体，不要求用户安装 LibreOffice。</p>
-        </article>
-        <article>
-          <span class="state on">默认启用</span>
-          <h3>蓬莱记忆</h3>
-          <p>安全的项目事实会整理到当前 Workspace；整理候选会调用你选择的模型供应商，记录与召回留在本机。个人事实仍需明确保存，记忆不会跨 Workspace 召回。</p>
-        </article>
-        <article>
-          <span class="state">按需启用</span>
-          <h3>消息连接</h3>
-          <p>微信、飞书、钉钉、企业微信、QQ、Slack、Telegram 与 Discord 进入同一个 <code>@penglai/im</code>。按平台使用扫码、设备注册或官方 Token。WhatsApp 在 0.5.12 中不展示、不支持，也不捆绑运行时。</p>
-        </article>
-        <article>
-          <span class="state">按需启用</span>
-          <h3>本地语音</h3>
-          <p>SenseVoice 负责识别，MOSS-TTS 负责生成。会话朗读原文，不负责翻译；试听与朗读都可再次点击停止。插件代码随包，较大的模型权重会在启用时说明后再下载。</p>
-        </article>
-        <article>
-          <span class="state">按需启用</span>
-          <h3>主动陪伴</h3>
-          <p>只有你开启后才会定时联系，并受安静时间、每日次数和指定消息渠道约束。全新安装默认关闭。</p>
-        </article>
-        <article>
-          <span class="state">独立更新</span>
-          <h3>签名插件中心</h3>
-          <p>目录来自不可变 GitHub Release。通过审核、兼容 DSH 0.1.3-alpha.2 的插件可以后加入，不必只为改一张列表重发桌面版本。界面状态不等于已安装或健康。</p>
-        </article>
+      <div>
+        <p>官方 DeepSeek Harness 是唯一 Agent 核心。模型、工具、审批、Workspace、Session、Turn 和会话界面都归它。蓬莱负责安装包、首次引导、进程监管、升级、卸载、本地目录和一组经过审核的插件。这里没有第二套蓬莱 Agent，也没有另做一张聊天页。会话升级会把历史日志拷进新文件，并保留原件。从 0.5.12 升级时拷贝已经用过的 DSH Home，不会重建安装链接。</p>
+        <p class="identity">Penglai 0.6.0 · DSH <code>0.1.5-alpha.1</code> · tag <code>dsh-v0.1.5-alpha.1</code> · commit <code>5dda764ed3aa172535a7967b06ff95d9cbfe536a</code> · 272 包</p>
       </div>
     </section>
 
-    <section class="gallery" aria-label="0.5.5 安装版界面参考" data-reveal>
-      <figure>
-        <img src="../shots/0.5.5/office.png" alt="蓬莱办公设置页">
-        <figcaption>蓬莱办公：创建、查看和有确认的修改</figcaption>
-      </figure>
-      <figure>
-        <img src="../shots/0.5.5/memory.png" alt="蓬莱记忆设置页">
-        <figcaption>蓬莱记忆：Workspace 隔离、图谱、更正和迁移</figcaption>
-      </figure>
-      <figure>
-        <img src="../shots/0.5.5/mobile-messaging.png" alt="蓬莱消息连接设置页">
-        <figcaption>消息连接：微信与飞书共用一个 IM 插件</figcaption>
-      </figure>
-      <figure>
-        <img src="../shots/0.5.5/speech-recognition.png" alt="蓬莱语音识别设置页">
-        <figcaption>语音识别：模型安装后，电脑会话出现麦克风</figcaption>
-      </figure>
-    </section>
+    <figure class="wide-shot" data-reveal>
+      <img src="../shots/0.5.5/plugin-center.png" alt="运行在官方 DSH 设置里的蓬莱插件中心，可见办公、记忆、消息和语音">
+      <figcaption>0.5.5 安装版插件中心，运行在官方 DSH 设置里。界面状态不等于已安装或健康。这不是 0.6.0 截图。</figcaption>
+    </figure>
 
     <section class="section split" data-reveal>
       <div class="copy">
-        <p class="eyebrow">一次完整工作</p>
-        <h2>文件进工作区，写入必须经过确认。</h2>
-        <p>蓬莱办公提供封闭的 typed operation：检查、创建、生成可见修改计划、预览、确认后提交，以及撤销上一笔提交。模型不能编造任意路径，也不能运行宏。输入和输出都是 Host 发出的 <code>artifact:&lt;uuid&gt;</code> 句柄，每次操作重新检查 Workspace 边界。</p>
+        <p class="eyebrow">蓬莱办公 · 默认启用</p>
+        <h2>文件进工作区，写入必须等确认。</h2>
+        <p>办公是一组封闭的 typed operation：检查、创建、生成可见修改计划、预览、确认后提交，以及撤销上一笔提交。模型不能编造任意路径，也不能运行宏。输入和输出都是 Host 发出的 <code>artifact:&lt;uuid&gt;</code> 句柄，每次操作重新检查。</p>
         <ul class="workflow-list">
-          <li>DOCX、XLSX、PPTX、PDF 都在同一条产品路径里。</li>
-          <li>PDF 输出内置 OFL 中文字体。</li>
-          <li>保存、导出、回传绑定具体动作，而不是聊天里随口说“好的”。</li>
+          <li>DOCX、XLSX、PPTX、PDF 走同一条产品路径。</li>
+          <li>PDF 输出内置 OFL 中文字体，不要求用户安装 LibreOffice。</li>
+          <li>保存、导出、回传绑定具体动作，不是聊天里随口说好。</li>
         </ul>
       </div>
-      <img src="../shots/0.5.5/office.png" alt="蓬莱办公创建、查看和目标修改入口">
+      <img src="../shots/0.5.5/office.png" alt="蓬莱办公设置：针对 DOCX 的创建、查看和目标修改">
     </section>
 
     <section class="section split reverse" data-reveal>
       <div class="copy">
-        <p class="eyebrow">记忆有边界</p>
+        <p class="eyebrow">蓬莱记忆 · 默认启用</p>
         <h2>当前项目记得住，隔壁项目看不见。</h2>
-        <p>全新安装默认智能整理当前 Workspace。Turn 结束后，一个禁用全部工具的官方 Agent 沿用你正在用的供应商和模型，输出由 Host 封闭校验。密钥、敏感内容和类似注入的文本会被跳过。后续步骤只召回当前 Workspace 已确认记录，以及你明确保存的个人事实。</p>
+        <p>Turn 结束后，一个禁用全部工具的官方 Agent 沿用你正在用的供应商和模型，提出安全的项目事实。Host 用封闭格式校验，密钥、敏感内容和类似注入的文本会被跳过。后续步骤只召回当前 Workspace 已确认记录，以及你明确保存的个人事实。</p>
         <ul class="workflow-list">
           <li>可以关闭记忆，或改成先看候选。</li>
           <li>授权文件夹只建派生索引，撤销时不改原文件。</li>
-          <li>Mnemon 0.2.8 是唯一召回引擎，已随包装入。</li>
+          <li>整理候选会调用你选择的模型供应商。记录与召回留在本机。Mnemon 0.2.8 已随包。</li>
         </ul>
       </div>
-      <img src="../shots/0.5.5/memory.png" alt="蓬莱记忆的范围、图谱和更正">
+      <img src="../shots/0.5.5/memory.png" alt="蓬莱记忆设置：范围、图谱、更正和迁移">
     </section>
 
-    <section class="section split first-run" id="setup" data-reveal>
+    <section class="section" data-reveal>
+      <p class="eyebrow">你开口之前，先靠边</p>
+      <h2>可选能力不会挡路。</h2>
+      <div class="opt-list">
+        <article>
+          <div>
+            <span class="state">按需启用</span>
+            <h3>消息连接</h3>
+          </div>
+          <p>微信、飞书、钉钉、企业微信、QQ、Slack、Telegram 与 Discord 进入同一个 <code>@penglai/im</code>。按平台使用扫码、设备注册或官方 Token。WhatsApp 不展示、不支持，也不捆绑运行时。</p>
+        </article>
+        <article>
+          <div>
+            <span class="state">按需启用</span>
+            <h3>本地语音</h3>
+          </div>
+          <p>SenseVoice 负责识别，MOSS-TTS 负责生成。插件代码随包。较大的模型权重会在启用时说明后再下载。会话朗读原文，不负责翻译。</p>
+        </article>
+        <article>
+          <div>
+            <span class="state">按需启用</span>
+            <h3>主动陪伴</h3>
+          </div>
+          <p>只有你开启后才会定时联系，并受安静时间、每日次数和指定消息渠道约束。全新安装默认关闭。</p>
+        </article>
+        <article>
+          <div>
+            <span class="state">独立更新</span>
+            <h3>插件中心</h3>
+          </div>
+          <p>目录来自不可变 GitHub Release。通过审核、兼容 DSH 0.1.5-alpha.1 的插件可以后加入，不必只为改一张列表重发桌面版本。签名、哈希、权限和回滚保护分发；插件仍与本地 DSH 共享进程。</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section split" id="setup" data-reveal>
       <div class="copy">
-        <p class="eyebrow">第一次打开，不该是一道坎</p>
-        <h2>七步引导，走到第一条真实回复才算完成。</h2>
+        <p class="eyebrow">第一次打开</p>
+        <h2>七步引导，走到真实回复才算完成。</h2>
         <p>选择语言和外观，阅读本地数据边界，从官方模型列表选择供应商和模型，测试自己的 API 密钥，选择真实 Workspace，然后发送第一条消息。可以返回、重试，也可以关掉窗口后继续。失败的请求不会被说成成功。应用数据目录和安装目录不能当作 Workspace。</p>
         <ul class="workflow-list">
-          <li>Apple 芯片、Intel Mac 与 Windows x64 必须使用对应安装包，不要混用。</li>
+          <li>请使用对应安装包。Apple 芯片、Intel、Windows 与 UOS 不要混用。</li>
           <li>升级使用同平台安装包手动覆盖，不会静默更新。</li>
-          <li>默认卸载保留用户数据；外部 Workspace 与 <code>Penglai/0.5</code> 代际会留下。</li>
+          <li>默认卸载保留用户数据。外部 Workspace 与 <code>Penglai/0.5</code> 代际会留下。</li>
         </ul>
       </div>
-      <img src="../shots/0.5.5/welcome.png" alt="蓬莱 0.5.5 首次引导欢迎页">
+      <img src="../shots/0.5.5/privacy.png" alt="蓬莱首次引导中的隐私说明：密钥写入本机 YAML，聊天和二维码不进日志">
     </section>
 
-    <section class="sea section" id="privacy" data-reveal>
-      <p class="eyebrow">隐私与信任</p>
-      <h2>没有蓬莱账号。社区发行版，不把签名说成系统背书。</h2>
-      <div class="trust-grid">
-        <p><strong>没有蓬莱云同步。</strong>官方 DSH 自带 session-telemetry adapter 和一个休眠的 DeepSeek OTLP 地址。蓬莱会在所有 profile patch 之后硬性禁用该行，因此本机 DSH 进程不会创建 SDK provider 或上传管线。模型调用仍会把本次任务需要的内容发给你选择的供应商。</p>
-        <p><strong>写入和外发要单独确认。</strong>办公保存与回传、记忆个人化、插件安装都走产品内与动作绑定的确认。诊断导出不得包含凭据、聊天正文、二维码或私人绝对路径。</p>
-        <p><strong>macOS 未公证。</strong>安装包是 ad-hoc 签名；Windows 没有 Authenticode。Gatekeeper 或 SmartScreen 可能提醒。蓬莱 Ed25519 保护的是升级和插件字节，不是 Apple 或 Microsoft 发布者身份。</p>
-        <p><strong>插件不是沙箱。</strong>签名、哈希、权限清单和回滚保护分发链路；DSH 插件仍与本地 DSH 共享进程。无凭据检查不能证明真实模型回复或账号消息送达。</p>
+    <section class="section limits" id="privacy" data-reveal>
+      <p class="eyebrow">边界，说清楚</p>
+      <h2>没有蓬莱账号。模型调用仍会离开这台电脑。</h2>
+      <div class="limit-grid">
+        <p><strong>数据去哪</strong> 没有蓬莱账号、蓬莱运营的遥测后端或云端记忆同步。官方 DSH 自带一个休眠的 DeepSeek OTLP 地址，蓬莱会硬性禁用。模型调用仍会把本次任务需要的内容发给你选择的供应商。</p>
+        <p><strong>哪些事要单独确认</strong> 办公保存与回传、记忆个人化、插件安装和外发消息，都走与动作绑定的确认。诊断不得包含凭据、聊天正文、二维码或私人绝对路径。</p>
+        <p><strong>签名不是系统背书</strong> macOS 是 ad-hoc 签名、未公证；Windows 没有 Authenticode。Gatekeeper 或 SmartScreen 可能提醒。蓬莱 Ed25519 保护升级和插件字节，不是 Apple 或 Microsoft 发布者身份。</p>
+        <p><strong>UOS 是第四端，不是已完成的真机声明</strong> 统信 UOS 20 龙芯的安装包是 <code>Penglai_0.6.0_uos_loong64.deb</code>。该机上的安装、启动和功能由 Owner 在发布后测试。UOS 运行时是龙芯 Electron 31.7.7（Chromium 126），不是 Mac/Windows 的 Electron 43。</p>
       </div>
     </section>
 
-    <section class="story section" id="story" data-reveal>
+    <section class="section download" id="download" data-reveal>
+      <p class="eyebrow">Penglai 0.6.0</p>
+      <h2>选和这台机器对应的安装包。</h2>
+      <p class="download-hint" id="downloadHint" hidden data-mac="当前浏览器像是 Mac。M 系列一般选 Apple 芯片；若「关于本机」仍写 Intel，请用 Intel 包。" data-windows="当前浏览器像是 Windows。请使用 64 位安装器。" data-linux="当前浏览器像是 Linux。公开的 Linux 包只覆盖统信 UOS 20 龙芯。"></p>
+      <div class="download-grid">
+        <a data-family="mac" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_aarch64.dmg">
+          <strong>macOS · Apple 芯片</strong>
+          <span>macOS 13+ · M1 及更新</span>
+          <em>Penglai_0.6.0_macos_aarch64.dmg</em>
+        </a>
+        <a data-family="mac" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_x64.dmg">
+          <strong>macOS · Intel</strong>
+          <span>macOS 13+ · x86_64 Mac</span>
+          <em>Penglai_0.6.0_macos_x64.dmg</em>
+        </a>
+        <a data-family="windows" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_windows_x64_setup.exe">
+          <strong>Windows · x64</strong>
+          <span>Windows 10+ · 64 位安装器</span>
+          <em>Penglai_0.6.0_windows_x64_setup.exe</em>
+        </a>
+        <a data-family="linux" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_uos_loong64.deb">
+          <strong>UOS 20 · 龙芯</strong>
+          <span>统信 UOS 20 专业版 1070，旧世界。真机安装与功能由 Owner 在发布后测试。</span>
+          <em>Penglai_0.6.0_uos_loong64.deb</em>
+        </a>
+      </div>
+      <p class="note-panel">权威公开下载源是不可变 GitHub Release：<a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0">v0.6.0</a>。在这些字节存在并回读完成前，最近的公开安装包仍是 <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12">v0.5.12</a>。发布后请用该页的 <code>SHA256SUMS</code> 核对文件。Linux amd64 与 Windows ARM 不是目标。更新不会静默执行。</p>
+      <div class="actions">
+        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/RELEASE_NOTES_0.6.0.md">发布说明草稿</a>
+        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">安全说明</a>
+      </div>
+    </section>
+
+    <section class="section story" id="story" data-reveal>
       <p class="eyebrow">为什么叫蓬莱</p>
-      <blockquote>我做了十多年网络、安全和运维，却不是软件开发者。蓬莱一开始就想证明一件事：AI 时代，普通人也能为自己造工具。</blockquote>
+      <blockquote>我做了十多年网络、安全和运维，却不是软件开发者。蓬莱一开始就想证明一件事：普通人应该能从自己已经有的电脑，找到真正能用的助手。</blockquote>
       <p>从命令行到窗口，再到每个人口袋里的手机，计算机一直在降低使用门槛。Agent 也应该走同一条路。会发消息，就应该能找到自己的助手；它替你做了什么、能看什么、花了多少，也应该讲得清楚。</p>
-      <p>蓬莱已经重做过不止一次。0.5 最重要的决定，是停止再造一个 Agent，转而站在 DeepSeek Harness 这个开源核心上，把安装、办公、记忆、手机消息和本地语音一件件做好。旧版本留在 Git 历史里讲这段路，但不会和新的 DSH 核心混在一起。</p>
+      <p>蓬莱已经重做过不止一次。0.5 最重要的决定，是停止再造一个 Agent，转而站在 DeepSeek Harness 上。0.6.0 把同一件事做到四台电脑上，包括统信 UOS 20 龙芯。旧版本留在 Git 历史里讲这段路，但不会和新的核心混在一起。</p>
       <p class="signature">陈克文 / Kevin Chen</p>
     </section>
 
     <section class="section" id="faq" data-reveal>
       <p class="eyebrow">常见问题</p>
-      <h2>先把限制说清楚，再下载。</h2>
+      <h2>安装前先看这几句。</h2>
       <div class="faq-grid">
         <article>
           <h3>蓬莱是另一个 Agent 吗？</h3>
@@ -204,7 +244,7 @@
         </article>
         <article>
           <h3>现在该下载哪个版本？</h3>
-          <p>公开安装包是 0.5.12。已发布的 0.5.10 与 0.5.11 仍是不可变历史版本。</p>
+          <p>本页描述的是 Penglai 0.6.0。在 v0.6.0 Release 公开前，最近的不可变安装包是 0.5.12。已发布的 0.5.10 与 0.5.11 仍是历史版本。</p>
         </article>
         <article>
           <h3>为什么 Gatekeeper 会提示？</h3>
@@ -216,46 +256,25 @@
         </article>
         <article>
           <h3>密钥填错了怎么办？</h3>
-          <p>引导支持返回、重试和重启续接。密钥测试失败不会被记成成功；可以改密钥再测，或回到模型选择。</p>
+          <p>引导支持返回、重试和重启续接。密钥测试失败不会被记成成功。</p>
         </article>
         <article>
           <h3>卸载会删掉我的文件吗？</h3>
           <p>默认卸载去掉应用和缓存，保留用户数据。完整删除走单独的分类计划，不会递归清掉 Workspace 或主目录。</p>
         </article>
       </div>
-    </section>
-
-    <section class="download section" id="download" data-reveal>
-      <p class="eyebrow">Penglai 0.5.12</p>
-      <h2>选择你的电脑。</h2>
-      <div class="download-grid">
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_aarch64.dmg">
-          <strong>macOS · Apple 芯片</strong>
-          <span>GitHub · 271.0 MiB · M1 / M2 / M3 / M4 / M5</span>
-          <code>1f6d7f9ceab13c62a6e31d52a0517c4972a52378e5ce102bf2983f3c32fd8034</code>
-        </a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_macos_x64.dmg">
-          <strong>macOS · Intel</strong>
-          <span>GitHub · 280.2 MiB · x86_64 Mac</span>
-          <code>f82a5d44bccb7d15def176602f8320d1464eae802897e41c5ec39c8d471d61c3</code>
-        </a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.5.12/Penglai_0.5.12_windows_x64_setup.exe">
-          <strong>Windows · x64</strong>
-          <span>GitHub · 353.9 MiB · 64 位安装器</span>
-          <code>5d926a884ca2b93c43f8ee8d8e8897df636585d449f1810d25ab4bffae3159da</code>
-        </a>
-      </div>
-      <p class="note-panel">当前公开下载是已发布的 0.5.12。已发布的 0.5.10 与 0.5.11 仍不可变。只以不可变 GitHub Release 为权威公开下载源；北京镜像尚未发布 0.5.12。三个安装包来自源码 <code>54a0ef30afa4e3d653e400a637d4aa8eb4abbb75</code>。完整 SHA256SUMS、SBOM、第三方声明与签名元数据同页提供；更新不会静默执行。</p>
-      <div class="actions centered">
-        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12">中英文发布说明</a>
-        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">安全说明</a>
-      </div>
+      <p class="docs-row">
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/PRODUCT.md">产品契约</a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/ARCHITECTURE.md">架构</a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/PLUGIN_CENTER.md">插件中心</a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/0.6.0/ACCEPTANCE_DELTA.md">0.6.0 验收增量</a>
+      </p>
     </section>
   </main>
 
   <footer>
     <p>Penglai 由 <a href="https://github.com/kevinchennewbee">陈克文 / Kevin Chen</a> 发起并维护，基于 <a href="https://github.com/deepseek-ai/deepseek-harness">DeepSeek Harness</a>，MIT 开源。</p>
-    <p>多通道工程参考来自 <a href="https://github.com/xmanrui/dsh-im">DSH-IM</a> 社区；QQ 官方机器人接入参考来自 <a href="https://github.com/tencent-connect/qqbot-agent-sdk">qqbot-agent-sdk</a>。两者均未作为运行时整体捆绑。</p>
+    <p>多通道工程参考来自 <a href="https://github.com/xmanrui/dsh-im">DSH-IM</a> 社区。QQ 官方机器人接入参考来自 <a href="https://github.com/tencent-connect/qqbot-agent-sdk">qqbot-agent-sdk</a>。两者均未作为运行时整体捆绑。</p>
     <p>感谢 Electron、Node.js、TypeScript、pnpm、SenseVoice、sherpa-onnx、MOSS-TTS-Nano、Mnemon、Lark SDK、openclaw-weixin 以及所有贡献者。</p>
     <p><a href="../" hreflang="en" lang="en">English</a> · <span lang="zh-CN">中文</span></p>
   </footer>

--- a/website/zh/index.html
+++ b/website/zh/index.html
@@ -127,7 +127,7 @@
         <ul class="workflow-list">
           <li>可以关闭记忆，或改成先看候选。</li>
           <li>授权文件夹只建派生索引，撤销时不改原文件。</li>
-          <li>整理候选会调用你选择的模型供应商。记录与召回留在本机。Mnemon 0.2.8 已随包。</li>
+          <li>整理候选会调用你选择的模型供应商。记录与召回留在本机。记忆必装默认开启，UOS 上也带入 Mnemon 0.2.8 引擎。</li>
         </ul>
       </div>
       <img src="../shots/0.5.5/memory.png" alt="蓬莱记忆设置：范围、图谱、更正和迁移">
@@ -149,7 +149,7 @@
             <span class="state">按需启用</span>
             <h3>本地语音</h3>
           </div>
-          <p>SenseVoice 负责识别，MOSS-TTS 负责生成。插件代码随包。较大的模型权重会在启用时说明后再下载。会话朗读原文，不负责翻译。</p>
+          <p>SenseVoice 负责识别。MOSS-TTS 在 Mac/Windows 上负责生成。插件代码随包。SenseVoice 较大权重会在启用时说明后再下载。MOSS-TTS 在龙芯上不可用、不可启用。会话朗读原文，不负责翻译。</p>
         </article>
         <article>
           <div>
@@ -189,7 +189,7 @@
         <p><strong>数据去哪</strong> 没有蓬莱账号、蓬莱运营的遥测后端或云端记忆同步。官方 DSH 自带一个休眠的 DeepSeek OTLP 地址，蓬莱会硬性禁用。模型调用仍会把本次任务需要的内容发给你选择的供应商。</p>
         <p><strong>哪些事要单独确认</strong> 办公保存与回传、记忆个人化、插件安装和外发消息，都走与动作绑定的确认。诊断不得包含凭据、聊天正文、二维码或私人绝对路径。</p>
         <p><strong>签名不是系统背书</strong> macOS 是 ad-hoc 签名、未公证；Windows 没有 Authenticode。Gatekeeper 或 SmartScreen 可能提醒。蓬莱 Ed25519 保护升级和插件字节，不是 Apple 或 Microsoft 发布者身份。</p>
-        <p><strong>UOS 是第四端，不是已完成的真机声明</strong> 统信 UOS 20 龙芯的安装包是 <code>Penglai_0.6.0_uos_loong64.deb</code>。该机上的安装、启动和功能由 Owner 在发布后测试。UOS 运行时是龙芯 Electron 31.7.7（Chromium 126），不是 Mac/Windows 的 Electron 43。</p>
+        <p><strong>UOS 是第四端，不是已完成的真机声明</strong> 统信 UOS 20 龙芯的安装包是 <code>Penglai_0.6.0_uos_loong64.deb</code>。该机上的安装、启动和功能仍是 Owner 发布后测试（<code>OWNER_POST_RELEASE</code>），不是 PASS。UOS 运行时是龙芯 Electron 31.7.7（Chromium 126），未维持，也不是 Mac/Windows Electron 43 / Chromium 150 的安全等价。记忆必开且带入 Mnemon 引擎。MOSS-TTS 在龙芯上不可用、不可启用。</p>
       </div>
     </section>
 
@@ -200,28 +200,32 @@
       <div class="download-grid">
         <a data-family="mac" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_aarch64.dmg">
           <strong>macOS · Apple 芯片</strong>
-          <span>macOS 13+ · M1 及更新</span>
+          <span>GitHub · 271.2 MiB · macOS 13+ · M1 及更新</span>
           <em>Penglai_0.6.0_macos_aarch64.dmg</em>
+          <code>98d1c0a133d50200c03626d39e225a52ff08d1f1a09fdb1595ab706b70f183cb</code>
         </a>
         <a data-family="mac" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_macos_x64.dmg">
           <strong>macOS · Intel</strong>
-          <span>macOS 13+ · x86_64 Mac</span>
+          <span>GitHub · 280.4 MiB · x86_64 Mac</span>
           <em>Penglai_0.6.0_macos_x64.dmg</em>
+          <code>4c74a4ce9353ccf23aa74471d279237c4b5b9822d118aa2a90e44e16caf16498</code>
         </a>
         <a data-family="windows" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_windows_x64_setup.exe">
           <strong>Windows · x64</strong>
-          <span>Windows 10+ · 64 位安装器</span>
+          <span>GitHub · 352.7 MiB · 64 位安装器</span>
           <em>Penglai_0.6.0_windows_x64_setup.exe</em>
+          <code>6316f623fe877686662b7b3a5641945bc946e2b1dd31bf3d9527c6a17f7c35e9</code>
         </a>
         <a data-family="linux" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.0/Penglai_0.6.0_uos_loong64.deb">
           <strong>UOS 20 · 龙芯</strong>
-          <span>统信 UOS 20 专业版 1070，旧世界。真机安装与功能由 Owner 在发布后测试。</span>
+          <span>GitHub · 279.1 MiB · 统信 UOS 20 专业版 1070，旧世界。真机功能为 Owner 发布后测试。</span>
           <em>Penglai_0.6.0_uos_loong64.deb</em>
+          <code>a541e9fa9b06626750b4a87859cc76ff3df51b5a0eb8960de08e8eba20cad430</code>
         </a>
       </div>
-      <p class="note-panel">权威公开下载源是不可变 GitHub Release：<a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0">v0.6.0</a>。在这些字节存在并回读完成前，最近的公开安装包仍是 <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.5.12">v0.5.12</a>。发布后请用该页的 <code>SHA256SUMS</code> 核对文件。Linux amd64 与 Windows ARM 不是目标。更新不会静默执行。</p>
+      <p class="note-panel">权威公开下载源是不可变 GitHub Release：<a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0">v0.6.0</a>。四个安装包来自源码 <code>7dd68b4ab08bbe4edf4dfac7f82abb6b164cb316</code>。请用该页的 <code>SHA256SUMS</code> 核对文件。Linux amd64 与 Windows ARM 不是目标。更新不会静默执行。已发布的 0.5.10、0.5.11、0.5.12 保持不可变。</p>
       <div class="actions">
-        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/RELEASE_NOTES_0.6.0.md">发布说明草稿</a>
+        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/RELEASE_NOTES_0.6.0.md">发布说明</a>
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">安全说明</a>
       </div>
     </section>
@@ -244,7 +248,7 @@
         </article>
         <article>
           <h3>现在该下载哪个版本？</h3>
-          <p>本页描述的是 Penglai 0.6.0。在 v0.6.0 Release 公开前，最近的不可变安装包是 0.5.12。已发布的 0.5.10 与 0.5.11 仍是历史版本。</p>
+          <p>本页描述的是已发布的 Penglai 0.6.0。请从不可变 <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.0">v0.6.0</a> GitHub Release 下载对应安装包。已发布的 0.5.10、0.5.11、0.5.12 仍是不可变历史版本。</p>
         </article>
         <article>
           <h3>为什么 Gatekeeper 会提示？</h3>


### PR DESCRIPTION
Installer source remains `7dd68b4ab08bbe4edf4dfac7f82abb6b164cb316` (immutable `v0.6.0`). This PR is publication narrative, accepted README/website design, signed-readback `.deb` coverage, and the UOS native-aggregate collector path. It does not rebuild natives or rewrite 0.5.x.

- Cherry-pick accepted design `3525cc50`
- Bind public SHA-256/sizes/freeze SHA; remove draft download language
- Honest UOS/Mnemon/MOSS/Electron 31.7.7 limits
- Collect `Penglai_0.6.0_uos_loong64.deb` from anywhere under `.native/linux-loong64`
- Allow those publication-scope paths in website deploy

GitHub aggregate job on run 34376799819 remains FAILED and is not waived.