### PR TITLE
site: add Beijing HTTPS mirror for 0.6.1 installers

### DIFF
--- a/packages/release-identity/src/public-docs.test.ts
+++ b/packages/release-identity/src/public-docs.test.ts
@@ -102,6 +102,10 @@ test("website keeps the full bilingual visual site during publication preparatio
     assert.match(html, /shots\/0\.5\.5\/plugin-center\.png/);
     assert.match(html, /shots\/0\.5\.5\/office\.png/);
     assert.match(html, /shots\/0\.5\.5\/memory\.png/);
+    assert.match(html, /https:\/\/82\.156\.107\.151\/releases\/v0\.6\.1\/Penglai_0\.6\.1_macos_aarch64\.dmg/);
+    assert.match(html, /https:\/\/82\.156\.107\.151\/releases\/v0\.6\.1\/Penglai_0\.6\.1_windows_x64_setup\.exe/);
+    assert.match(html, /https:\/\/82\.156\.107\.151\/releases\/v0\.6\.1\/Penglai_0\.6\.1_uos_loong64\.deb/);
+    assert.match(html, /in-app updates still use GitHub|应用内更新仍走 GitHub/);
   }
   assert.match(css, /\.download-grid/);
   assert.match(css, /\.site-nav/);

--- a/website/en/index.html
+++ b/website/en/index.html
@@ -217,6 +217,27 @@
           <code>cd38c06e37151f226e7f9eb2519dba0800fc9ed7f4449d2b7edd5a282efb5934</code>
         </a>
       </div>
+      <p class="quiet">If GitHub is slow from mainland China, download the same installers from the Beijing mirror. Verify each file against the GitHub <code>SHA256SUMS</code>; in-app updates still use GitHub.</p>
+      <div class="download-grid download-grid-mirror">
+        <a href="https://82.156.107.151/releases/v0.6.1/Penglai_0.6.1_macos_aarch64.dmg">
+          <strong>China mirror · Apple Silicon</strong>
+          <span>Beijing HTTPS · 271.2 MiB</span>
+          <em>Penglai_0.6.1_macos_aarch64.dmg</em>
+          <code>91393e2e760871694e836c2582b903f6fee509e9fa11391724567e472f9946e9</code>
+        </a>
+        <a href="https://82.156.107.151/releases/v0.6.1/Penglai_0.6.1_windows_x64_setup.exe">
+          <strong>China mirror · Windows x64</strong>
+          <span>Beijing HTTPS · 354.1 MiB</span>
+          <em>Penglai_0.6.1_windows_x64_setup.exe</em>
+          <code>d4fb670edea847024abcb2a1ac760cc2f7c5814d0c60f77f80ec647c59f51791</code>
+        </a>
+        <a href="https://82.156.107.151/releases/v0.6.1/Penglai_0.6.1_uos_loong64.deb">
+          <strong>China mirror · UOS LoongArch</strong>
+          <span>Beijing HTTPS · 279.5 MiB</span>
+          <em>Penglai_0.6.1_uos_loong64.deb</em>
+          <code>cd38c06e37151f226e7f9eb2519dba0800fc9ed7f4449d2b7edd5a282efb5934</code>
+        </a>
+      </div>
       <p class="note-panel">The immutable GitHub Release is the authoritative public download source: <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.1">v0.6.1</a>. All three installers come from source <code>7ad7c29ecda5d9e867fdde0fe3fefd5c42d3ab1b</code>. Check the file against <code>SHA256SUMS</code> on that page. The release is three installers and ten assets. The signed updater covers Apple Silicon and Windows x64. Intel Mac is not a 0.6.1 installer. Linux amd64 and Windows ARM are not targets. Updates are never silent. Published 0.5.10, 0.5.11, 0.5.12, and 0.6.0 remain immutable.</p>
       <div class="actions">
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/RELEASE_NOTES_0.6.1.md">Release notes</a>

--- a/website/index.html
+++ b/website/index.html
@@ -216,6 +216,27 @@
           <code>cd38c06e37151f226e7f9eb2519dba0800fc9ed7f4449d2b7edd5a282efb5934</code>
         </a>
       </div>
+      <p class="quiet">If GitHub is slow from mainland China, download the same installers from the Beijing mirror. Verify each file against the GitHub <code>SHA256SUMS</code>; in-app updates still use GitHub.</p>
+      <div class="download-grid download-grid-mirror">
+        <a href="https://82.156.107.151/releases/v0.6.1/Penglai_0.6.1_macos_aarch64.dmg">
+          <strong>China mirror · Apple Silicon</strong>
+          <span>Beijing HTTPS · 271.2 MiB</span>
+          <em>Penglai_0.6.1_macos_aarch64.dmg</em>
+          <code>91393e2e760871694e836c2582b903f6fee509e9fa11391724567e472f9946e9</code>
+        </a>
+        <a href="https://82.156.107.151/releases/v0.6.1/Penglai_0.6.1_windows_x64_setup.exe">
+          <strong>China mirror · Windows x64</strong>
+          <span>Beijing HTTPS · 354.1 MiB</span>
+          <em>Penglai_0.6.1_windows_x64_setup.exe</em>
+          <code>d4fb670edea847024abcb2a1ac760cc2f7c5814d0c60f77f80ec647c59f51791</code>
+        </a>
+        <a href="https://82.156.107.151/releases/v0.6.1/Penglai_0.6.1_uos_loong64.deb">
+          <strong>China mirror · UOS LoongArch</strong>
+          <span>Beijing HTTPS · 279.5 MiB</span>
+          <em>Penglai_0.6.1_uos_loong64.deb</em>
+          <code>cd38c06e37151f226e7f9eb2519dba0800fc9ed7f4449d2b7edd5a282efb5934</code>
+        </a>
+      </div>
       <p class="note-panel">The immutable GitHub Release is the authoritative public download source: <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.1">v0.6.1</a>. All three installers come from source <code>7ad7c29ecda5d9e867fdde0fe3fefd5c42d3ab1b</code>. Check the file against <code>SHA256SUMS</code> on that page. The release is three installers and ten assets. The signed updater covers Apple Silicon and Windows x64. Intel Mac is not a 0.6.1 installer. Linux amd64 and Windows ARM are not targets. Updates are never silent. Published 0.5.10, 0.5.11, 0.5.12, and 0.6.0 remain immutable.</p>
       <div class="actions">
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/RELEASE_NOTES_0.6.1.md">Release notes</a>

