### PR TITLE
Fix release aggregation for native upgrade evidence

### DIFF
--- a/scripts/lib/native-upgrade-set.test.mjs
+++ b/scripts/lib/native-upgrade-set.test.mjs
@@ -53,6 +53,14 @@ test("current 0.6.2 workflow requires the 0.6.1 native upgrade path", () => {
   assert.equal(historical.requiredLifecycleGate, "verify:upgrade-uninstall");
 });
 
+test("release aggregation consumes native upgrade evidence instead of rerunning lifecycle mutation", () => {
+  const releaseVerifier = readFileSync(join(ROOT, "scripts", "verify-release.mjs"), "utf8");
+  assert.match(
+    releaseVerifier,
+    /const nativeSetGates = new Set\(\[[\s\S]*?"verify:upgrade-uninstall"[\s\S]*?\]\);/,
+  );
+});
+
 test("0.6.2 updater sequence is exactly one after immutable v0.6.1", () => {
   assert.equal(assertNextUpdaterSequence(sources, 11), 10);
   assert.throws(() => assertNextUpdaterSequence(sources, 10), /must follow public sequence 10/);

--- a/scripts/verify-release.mjs
+++ b/scripts/verify-release.mjs
@@ -18,6 +18,7 @@ const nativeSetGates = new Set([
   "verify:profile",
   "verify:signing",
   "verify:fresh-install-uninstall",
+  "verify:upgrade-uninstall",
 ]);
 
 const {


### PR DESCRIPTION
## Summary
- route `verify:upgrade-uninstall` through the exact native evidence-set verifier during release aggregation
- prevent the aggregate runner from attempting a second native lifecycle mutation
- add a regression test that keeps the upgrade gate in the evidence-backed native set

## Evidence
- Failure reproduced in native run 34707233576 after all three platform jobs passed: aggregate `verify:release` returned BLOCKED because it attempted native lifecycle mutation without `PENGLAI_LIFECYCLE_ALLOW_NATIVE=1`.
- Targeted regression: 5/5 PASS.
- Full unit: 1123 PASS, 2 skipped, 0 failed (local Node 22.22.2 with engine-strict override; CI uses pinned 22.23.2).
- Format, typecheck, contract, security, contract verification, secret audit: PASS.

## Scope
No product behavior, installer bytes, lifecycle criteria, or platform claims are weakened. The aggregate now consumes the already verified Mac and Windows native upgrade receipts, matching every other native evidence gate.