### PR TITLE
Accept redacted native Windows lifecycle receipts

### DIFF
--- a/scripts/lib/native-fresh-set.mjs
+++ b/scripts/lib/native-fresh-set.mjs
@@ -1,9 +1,9 @@
 import { NATIVE_INSTALLED_TARGETS } from "./release-targets.mjs";
 import {
+  WINDOWS_DEFAULT_APP_SEGMENTS,
   classifyApplicationShutdown,
   hostFactsMatchTarget,
   profileRestartProblems,
-  windowsDestinationIsDefaultInstdir,
 } from "./native-lifecycle-proof.mjs";
 
 export const FRESH_LIFECYCLE_COMMAND = "verify:fresh-install-uninstall";
@@ -21,6 +21,18 @@ function uninstallMethodForTarget(target) {
   if (target === "win32-x86_64") return "nsis-uninstaller";
   if (String(target).startsWith("darwin-")) return "dedicated-app-removal";
   return "";
+}
+
+function windowsInstallReceiptProvesDefaultInstdir(install) {
+  return (
+    isRecord(install) &&
+    install.defaultNativeInstdir === true &&
+    install.customDestination === false &&
+    install.payloadDeletedByHarness === false &&
+    install.nsisDefaultInstallDir === String.raw`$LOCALAPPDATA\Penglai\app\0.5` &&
+    Array.isArray(install.segments) &&
+    JSON.stringify(install.segments) === JSON.stringify(WINDOWS_DEFAULT_APP_SEGMENTS)
+  );
 }
 
 export function freshInstallUninstallEvidenceProblems(record, expected = {}) {
@@ -86,8 +98,10 @@ export function freshInstallUninstallEvidenceProblems(record, expected = {}) {
   }
   if (!hostFactsMatchTarget(record.host, target || expectedTarget)) problems.push("missing target");
   if ((target || expectedTarget) === "win32-x86_64") {
-    const dest = record.windowsInstall?.path ?? record.destination;
-    if (!windowsDestinationIsDefaultInstdir(dest) || record.windowsInstall?.customDestination === true) {
+    // Raw user paths are deliberately redacted before evidence is uploaded.
+    // Aggregate only the non-private structural receipt emitted after the
+    // native installer proved its exact default destination on the host.
+    if (!windowsInstallReceiptProvesDefaultInstdir(record.windowsInstall)) {
       problems.push("incompatible receipt shape");
     }
     if (record.windowsInstall?.payloadDeletedByHarness === true) {

--- a/scripts/lib/native-fresh-set.test.mjs
+++ b/scripts/lib/native-fresh-set.test.mjs
@@ -67,7 +67,7 @@ function gracefulShutdown(target) {
 
 function passingReceipt(target, extra = {}) {
   const method = target === "win32-x86_64" ? "nsis-uninstaller" : "dedicated-app-removal";
-  const windowsPath = "C:\\Users\\runner\\AppData\\Local\\Penglai\\app\\0.5";
+  const windowsPath = "[private-path]";
   return {
     schema: FRESH_LIFECYCLE_SCHEMA,
     command: FRESH_LIFECYCLE_COMMAND,
@@ -81,7 +81,14 @@ function passingReceipt(target, extra = {}) {
     host: hostFor(target),
     destination: target === "win32-x86_64" ? windowsPath : "/tmp/Penglai.app",
     windowsInstall: target === "win32-x86_64"
-      ? { path: windowsPath, customDestination: false, payloadDeletedByHarness: false }
+      ? {
+          path: windowsPath,
+          segments: ["Penglai", "app", "0.5"],
+          defaultNativeInstdir: true,
+          customDestination: false,
+          payloadDeletedByHarness: false,
+          nsisDefaultInstallDir: String.raw`$LOCALAPPDATA\Penglai\app\0.5`,
+        }
       : undefined,
     boot: { freshReadiness: true, shutdown: gracefulShutdown(target), profileIdentity: bootIdentity },
     restart: { freshReadiness: true, resumed: true, shutdown: gracefulShutdown(target), profileIdentity: restartIdentity },
@@ -265,8 +272,30 @@ test("fresh lifecycle aggregation negatives: missing target, SHA, hash, proofs, 
   assert.ok(
     freshInstallUninstallEvidenceProblems(
       passingReceipt("win32-x86_64", {
-        destination: "C:\\repo\\.tmp\\fresh-install-uninstall\\app",
-        windowsInstall: { path: "C:\\repo\\.tmp\\fresh-install-uninstall\\app", customDestination: true, payloadDeletedByHarness: false },
+        destination: "[private-path]",
+        windowsInstall: {
+          path: "[private-path]",
+          segments: ["Penglai", "app", "0.5"],
+          defaultNativeInstdir: true,
+          customDestination: true,
+          payloadDeletedByHarness: false,
+          nsisDefaultInstallDir: String.raw`$LOCALAPPDATA\Penglai\app\0.5`,
+        },
+      }),
+      { sourceSha, installerSha256, target: "win32-x86_64" },
+    ).includes("incompatible receipt shape"),
+  );
+  assert.ok(
+    freshInstallUninstallEvidenceProblems(
+      passingReceipt("win32-x86_64", {
+        windowsInstall: {
+          path: "[private-path]",
+          segments: ["Penglai", "app", "0.6"],
+          defaultNativeInstdir: true,
+          customDestination: false,
+          payloadDeletedByHarness: false,
+          nsisDefaultInstallDir: String.raw`$LOCALAPPDATA\Penglai\app\0.5`,
+        },
       }),
       { sourceSha, installerSha256, target: "win32-x86_64" },
     ).includes("incompatible receipt shape"),


### PR DESCRIPTION
## Summary

- aggregate the non-private structural Windows install receipt instead of requiring a redacted user path
- require the exact default NSIS expression, path segments, native-default flag, and no custom/test deletion
- retain all source SHA, installer hash, boot, restart, owner-data, shutdown, and uninstall checks
- add negative coverage for a wrong path segment and custom destination

## Evidence

- the real Windows PASS receipt from native run 34704419481 now returns no aggregate problems
- full unit and contract suites
- typecheck, security tests, contract verifier, format and secret/privacy scan

This fixes only the failed aggregate interpretation. It does not change or bypass the native Windows proof that already ran on the host.