--- a/website/styles/main.css
+++ b/website/styles/main.css
@@ -628,6 +628,19 @@ html[lang="zh-CN"] h2 {
   font-size: 0.98rem;
 }
 
+.quiet {
+  margin: 0 0 0.5rem;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.download-grid-mirror {
+  margin-top: 0.4rem;
+  margin-bottom: 1.4rem;
+}
+
+.download-grid-mirror a { background: rgba(255, 253, 248, 0.42); }
+
 .centered { justify-content: center; }
 
 .story { max-width: 42rem; }

--- a/website/zh/index.html
+++ b/website/zh/index.html
@@ -216,6 +216,27 @@
           <code>cd38c06e37151f226e7f9eb2519dba0800fc9ed7f4449d2b7edd5a282efb5934</code>
         </a>
       </div>
+      <p class="quiet">国内访问 GitHub 较慢时，可下载同一份安装包的北京镜像。请用 GitHub 的 <code>SHA256SUMS</code> 核对文件；应用内更新仍走 GitHub。</p>
+      <div class="download-grid download-grid-mirror">
+        <a href="https://82.156.107.151/releases/v0.6.1/Penglai_0.6.1_macos_aarch64.dmg">
+          <strong>国内镜像 · Apple 芯片</strong>
+          <span>北京 HTTPS · 271.2 MiB</span>
+          <em>Penglai_0.6.1_macos_aarch64.dmg</em>
+          <code>91393e2e760871694e836c2582b903f6fee509e9fa11391724567e472f9946e9</code>
+        </a>
+        <a href="https://82.156.107.151/releases/v0.6.1/Penglai_0.6.1_windows_x64_setup.exe">
+          <strong>国内镜像 · Windows x64</strong>
+          <span>北京 HTTPS · 354.1 MiB</span>
+          <em>Penglai_0.6.1_windows_x64_setup.exe</em>
+          <code>d4fb670edea847024abcb2a1ac760cc2f7c5814d0c60f77f80ec647c59f51791</code>
+        </a>
+        <a href="https://82.156.107.151/releases/v0.6.1/Penglai_0.6.1_uos_loong64.deb">
+          <strong>国内镜像 · 龙芯</strong>
+          <span>北京 HTTPS · 279.5 MiB</span>
+          <em>Penglai_0.6.1_uos_loong64.deb</em>
+          <code>cd38c06e37151f226e7f9eb2519dba0800fc9ed7f4449d2b7edd5a282efb5934</code>
+        </a>
+      </div>
       <p class="note-panel">权威公开下载源是不可变 GitHub Release：<a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.1">v0.6.1</a>。三个安装包来自源码 <code>7ad7c29ecda5d9e867fdde0fe3fefd5c42d3ab1b</code>。请用该页的 <code>SHA256SUMS</code> 核对文件。发布是三个安装包、十个文件。签名升级覆盖 Apple 芯片和 Windows x64。Intel Mac 不是 0.6.1 安装目标。Linux amd64 与 Windows ARM 不是目标。更新不会静默执行。已发布的 0.5.10、0.5.11、0.5.12、0.6.0 保持不可变。</p>
       <div class="actions">
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/RELEASE_NOTES_0.6.1.md">发布说明</a>


### PR DESCRIPTION
## What

Add a Beijing static mirror block to the 0.6.1 download section on the bilingual website, matching the approach used for 0.5.5/0.5.7.

- Same three 0.6.1 installers (Apple Silicon / Windows x64 / UOS LoongArch), same SHA-256 digests as the immutable GitHub Release.
- Page copy keeps GitHub as the authoritative source and states in-app updates still use GitHub.
- Adds `.quiet` / `.download-grid-mirror` styles and mirrors the assertion in `public-docs.test.ts`.

## Why

Users who cannot reach GitHub Releases reliably get a reachable HTTPS copy. `release-contract.json` still pins `updaterAllowedAssetHosts: ["github.com"]`, so only the webpage download surface changes — the updater is untouched.

## Notes

- `verify-website-release.mjs` collects installer URLs with a github.com-only regex, so these mirror links do not affect `assertWebsitePublication`; all changed paths are within the publication whitelist.
- The mirror is already live on `gh-pages` (Cloudflare follows it). This PR keeps `website/` in sync so the next `deploy-website` run does not revert the mirror.
- `pnpm test` for `packages/release-identity` passes locally (8/8 including the strict published-manifest test).