### PR TITLE
test(secret-scan): use synthetic identifiers in identity-rule fixtures

### DIFF
--- a/scripts/lib/secret-scan.test.mjs
+++ b/scripts/lib/secret-scan.test.mjs
@@ -64,9 +64,9 @@ test("R56-SEC-007 owner absolute paths in tracked text are hits", () => {
   const hits = scanIdentityText(
     "docs/notes.md",
     [
-      ["Repo lives at ", "/Users/kevin-private/repo", "."].join(""), // penglai-test-fixture
-      ["Backup on ", "/Volumes/MyDrive/backup", "."].join(""), // penglai-test-fixture
-      ["Windows copy ", "C:\\Users\\kevin\\secret", "."].join(""), // penglai-test-fixture
+      ["Repo lives at ", "/Users/fakeuser/repo", "."].join(""), // penglai-test-fixture
+      ["Backup on ", "/Volumes/fakedrive/backup", "."].join(""), // penglai-test-fixture
+      ["Windows copy ", "C:\\Users\\fakeuser\\secret", "."].join(""), // penglai-test-fixture
     ].join("\n"),
   );
   assert.deepEqual(
@@ -83,7 +83,7 @@ test("R56-SEC-007 personal webmail addresses in tracked text are hits", () => {
   const hits = scanIdentityText(
     "docs/contact.md",
     [
-      ["Owner contact ", "200705279@qq.com"].join(""), // penglai-test-fixture
+      ["Owner contact ", "fakeuser@qq.com"].join(""), // penglai-test-fixture
       ["Backup ", "owner@gmail.com"].join(""), // penglai-test-fixture
     ].join("\n"),
   );
@@ -108,10 +108,10 @@ test("R56-SEC-007 synthetic fixture identities are not owner leaks", () => {
 });
 
 test("R56-SEC-008 identity scanner never echoes the leaked value", () => {
-  const hits = scanIdentityText("notes.md", ["x ", "/Users/kevin-private/repo"].join("")); // penglai-test-fixture
+  const hits = scanIdentityText("notes.md", ["x ", "/Users/fakeuser/repo"].join("")); // penglai-test-fixture
   const report = formatSecretHits(hits);
   assert.match(report, /notes.md:1 rule=owner-absolute-path category=owner-path/);
-  assert.equal(report.includes("kevin-private"), false);
+  assert.equal(report.includes("fakeuser"), false);
 });
 
 test("R56-SEC-007 frozen publication records are exempt (release gate forbids editing them)", () => {


### PR DESCRIPTION
## What

A self-correction to #186. The identity-guard fixtures introduced there used a **real** personal webmail address and owner-derived path segments. A privacy gate must not itself carry the data it exists to catch.

Replace them with synthetic identifiers that exercise the same rules:

- `/Users/fakeuser/repo`, `/Volumes/fakedrive/backup`, `C:\Users\fakeuser\secret`, `fakeuser@qq.com`.

The synthetic-allow case keeps the public GitHub noreply address (`…@users.noreply.github.com`), which is intentionally *not* a hit.

## Verification

- `node --import tsx --test scripts/lib/secret-scan.test.mjs` → 12/12.
- `node scripts/audit-secrets.mjs` → `audit:secrets ok`.
- `node scripts/format-check.mjs` → ok.