### PR TITLE
test: separate healthy DSH probe completion from hang abort

### DIFF
--- a/packages/runtime/src/runtime.test.ts
+++ b/packages/runtime/src/runtime.test.ts
@@ -469,8 +469,10 @@ test("official DSH HTTP probe validates identity and aborts a hanging response",
     const address = server.address();
     assert.ok(address && typeof address !== "string");
     const origin = `http://127.0.0.1:${address.port}`;
-    assert.equal((await probeOfficialDsh(`${origin}/official`, 500)).official, true);
-    assert.equal((await probeOfficialDsh(`${origin}/other`, 500)).official, false);
+    // Test-only ceiling for healthy loopback identity; not a production probe SLO.
+    const healthyDeadlineMs = 10_000;
+    assert.equal((await probeOfficialDsh(`${origin}/official`, healthyDeadlineMs)).official, true);
+    assert.equal((await probeOfficialDsh(`${origin}/other`, healthyDeadlineMs)).official, false);
     const started = Date.now();
     await assert.rejects(() => probeOfficialDsh(`${origin}/hang`, 40));
     assert.ok(Date.now() - started < 1_000, "hanging probe must be bounded");


### PR DESCRIPTION
The Intel native candidate stopped during the healthy loopback DSH identity assertion: its test-only 500 ms deadline expired before the deliberately hanging-response assertion ran. Give healthy identity requests a separate, finite 10 s completion ceiling while retaining both identity checks, the 40 ms hanging-response deadline, and the requirement that abort finishes within 1 s. Production timeouts and shipped runtime code are unchanged.

Validation: frozen dependency install; type and format checks; 222 runtime tests passed. Independent manager verification passed the identity/abort case and the supervisor hang/restart case (2 tests, no failures or skips). The original Intel job remains failed evidence; exact hosted-runner scheduling was not reproduced on this ARM machine. A new source generation must pass the required main checks and all four packaging targets before release.

中文：Intel 候选构建在正常回环 HTTP 请求的 500 毫秒测试时限处失败。此修改为正常身份断言提供独立且有限的 10 秒完成时限，保留身份判断、挂起请求 40 毫秒超时与 1 秒内中止的要求。生产逻辑、依赖与安装包规则未改动。原始失败保留，新提交仍须通过云端检查和同源四端构建。
