### PR TITLE
docs: publish 0.6.2 public readback

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,20 @@ Your own AI workspace, ready to install.
 
 [English](#english) · [中文](#中文) · [Website](https://penglai.pages.dev) · [中文网站](https://penglai.pages.dev/zh/) · [Security](SECURITY.md)
 
-**Penglai 0.6.1 is the current public release.** It brings official
+**Penglai 0.6.2 is the current public release.** It brings official
 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) to Apple
 Silicon, Windows x64, and UnionTech UOS 20 LoongArch in a normal desktop
 package. Office and Memory are ready from the first launch. Messaging, speech,
 and Companion wait until you turn them on.
 
-[Download 0.6.1](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.1)
-· [Release notes](docs/RELEASE_NOTES_0.6.1.md)
+[Download 0.6.2](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.2)
+· [Release notes](docs/RELEASE_NOTES_0.6.2.md)
 · [Security](SECURITY.md)
 
-Source on this branch is the **0.6.2 release candidate**, built around the
-complete official DSH `0.1.5-rc.2` cohort. There is no public 0.6.2 download
-yet. Its acceptance record is in
-[`docs/0.6.2/`](docs/0.6.2/ACCEPTANCE_DELTA.md).
+The immutable release was built from
+`83ce4aa3c153b63d9f84c6a5d650a3727e8cfec6` with the complete official DSH
+`0.1.5-rc.2` cohort. The exact public bytes and validation boundaries are in
+the [publication manifest](docs/PUBLICATION_MANIFEST_0.6.2.md).
 
 <p align="center">
   <img src="website/shots/0.5.5/welcome.png" width="78%" alt="Penglai first-run welcome">
@@ -73,34 +73,34 @@ another. Personal memory is never folded in without a separate choice.
 </p>
 <p align="center"><sub>Installed 0.5.5 Plugin Center and Office screens, shown as product references.</sub></p>
 
-### Download 0.6.1
+### Download 0.6.2
 
 GitHub Releases is the authoritative source. Choose the package that matches
 the computer and verify it against `SHA256SUMS` on the
-[`v0.6.1` release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.1).
+[`v0.6.2` release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.2).
 All three installers were built from source
-`7ad7c29ecda5d9e867fdde0fe3fefd5c42d3ab1b`.
+`83ce4aa3c153b63d9f84c6a5d650a3727e8cfec6`.
 
 #### Apple Silicon, macOS 13+
 
-[`Penglai_0.6.1_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.1/Penglai_0.6.1_macos_aarch64.dmg)
+[`Penglai_0.6.2_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/Penglai_0.6.2_macos_aarch64.dmg)
 
-284,369,412 bytes · SHA-256
-`91393e2e760871694e836c2582b903f6fee509e9fa11391724567e472f9946e9`
+284,537,443 bytes · SHA-256
+`7a9e6d851c954e74d8af8ad8d4054838ad212dd575a82ad783cabd09bfdd9348`
 
 #### Windows 10+ x64
 
-[`Penglai_0.6.1_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.1/Penglai_0.6.1_windows_x64_setup.exe)
+[`Penglai_0.6.2_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/Penglai_0.6.2_windows_x64_setup.exe)
 
-371,266,017 bytes · SHA-256
-`d4fb670edea847024abcb2a1ac760cc2f7c5814d0c60f77f80ec647c59f51791`
+371,269,392 bytes · SHA-256
+`3e97111bfcefa3c1ab72e70aad6b160acb76f6bef70391f8be4818d80edb8cda`
 
 #### UnionTech UOS 20 LoongArch
 
-[`Penglai_0.6.1_uos_loong64.deb`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.1/Penglai_0.6.1_uos_loong64.deb)
+[`Penglai_0.6.2_uos_loong64.deb`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/Penglai_0.6.2_uos_loong64.deb)
 
-293,074,470 bytes · SHA-256
-`cd38c06e37151f226e7f9eb2519dba0800fc9ed7f4449d2b7edd5a282efb5934`
+293,093,278 bytes · SHA-256
+`d16d6b9569095b4d599e9da5afd5c325ebbb661ac7de21ce993fd281bf2998f7`
 
 ### A few things worth knowing
 
@@ -202,18 +202,18 @@ PDF，写入前会针对这次动作确认。项目记忆只留在当前 Workspa
 </p>
 <p align="center"><sub>0.5.5 安装版的记忆与隐私界面，作为产品参考。</sub></p>
 
-### 下载 0.6.1
+### 下载 0.6.2
 
 当前公开版是
-[`v0.6.1`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.1)。
+[`v0.6.2`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.2)。
 请按电脑选择 Apple 芯片、Windows x64 或统信 UOS 20 龙芯安装包，下载后用发行页
 里的 `SHA256SUMS` 核对。三个安装包来自同一源码
-`7ad7c29ecda5d9e867fdde0fe3fefd5c42d3ab1b`。Intel Mac、Linux amd64 和
+`83ce4aa3c153b63d9f84c6a5d650a3727e8cfec6`。Intel Mac、Linux amd64 和
 Windows ARM 不是本版目标。
 
-- [Apple 芯片安装包](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.1/Penglai_0.6.1_macos_aarch64.dmg)
-- [Windows x64 安装包](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.1/Penglai_0.6.1_windows_x64_setup.exe)
-- [统信 UOS 20 龙芯安装包](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.1/Penglai_0.6.1_uos_loong64.deb)
+- [Apple 芯片安装包](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/Penglai_0.6.2_macos_aarch64.dmg)
+- [Windows x64 安装包](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/Penglai_0.6.2_windows_x64_setup.exe)
+- [统信 UOS 20 龙芯安装包](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/Penglai_0.6.2_uos_loong64.deb)
 
 ### 安装前值得知道
 
@@ -229,11 +229,13 @@ Windows ARM 不是本版目标。
   龙芯不提供 MOSS-TTS。Electron 31.7.7 / Chromium 126 已不再维护。
 - 默认卸载会移除应用和缓存，保留用户数据与外部 Workspace；升级不会静默进行。
 
-### 0.6.2 正在做什么
+### 0.6.2 带来了什么
 
-当前源码已经切换到完整的官方 DSH `0.1.5-rc.2` 依赖组，并恢复 Apple 芯片和
-Windows x64 从 0.6.1 升级的安装版验收。0.6.2 还没有公开下载；只有不可变发行
-附件完成发布并回读后，这里才会换成真实的大小、哈希和下载地址。
+0.6.2 使用完整的官方 DSH `0.1.5-rc.2` 依赖组。Apple 芯片和 Windows x64
+已经完成从 0.6.1 到 0.6.2 的真实安装版升级，升级和默认卸载后继续保留设置、
+会话、插件选择与记忆数据。不可变发布的源码是
+`83ce4aa3c153b63d9f84c6a5d650a3727e8cfec6`；精确公开字节与验收边界见
+[发布清单](docs/PUBLICATION_MANIFEST_0.6.2.md)。
 
 更多资料：
 [产品](docs/PRODUCT.md) · [架构](docs/ARCHITECTURE.md) ·

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,13 +1,13 @@
 # Security Policy
 
-Penglai 0.6.1 is the current **community-verified** public desktop distribution. Source on this branch is the 0.6.2 candidate with official DeepSeek Harness (DSH) `0.1.5-rc.2`; it is not a public release until immutable bytes are published and read back. The full product contract lives in [`docs/SECURITY.md`](docs/SECURITY.md).
+Penglai 0.6.2 is the current **community-verified** immutable public desktop distribution. It uses the complete official DeepSeek Harness (DSH) `0.1.5-rc.2` npm cohort and was built from `83ce4aa3c153b63d9f84c6a5d650a3727e8cfec6`. Exact public bytes and validation boundaries are recorded in [`docs/PUBLICATION_MANIFEST_0.6.2.md`](docs/PUBLICATION_MANIFEST_0.6.2.md). The full product contract lives in [`docs/SECURITY.md`](docs/SECURITY.md).
 
 ## Supported versions
 
 | Version | Status |
 | --- | --- |
-| 0.6.2 | Release candidate; not yet a public download |
-| 0.6.1 | Current immutable public release |
+| 0.6.2 | Current immutable public release |
+| 0.6.1 | Historical immutable release |
 | 0.6.0 | Historical immutable release |
 | 0.5.12 | Historical immutable release; native Mac/Windows upgrades to 0.6.0 verified |
 | 0.5.11 | Historical immutable release |
@@ -78,7 +78,7 @@ owner paths, or updater private keys.
 Please include:
 
 - Penglai version and platform (`macos_aarch64`, `macos_x64`, `windows_x64`, or `uos_loong64`)
-- Whether the build is the publication candidate
+- Whether the build is the published package or a later source checkout
 - Reproduction without real API keys or account material
 - Impact on credentials, IM routing, update/uninstall, or Electron hardening
 
@@ -90,11 +90,11 @@ Penglai will not claim notarization, Authenticode, App Store trust, silent auto-
 
 ## 中文
 
-当前公开版本为 0.6.1。当前分支是使用固定官方 DSH `0.1.5-rc.2` npm 包的
-0.6.2 候选；不可变附件发布并回读前，不是公开下载。Apple Silicon 与 Windows x64
-必须完成全新安装、0.6.1 到 0.6.2 升级和默认卸载验证。Intel Mac 不是 0.6.2
-安装目标。UOS 龙芯真机安装、启动和功能由 Owner 在 0.6.2 发布后测试。
-旧版 DSH Home 保留，新代际在独立目录通过健康检查后启用。
+当前公开版本为不可变 Penglai 0.6.2，使用完整固定的官方 DSH `0.1.5-rc.2`
+npm 依赖组，安装包源码为 `83ce4aa3c153b63d9f84c6a5d650a3727e8cfec6`。
+Apple Silicon 与 Windows x64 已完成全新安装、0.6.1 到 0.6.2 升级和默认卸载
+验证。Intel Mac 不是 0.6.2 安装目标。UOS 龙芯真机安装、启动和功能仍由 Owner
+在发布后测试。旧版 DSH Home 保留，新代际在独立目录通过健康检查后启用。
 
 0.6.2 的正式发布包含十项完整附件，包括三个安装包、签名更新清单、校验和、
 SBOM 与第三方声明。0.5.9 历史发布只有三个安装包，缺少元数据属于当时的发布缺陷；

--- a/docs/0.6.2/ACCEPTANCE_DELTA.md
+++ b/docs/0.6.2/ACCEPTANCE_DELTA.md
@@ -1,6 +1,7 @@
 # Penglai 0.6.2 acceptance delta
 
-Status: development candidate. This file is not public-release evidence.
+Status: published acceptance delta. Immutable public-byte evidence is recorded
+in `docs/PUBLICATION_MANIFEST_0.6.2.md`.
 
 ## English
 

--- a/docs/0.6.2/PUBLIC_COPY.md
+++ b/docs/0.6.2/PUBLIC_COPY.md
@@ -1,7 +1,7 @@
 # Penglai 0.6.2 publication copy
 
-Status: candidate copy. There is no public 0.6.2 download until the immutable
-GitHub Release is published and read back.
+Status: published. The immutable GitHub Release and exact public bytes are
+recorded in `docs/PUBLICATION_MANIFEST_0.6.2.md`.
 
 Penglai 0.6.2 updates the complete official DeepSeek Harness cohort to
 `0.1.5-rc.2` and restores real installed upgrades from 0.6.1 on Apple Silicon
@@ -15,6 +15,6 @@ DSH, every first-party plugin, Office, Memory, and Mnemon. UOS native use still
 waits for the Owner's post-release machine test; package and ABI checks are not
 presented as that result.
 
-Exact source SHA, asset sizes, SHA-256 values, and public URLs must be copied
-from immutable readback after publication. Do not fill them from a previous
-release or from a local build.
+The exact source SHA, asset sizes, SHA-256 values, and public URLs come from
+immutable readback after publication, never from a previous release or local
+build. See `docs/PUBLICATION_MANIFEST_0.6.2.md`.

--- a/docs/0.6.2/TODO.md
+++ b/docs/0.6.2/TODO.md
@@ -16,11 +16,11 @@ turn an unrun native or public check into PASS.
 - [x] Add a fail-closed UOS `.deb` verifier for package identity, ABI, closure,
       runtime, plugins, licenses, and architecture.
 - [x] Harden evidence output, secret scanning, and owner-path redaction.
-- [ ] Merge the reviewed source into `main` and record the frozen source SHA.
-- [ ] Complete native Mac and Windows fresh-install, restart, upgrade, rollback,
+- [x] Merge the reviewed source into `main` and record the frozen source SHA.
+- [x] Complete native Mac and Windows fresh-install, restart, upgrade, rollback,
       and default-uninstall evidence on the exact frozen SHA.
-- [ ] Build and verify the exact UOS package on that same SHA.
-- [ ] Publish and read back the exact immutable asset set.
+- [x] Build and verify the exact UOS package on that same SHA.
+- [x] Publish and read back the exact immutable asset set.
 - [ ] Replace candidate wording with observed public sizes, hashes, and source
       identity; deploy and read back both public websites.
 - [ ] Owner post-release UOS native test: install, start, UI, file picker,

--- a/docs/PUBLICATION_0.6.2.md
+++ b/docs/PUBLICATION_0.6.2.md
@@ -1,0 +1,41 @@
+# Penglai 0.6.2 publication
+
+Recorded after immutable public readback of tag `v0.6.2`.
+
+Penglai 0.6.2 publishes three installers and seven metadata files. The
+[complete public byte manifest](PUBLICATION_MANIFEST_0.6.2.md) records every
+size and SHA-256 value. The [release notes](RELEASE_NOTES_0.6.2.md) describe
+the DSH `0.1.5-rc.2` migration, restored installed upgrade, security repair,
+and known boundaries.
+
+All installers were built from source
+`83ce4aa3c153b63d9f84c6a5d650a3727e8cfec6`. [Source CI](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34709659692),
+[CodeQL](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34709659600),
+and the exact three-target [native run](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34709915417)
+passed on that SHA. The signed draft was verified, published once, and all ten
+immutable public assets passed download readback in [run 34712617415](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34712617415).
+
+The later README, security entry, bilingual website, and these publication
+records are a separate public-documentation commit. They do not change the
+installer source. Website deployment independently checks that only allowed
+publication files changed, binds every download to the immutable release, and
+compares every deployed file at Cloudflare Pages and GitHub Pages.
+
+macOS is ad-hoc signed and not notarized. Windows has no Authenticode. UOS
+package identity, ABI, dependency closure, plugins, and licenses passed, while
+native UOS install, startup, UI, file picker, sleep/resume, and functional use
+remain `OWNER_POST_RELEASE`. The two-hour installed soak is `OWNER_EXCLUDED`.
+
+## 中文
+
+Penglai 0.6.2 已公开三个安装包和七项配套文件，精确公开字节见上方清单。所有
+安装包来自源码 `83ce4aa3c153b63d9f84c6a5d650a3727e8cfec6`；源码 CI、CodeQL、三目标
+原生任务、完整草稿验证与不可变公网回读均绑定该 SHA。
+
+README、安全入口、双语官网和发布记录属于随后独立提交的公开文档，不能把文档
+提交写成安装包来源。官网部署会另行核对变更边界、真实下载信息，并逐文件回读
+Cloudflare Pages 与 GitHub Pages。
+
+macOS 未公证，Windows 无 Authenticode。UOS 包身份、ABI、依赖闭包、插件与许可
+已经通过，真机安装、启动、界面、文件选择器、休眠恢复和功能仍为
+`OWNER_POST_RELEASE`。两小时安装版测试为 `OWNER_EXCLUDED`。

--- a/docs/PUBLICATION_MANIFEST_0.6.2.md
+++ b/docs/PUBLICATION_MANIFEST_0.6.2.md
@@ -1,0 +1,81 @@
+# PUBLICATION_MANIFEST 0.6.2
+
+Status: `PUBLIC_READBACK_PASS`
+
+The original public readback downloaded all ten immutable assets after
+publication and verified their exact sizes, SHA-256 digests, update signature,
+and installer signatures. This document records those observed public bytes.
+Committed source templates remain `phase=UNFROZEN` and `sourceSha=NONE`; they
+are not substituted for generated release identity.
+
+| Field | Value |
+| --- | --- |
+| Product | `0.6.2` |
+| DSH | official unmodified npm `0.1.5-rc.2`; tag `dsh-v0.1.5-rc.2`; commit `fb2c4b9e698e30edb738bca4cf0618587db7d203` |
+| Upstream cohort | 279 packages: 265 DSH, nine vendor, five native |
+| Build source SHA | `83ce4aa3c153b63d9f84c6a5d650a3727e8cfec6` |
+| Peeled tag source | `83ce4aa3c153b63d9f84c6a5d650a3727e8cfec6` (`refs/tags/v0.6.2`) |
+| Release | [`v0.6.2`](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.2), immutable |
+| Release id | `387670584` |
+| Published at | `2026-09-12T18:56:53Z` |
+| Public readback | `PASS`; asset-set seal `700d4b1da945674115d11355d7ea4070f68678026b7073e7f3fb5f0a4f775e0b`; update signature and all installer signatures verified |
+| Public source export | tree `2272bd45d55ce99dd8df6f048029fb083fb6fc3d8877131d1773c772e61ef264` |
+| Source CI run | [34709659692](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34709659692) on the build SHA |
+| CodeQL run | [34709659600](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34709659600) on the build SHA; zero open alerts at release |
+| Native targets | [34709915417](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34709915417): darwin-aarch64, win32-x86_64, linux-loong64; exact aggregate PASS; Intel Mac excluded |
+| Publish and readback | [34712617415](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34712617415) |
+| Trust | community-verified; macOS ad-hoc, not notarized; Windows no Authenticode; UOS Electron 31.7.7 / Chromium 126 and Node 22.16.0 unmaintained, without Mac/Windows security parity |
+| Native UOS | `OWNER_POST_RELEASE` |
+| Signed updater | Apple Silicon and Windows x64 |
+
+| Asset | Bytes | SHA-256 |
+| --- | ---: | --- |
+| [`Penglai_0.6.2_macos_aarch64.dmg`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/Penglai_0.6.2_macos_aarch64.dmg) | 284,537,443 | `7a9e6d851c954e74d8af8ad8d4054838ad212dd575a82ad783cabd09bfdd9348` |
+| [`Penglai_0.6.2_windows_x64_setup.exe`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/Penglai_0.6.2_windows_x64_setup.exe) | 371,269,392 | `3e97111bfcefa3c1ab72e70aad6b160acb76f6bef70391f8be4818d80edb8cda` |
+| [`Penglai_0.6.2_uos_loong64.deb`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/Penglai_0.6.2_uos_loong64.deb) | 293,093,278 | `d16d6b9569095b4d599e9da5afd5c325ebbb661ac7de21ce993fd281bf2998f7` |
+| [`update-manifest-v1.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/update-manifest-v1.json) | 1,621 | `dc7d17006df08432b1ed1be0ebdbbf1785a90de5cdb88a6f8a9bb1bf433f0bd2` |
+| [`update-manifest-v1.json.sig`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/update-manifest-v1.json.sig) | 64 | `0a1bbaf9873903244e94ebb97a21816eb26f0ea7ff1783b20ede06423f7c6cbe` |
+| [`release-manifest.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/release-manifest.json) | 756 | `4b07dcb6ced893ca529bfecf66bff80e9dad09985b21eb7b9d9704be0a6e31ef` |
+| [`SBOM.cdx.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/SBOM.cdx.json) | 1,097,189 | `874f6f8b62fd7735aa767a9b3940aa7a02a42de4c0313077e6777eaa153c2940` |
+| [`THIRD_PARTY_NOTICES.txt`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/THIRD_PARTY_NOTICES.txt) | 161,525 | `f3436e29ee4037b7f80ee88e106cafa92af6a22ee0b14302087874104c8d89bf` |
+| [`SHA256SUMS`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/SHA256SUMS) | 832 | `d0644d5dbffd1d3d9d1c651f1dcaaa477c3fe9d23e43802c8e95584a36648735` |
+| [`public-export-manifest.json`](https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/public-export-manifest.json) | 327,083 | `2d46d773208d1d659710bf3c256abd06351f4b56cacc6283263158c6b1c51f77` |
+
+## Scoped completed validation
+
+- The stable GitHub Release is `draft=false`, `prerelease=false`, and
+  `immutable=true`; its tag and release manifest both bind the build SHA.
+- The complete 279-package official npm cohort and packaged runtime closure
+  passed integrity, license, dependency, secret, and public-export gates.
+- Apple Silicon and Windows x64 passed fresh install, restart, invalid-folder
+  rejection, credential-failure recovery, official first reply, installed
+  plugin checks, the installed 0.6.1 to 0.6.2 upgrade, preservation, rollback,
+  and default uninstall on the final packages.
+- The UOS package passed exact identity, ABI, dependency closure, runtime,
+  first-party plugin, license, and architecture checks.
+
+Explicitly not PASS:
+
+- Native UOS install, startup, UI, file picker, sleep/resume, model
+  conversation, Office, and Memory: `OWNER_POST_RELEASE`.
+- Two-hour installed soak: `OWNER_EXCLUDED`.
+- Optional private-account IM and iMessage live delivery: `NOT_RUN`.
+- Default Defender-enabled Windows: not verified. Native Windows checks used
+  the hosted runner's existing configuration.
+- macOS notarization and Windows Authenticode: not present.
+- Packaged PDF page-image preview: deferred. The generic sidebar is not a
+  DOCX renderer.
+
+## 中文
+
+以上十项附件均由原始公网回读从不可变发布下载核对，文件大小、SHA-256、更新签名
+和安装器签名全部通过。三个安装包来自同一源码
+`83ce4aa3c153b63d9f84c6a5d650a3727e8cfec6`。Intel Mac、Linux amd64 和
+Windows ARM 不是 0.6.2 目标。
+
+Apple 芯片与 Windows x64 已完成全新安装、重启、错误目录拒绝、凭据失败恢复、
+首条官方回复、已安装插件、0.6.1 到 0.6.2 真实升级、数据保留、回滚与默认卸载。
+UOS 包身份、ABI、依赖闭包、运行时、第一方插件、许可和架构验证通过；真机安装、
+启动、界面、文件选择器、休眠恢复、模型会话、办公与记忆仍为
+`OWNER_POST_RELEASE`。macOS 未公证，Windows 无 Authenticode，默认开启 Defender
+的 Windows 尚未验证。两小时安装版测试为 `OWNER_EXCLUDED`。

--- a/docs/RELEASE_NOTES_0.6.2.md
+++ b/docs/RELEASE_NOTES_0.6.2.md
@@ -1,7 +1,9 @@
 # Penglai 0.6.2
 
-Status: release candidate. Public URLs, sizes, hashes, and final source identity
-will be added only after immutable release readback.
+Status: immutable public release. All ten assets were published once and passed
+public readback. The exact sizes and SHA-256 values are recorded in the
+[publication manifest](PUBLICATION_MANIFEST_0.6.2.md). The installer source is
+`83ce4aa3c153b63d9f84c6a5d650a3727e8cfec6`.
 
 Penglai 0.6.2 adopts the complete official DeepSeek Harness `0.1.5-rc.2` npm
 cohort: 265 DSH packages, nine vendor packages, and five native packages. DSH
@@ -24,11 +26,11 @@ generation, and Companion remain optional and default off. iMessage is an
 optional Mac-only private-text channel and remains `LIVE_NOT_RUN`. WhatsApp is
 not bundled.
 
-The planned release set is exactly three installers plus the signed updater,
-release manifests, checksums, and public source-export manifest named in
-`release-contract.json`. Intel Mac, Linux amd64, and Windows ARM are not 0.6.2
-targets. macOS remains ad-hoc signed and not notarized; Windows has no
-Authenticode.
+The [immutable `v0.6.2` release](https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.2)
+contains exactly three installers plus the signed updater, release manifests,
+checksums, and public source-export manifest named in `release-contract.json`.
+Intel Mac, Linux amd64, and Windows ARM are not 0.6.2 targets. macOS remains
+ad-hoc signed and not notarized; Windows has no Authenticode.
 
 The UOS 20 LoongArch `.deb` is a complete installer containing Electron, Node,
 official DSH, every first-party plugin, Office, Memory, Mnemon, and its local
@@ -42,9 +44,11 @@ The two-hour installed soak is `OWNER_EXCLUDED`.
 
 ## 中文
 
-蓬莱 0.6.2 使用完整的官方 DeepSeek Harness `0.1.5-rc.2` npm 依赖组，DSH
-仍是唯一 Agent 核心和官方会话界面。本版保留上游反馈入口，但明确按真实边界工作：
-反馈只留在本机，蓬莱不会通过该入口上传会话内容。
+蓬莱 0.6.2 已作为不可变公开版本发布，十项附件均完成公网回读。精确大小与
+SHA-256 见[发布清单](PUBLICATION_MANIFEST_0.6.2.md)，安装包源码为
+`83ce4aa3c153b63d9f84c6a5d650a3727e8cfec6`。本版使用完整的官方 DeepSeek
+Harness `0.1.5-rc.2` npm 依赖组，DSH 仍是唯一 Agent 核心和官方会话界面。
+上游反馈入口按真实边界工作：反馈只留在本机，蓬莱不会通过该入口上传会话内容。
 
 ONNX 打包工具链间接依赖的 `adm-zip` 已固定到 `0.6.1`，会拒绝通过目标目录中
 已有的符号链接向外写入。依赖安装脚本仍保持关闭，安装后的产品运行时也不调用该

--- a/packages/release-identity/src/public-docs.test.ts
+++ b/packages/release-identity/src/public-docs.test.ts
@@ -102,10 +102,10 @@ test("website keeps the full bilingual visual site during publication preparatio
     assert.match(html, /shots\/0\.5\.5\/plugin-center\.png/);
     assert.match(html, /shots\/0\.5\.5\/office\.png/);
     assert.match(html, /shots\/0\.5\.5\/memory\.png/);
-    assert.match(html, /https:\/\/82\.156\.107\.151\/releases\/v0\.6\.1\/Penglai_0\.6\.1_macos_aarch64\.dmg/);
-    assert.match(html, /https:\/\/82\.156\.107\.151\/releases\/v0\.6\.1\/Penglai_0\.6\.1_windows_x64_setup\.exe/);
-    assert.match(html, /https:\/\/82\.156\.107\.151\/releases\/v0\.6\.1\/Penglai_0\.6\.1_uos_loong64\.deb/);
-    assert.match(html, /in-app updates still use GitHub|应用内更新仍走 GitHub/);
+    assert.match(html, /releases\/download\/v0\.6\.2\/Penglai_0\.6\.2_macos_aarch64\.dmg/);
+    assert.match(html, /releases\/download\/v0\.6\.2\/Penglai_0\.6\.2_windows_x64_setup\.exe/);
+    assert.match(html, /releases\/download\/v0\.6\.2\/Penglai_0\.6\.2_uos_loong64\.deb/);
+    assert.doesNotMatch(html, /82\.156\.107\.151|releases\/v0\.6\.1/);
   }
   assert.match(css, /\.download-grid/);
   assert.match(css, /\.site-nav/);

--- a/website/en/index.html
+++ b/website/en/index.html
@@ -4,9 +4,9 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Penglai 0.6.1 | Make room for the work that matters</title>
-  <meta name="description" content="Penglai 0.6.1 installs official DeepSeek Harness 0.1.5-rc.1 on a personal computer, with Office, Memory, messaging, and local voice. Apple Silicon, Windows x64, and UnionTech UOS 20 LoongArch.">
-  <meta property="og:title" content="Penglai 0.6.1">
+  <title>Penglai 0.6.2 | Make room for the work that matters</title>
+  <meta name="description" content="Penglai 0.6.2 installs official DeepSeek Harness 0.1.5-rc.2 on a personal computer, with Office, Memory, messaging, and local voice. Apple Silicon, Windows x64, and UnionTech UOS 20 LoongArch.">
+  <meta property="og:title" content="Penglai 0.6.2">
   <meta property="og:description" content="Official DeepSeek Harness, installed on your computer. Office and Memory start on. You finish setup after the first real reply.">
   <meta name="theme-color" content="#F3EEE4">
   <meta property="og:type" content="website">
@@ -43,7 +43,7 @@
     <section class="hero" id="top">
       <div class="hero-inner">
         <div class="hero-copy">
-          <p class="eyebrow">Penglai 0.6.1</p>
+          <p class="eyebrow">Penglai 0.6.2</p>
           <h1>A real assistant, without turning your computer into a project.</h1>
           <p class="lead">Install Penglai, bring the model key you already use, and begin in a Workspace you choose. Office and Memory are ready. Everything else stays quiet until you invite it.</p>
           <div class="actions">
@@ -62,7 +62,7 @@
             <div class="app-chrome" aria-hidden="true"><i></i><i></i><i></i><span>Penglai</span></div>
             <img src="../shots/0.5.5/welcome.png" alt="Penglai first-run welcome: language, appearance, and a seven-step guide">
           </div>
-          <figcaption>Installed 0.5.5 first-run welcome, kept as a UI reference. This is not a 0.6.1 screenshot.</figcaption>
+          <figcaption>Installed 0.5.5 first-run welcome, kept as a UI reference. This is not a 0.6.2 screenshot.</figcaption>
         </figure>
       </div>
     </section>
@@ -96,13 +96,13 @@
       </div>
       <div>
         <p>Official DeepSeek Harness is the only agent core. It owns models, tools, approvals, Workspace, Session, Turn, and the conversation interface. Penglai owns the installer, first-run, process supervision, updates, uninstall, local paths, and a reviewed plugin set. There is no second Penglai agent and no replacement chat page. Fresh setup lists official <code>deepseek-flash</code> (DeepSeek-V41-Flash) with text and image input. A model you already chose stays in official settings.</p>
-        <p class="identity">Penglai 0.6.1 · DSH <code>0.1.5-rc.1</code> · tag <code>dsh-v0.1.5-rc.1</code> · commit <code>183f08e9c6dde7e36cd2318eaee70b0da08fb35e</code> · 279 packages</p>
+        <p class="identity">Penglai 0.6.2 · DSH <code>0.1.5-rc.2</code> · tag <code>dsh-v0.1.5-rc.2</code> · commit <code>fb2c4b9e698e30edb738bca4cf0618587db7d203</code> · 279 packages</p>
       </div>
     </section>
 
     <figure class="wide-shot" data-reveal>
       <img src="../shots/0.5.5/plugin-center.png" alt="Penglai Plugin Center inside official DSH settings, showing Office, Memory, messaging, and voice">
-      <figcaption>Installed 0.5.5 Plugin Center, running in official DSH settings. UI state is never proof that a plugin is installed or healthy. Not a 0.6.1 screenshot.</figcaption>
+      <figcaption>Installed 0.5.5 Plugin Center, running in official DSH settings. UI state is never proof that a plugin is installed or healthy. Not a 0.6.2 screenshot.</figcaption>
     </figure>
 
     <section class="section split" data-reveal>
@@ -163,7 +163,7 @@
             <span class="state">Independent updates</span>
             <h3>Plugin Center</h3>
           </div>
-          <p>The catalog comes from immutable GitHub Releases. The current live catalog is <code>plugin-catalog-v1.000006</code>: no extra downloads, with the historic office-reader revocation kept. A reviewed plugin compatible with DSH 0.1.5-rc.1 can join later without a new desktop release. Signatures, hashes, permissions, and rollback protect distribution. Plugins still share the local DSH process.</p>
+          <p>The catalog comes from immutable GitHub Releases. The current live catalog is <code>plugin-catalog-v1.000006</code>: no extra downloads, with the historic office-reader revocation kept. A reviewed plugin compatible with DSH 0.1.5-rc.2 can join later without a new desktop release. Signatures, hashes, permissions, and rollback protect distribution. Plugins still share the local DSH process.</p>
         </article>
       </div>
     </section>
@@ -198,53 +198,32 @@
     </section>
 
     <section class="section download" id="download" data-reveal>
-      <p class="eyebrow">Penglai 0.6.1</p>
+      <p class="eyebrow">Penglai 0.6.2</p>
       <h2>Pick your machine. Start there.</h2>
-      <p class="download-hint" id="downloadHint" hidden data-mac="This browser looks like a Mac. Apple Silicon is the 0.6.1 Mac installer. Intel Mac is not a 0.6.1 target." data-windows="This browser looks like Windows. Use the 64-bit installer." data-linux="This browser looks like Linux. The public Linux package is UnionTech UOS 20 LoongArch only."></p>
+      <p class="download-hint" id="downloadHint" hidden data-mac="This browser looks like a Mac. Apple Silicon is the 0.6.2 Mac installer. Intel Mac is not a 0.6.2 target." data-windows="This browser looks like Windows. Use the 64-bit installer." data-linux="This browser looks like Linux. The public Linux package is UnionTech UOS 20 LoongArch only."></p>
       <div class="download-grid">
-        <a data-family="mac" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.1/Penglai_0.6.1_macos_aarch64.dmg">
+        <a data-family="mac" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/Penglai_0.6.2_macos_aarch64.dmg">
           <strong>macOS · Apple Silicon</strong>
-          <span>GitHub · 271.2 MiB · macOS 13+ · M1 and later</span>
-          <em>Penglai_0.6.1_macos_aarch64.dmg</em>
-          <code>91393e2e760871694e836c2582b903f6fee509e9fa11391724567e472f9946e9</code>
+          <span>GitHub · 271.4 MiB · macOS 13+ · M1 and later</span>
+          <em>Penglai_0.6.2_macos_aarch64.dmg</em>
+          <code>7a9e6d851c954e74d8af8ad8d4054838ad212dd575a82ad783cabd09bfdd9348</code>
         </a>
-        <a data-family="windows" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.1/Penglai_0.6.1_windows_x64_setup.exe">
+        <a data-family="windows" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/Penglai_0.6.2_windows_x64_setup.exe">
           <strong>Windows · x64</strong>
           <span>GitHub · 354.1 MiB · 64-bit installer</span>
-          <em>Penglai_0.6.1_windows_x64_setup.exe</em>
-          <code>d4fb670edea847024abcb2a1ac760cc2f7c5814d0c60f77f80ec647c59f51791</code>
+          <em>Penglai_0.6.2_windows_x64_setup.exe</em>
+          <code>3e97111bfcefa3c1ab72e70aad6b160acb76f6bef70391f8be4818d80edb8cda</code>
         </a>
-        <a data-family="linux" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.1/Penglai_0.6.1_uos_loong64.deb">
+        <a data-family="linux" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/Penglai_0.6.2_uos_loong64.deb">
           <strong>UOS 20 · LoongArch</strong>
           <span>GitHub · 279.5 MiB · UOS 20 Professional 1070, old-world. Native function is Owner post-publication.</span>
-          <em>Penglai_0.6.1_uos_loong64.deb</em>
-          <code>cd38c06e37151f226e7f9eb2519dba0800fc9ed7f4449d2b7edd5a282efb5934</code>
+          <em>Penglai_0.6.2_uos_loong64.deb</em>
+          <code>d16d6b9569095b4d599e9da5afd5c325ebbb661ac7de21ce993fd281bf2998f7</code>
         </a>
       </div>
-      <p class="quiet">If GitHub is slow from mainland China, download the same installers from the Beijing mirror. Verify each file against the GitHub <code>SHA256SUMS</code>; in-app updates still use GitHub.</p>
-      <div class="download-grid download-grid-mirror">
-        <a href="https://82.156.107.151/releases/v0.6.1/Penglai_0.6.1_macos_aarch64.dmg">
-          <strong>China mirror · Apple Silicon</strong>
-          <span>Beijing HTTPS · 271.2 MiB</span>
-          <em>Penglai_0.6.1_macos_aarch64.dmg</em>
-          <code>91393e2e760871694e836c2582b903f6fee509e9fa11391724567e472f9946e9</code>
-        </a>
-        <a href="https://82.156.107.151/releases/v0.6.1/Penglai_0.6.1_windows_x64_setup.exe">
-          <strong>China mirror · Windows x64</strong>
-          <span>Beijing HTTPS · 354.1 MiB</span>
-          <em>Penglai_0.6.1_windows_x64_setup.exe</em>
-          <code>d4fb670edea847024abcb2a1ac760cc2f7c5814d0c60f77f80ec647c59f51791</code>
-        </a>
-        <a href="https://82.156.107.151/releases/v0.6.1/Penglai_0.6.1_uos_loong64.deb">
-          <strong>China mirror · UOS LoongArch</strong>
-          <span>Beijing HTTPS · 279.5 MiB</span>
-          <em>Penglai_0.6.1_uos_loong64.deb</em>
-          <code>cd38c06e37151f226e7f9eb2519dba0800fc9ed7f4449d2b7edd5a282efb5934</code>
-        </a>
-      </div>
-      <p class="note-panel">The immutable GitHub Release is the authoritative public download source: <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.1">v0.6.1</a>. All three installers come from source <code>7ad7c29ecda5d9e867fdde0fe3fefd5c42d3ab1b</code>. Check the file against <code>SHA256SUMS</code> on that page. The release is three installers and ten assets. The signed updater covers Apple Silicon and Windows x64. Intel Mac is not a 0.6.1 installer. Linux amd64 and Windows ARM are not targets. Updates are never silent. Published 0.5.10, 0.5.11, 0.5.12, and 0.6.0 remain immutable.</p>
+      <p class="note-panel">The immutable GitHub Release is the authoritative public download source: <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.2">v0.6.2</a>. All three installers come from source <code>83ce4aa3c153b63d9f84c6a5d650a3727e8cfec6</code>. Check the file against <code>SHA256SUMS</code> on that page. The release is three installers and ten assets. The signed updater covers Apple Silicon and Windows x64. Intel Mac is not a 0.6.2 installer. Linux amd64 and Windows ARM are not targets. Updates are never silent. Published 0.5.10, 0.5.11, 0.5.12, 0.6.0, and 0.6.1 remain immutable.</p>
       <div class="actions">
-        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/RELEASE_NOTES_0.6.1.md">Release notes</a>
+        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/RELEASE_NOTES_0.6.2.md">Release notes</a>
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">Security notes</a>
       </div>
     </section>
@@ -253,7 +232,7 @@
       <p class="eyebrow">Why Penglai</p>
       <blockquote>I spent more than ten years around networking, security, and operations, but I was not a software developer. Penglai began with one stubborn idea: ordinary people should be able to reach a real assistant from the computer they already have.</blockquote>
       <p>Computers travelled from command lines to windows and then into everyone's pocket. Agents should make the same trip. If I can send a message, I should be able to reach my own assistant. If it acts for me, I should be able to see what it was allowed to do, what actually happened, and what it cost.</p>
-      <p>Penglai has been rebuilt more than once. The important decision in 0.5 was to stop building another agent and stand on DeepSeek Harness instead. 0.6.1 keeps that decision and puts the same product on three computers, including UnionTech UOS 20 LoongArch. Older generations remain in Git history; their runtimes are not mixed into this core.</p>
+      <p>Penglai has been rebuilt more than once. The important decision in 0.5 was to stop building another agent and stand on DeepSeek Harness instead. 0.6.2 keeps that decision and puts the same product on three computers, including UnionTech UOS 20 LoongArch. Older generations remain in Git history; their runtimes are not mixed into this core.</p>
       <p class="signature">Kevin Chen / 陈克文</p>
     </section>
 
@@ -267,7 +246,7 @@
         </article>
         <article>
           <h3>Which version should I download?</h3>
-          <p>This page describes Penglai 0.6.1. Download the matching installer from the immutable <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.1">v0.6.1</a> GitHub Release. Intel Mac is not a 0.6.1 installer. Published 0.5.10, 0.5.11, 0.5.12, and 0.6.0 remain historical and immutable.</p>
+          <p>This page describes Penglai 0.6.2. Download the matching installer from the immutable <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.2">v0.6.2</a> GitHub Release. Intel Mac is not a 0.6.2 installer. Published 0.5.10, 0.5.11, 0.5.12, 0.6.0, and 0.6.1 remain historical and immutable.</p>
         </article>
         <article>
           <h3>Why does Gatekeeper warn?</h3>
@@ -294,7 +273,7 @@
         <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/PRODUCT.md">Product contract</a>
         <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/ARCHITECTURE.md">Architecture</a>
         <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/PLUGIN_CENTER.md">Plugin Center</a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/0.6.1/ACCEPTANCE_DELTA.md">0.6.1 acceptance delta</a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/0.6.2/ACCEPTANCE_DELTA.md">0.6.2 acceptance delta</a>
       </p>
     </section>
   </main>

--- a/website/index.html
+++ b/website/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Penglai 0.6.1 | Make room for the work that matters</title>
-  <meta name="description" content="Penglai 0.6.1 installs official DeepSeek Harness 0.1.5-rc.1 on a personal computer, with Office, Memory, messaging, and local voice. Apple Silicon, Windows x64, and UnionTech UOS 20 LoongArch.">
-  <meta property="og:title" content="Penglai 0.6.1">
+  <title>Penglai 0.6.2 | Make room for the work that matters</title>
+  <meta name="description" content="Penglai 0.6.2 installs official DeepSeek Harness 0.1.5-rc.2 on a personal computer, with Office, Memory, messaging, and local voice. Apple Silicon, Windows x64, and UnionTech UOS 20 LoongArch.">
+  <meta property="og:title" content="Penglai 0.6.2">
   <meta property="og:description" content="Official DeepSeek Harness, installed on your computer. Office and Memory start on. You finish setup after the first real reply.">
   <meta name="theme-color" content="#F3EEE4">
   <meta property="og:type" content="website">
@@ -42,7 +42,7 @@
     <section class="hero" id="top">
       <div class="hero-inner">
         <div class="hero-copy">
-          <p class="eyebrow">Penglai 0.6.1</p>
+          <p class="eyebrow">Penglai 0.6.2</p>
           <h1>A real assistant, without turning your computer into a project.</h1>
           <p class="lead">Install Penglai, bring the model key you already use, and begin in a Workspace you choose. Office and Memory are ready. Everything else stays quiet until you invite it.</p>
           <div class="actions">
@@ -61,7 +61,7 @@
             <div class="app-chrome" aria-hidden="true"><i></i><i></i><i></i><span>Penglai</span></div>
             <img src="./shots/0.5.5/welcome.png" alt="Penglai first-run welcome: language, appearance, and a seven-step guide">
           </div>
-          <figcaption>Installed 0.5.5 first-run welcome, kept as a UI reference. This is not a 0.6.1 screenshot.</figcaption>
+          <figcaption>Installed 0.5.5 first-run welcome, kept as a UI reference. This is not a 0.6.2 screenshot.</figcaption>
         </figure>
       </div>
     </section>
@@ -95,13 +95,13 @@
       </div>
       <div>
         <p>Official DeepSeek Harness is the only agent core. It owns models, tools, approvals, Workspace, Session, Turn, and the conversation interface. Penglai owns the installer, first-run, process supervision, updates, uninstall, local paths, and a reviewed plugin set. There is no second Penglai agent and no replacement chat page. Fresh setup lists official <code>deepseek-flash</code> (DeepSeek-V41-Flash) with text and image input. A model you already chose stays in official settings.</p>
-        <p class="identity">Penglai 0.6.1 · DSH <code>0.1.5-rc.1</code> · tag <code>dsh-v0.1.5-rc.1</code> · commit <code>183f08e9c6dde7e36cd2318eaee70b0da08fb35e</code> · 279 packages</p>
+        <p class="identity">Penglai 0.6.2 · DSH <code>0.1.5-rc.2</code> · tag <code>dsh-v0.1.5-rc.2</code> · commit <code>fb2c4b9e698e30edb738bca4cf0618587db7d203</code> · 279 packages</p>
       </div>
     </section>
 
     <figure class="wide-shot" data-reveal>
       <img src="./shots/0.5.5/plugin-center.png" alt="Penglai Plugin Center inside official DSH settings, showing Office, Memory, messaging, and voice">
-      <figcaption>Installed 0.5.5 Plugin Center, running in official DSH settings. UI state is never proof that a plugin is installed or healthy. Not a 0.6.1 screenshot.</figcaption>
+      <figcaption>Installed 0.5.5 Plugin Center, running in official DSH settings. UI state is never proof that a plugin is installed or healthy. Not a 0.6.2 screenshot.</figcaption>
     </figure>
 
     <section class="section split" data-reveal>
@@ -162,7 +162,7 @@
             <span class="state">Independent updates</span>
             <h3>Plugin Center</h3>
           </div>
-          <p>The catalog comes from immutable GitHub Releases. The current live catalog is <code>plugin-catalog-v1.000006</code>: no extra downloads, with the historic office-reader revocation kept. A reviewed plugin compatible with DSH 0.1.5-rc.1 can join later without a new desktop release. Signatures, hashes, permissions, and rollback protect distribution. Plugins still share the local DSH process.</p>
+          <p>The catalog comes from immutable GitHub Releases. The current live catalog is <code>plugin-catalog-v1.000006</code>: no extra downloads, with the historic office-reader revocation kept. A reviewed plugin compatible with DSH 0.1.5-rc.2 can join later without a new desktop release. Signatures, hashes, permissions, and rollback protect distribution. Plugins still share the local DSH process.</p>
         </article>
       </div>
     </section>
@@ -197,53 +197,32 @@
     </section>
 
     <section class="section download" id="download" data-reveal>
-      <p class="eyebrow">Penglai 0.6.1</p>
+      <p class="eyebrow">Penglai 0.6.2</p>
       <h2>Pick your machine. Start there.</h2>
-      <p class="download-hint" id="downloadHint" hidden data-mac="This browser looks like a Mac. Apple Silicon is the 0.6.1 Mac installer. Intel Mac is not a 0.6.1 target." data-windows="This browser looks like Windows. Use the 64-bit installer." data-linux="This browser looks like Linux. The public Linux package is UnionTech UOS 20 LoongArch only."></p>
+      <p class="download-hint" id="downloadHint" hidden data-mac="This browser looks like a Mac. Apple Silicon is the 0.6.2 Mac installer. Intel Mac is not a 0.6.2 target." data-windows="This browser looks like Windows. Use the 64-bit installer." data-linux="This browser looks like Linux. The public Linux package is UnionTech UOS 20 LoongArch only."></p>
       <div class="download-grid">
-        <a data-family="mac" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.1/Penglai_0.6.1_macos_aarch64.dmg">
+        <a data-family="mac" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/Penglai_0.6.2_macos_aarch64.dmg">
           <strong>macOS · Apple Silicon</strong>
-          <span>GitHub · 271.2 MiB · macOS 13+ · M1 and later</span>
-          <em>Penglai_0.6.1_macos_aarch64.dmg</em>
-          <code>91393e2e760871694e836c2582b903f6fee509e9fa11391724567e472f9946e9</code>
+          <span>GitHub · 271.4 MiB · macOS 13+ · M1 and later</span>
+          <em>Penglai_0.6.2_macos_aarch64.dmg</em>
+          <code>7a9e6d851c954e74d8af8ad8d4054838ad212dd575a82ad783cabd09bfdd9348</code>
         </a>
-        <a data-family="windows" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.1/Penglai_0.6.1_windows_x64_setup.exe">
+        <a data-family="windows" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/Penglai_0.6.2_windows_x64_setup.exe">
           <strong>Windows · x64</strong>
           <span>GitHub · 354.1 MiB · 64-bit installer</span>
-          <em>Penglai_0.6.1_windows_x64_setup.exe</em>
-          <code>d4fb670edea847024abcb2a1ac760cc2f7c5814d0c60f77f80ec647c59f51791</code>
+          <em>Penglai_0.6.2_windows_x64_setup.exe</em>
+          <code>3e97111bfcefa3c1ab72e70aad6b160acb76f6bef70391f8be4818d80edb8cda</code>
         </a>
-        <a data-family="linux" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.1/Penglai_0.6.1_uos_loong64.deb">
+        <a data-family="linux" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/Penglai_0.6.2_uos_loong64.deb">
           <strong>UOS 20 · LoongArch</strong>
           <span>GitHub · 279.5 MiB · UOS 20 Professional 1070, old-world. Native function is Owner post-publication.</span>
-          <em>Penglai_0.6.1_uos_loong64.deb</em>
-          <code>cd38c06e37151f226e7f9eb2519dba0800fc9ed7f4449d2b7edd5a282efb5934</code>
+          <em>Penglai_0.6.2_uos_loong64.deb</em>
+          <code>d16d6b9569095b4d599e9da5afd5c325ebbb661ac7de21ce993fd281bf2998f7</code>
         </a>
       </div>
-      <p class="quiet">If GitHub is slow from mainland China, download the same installers from the Beijing mirror. Verify each file against the GitHub <code>SHA256SUMS</code>; in-app updates still use GitHub.</p>
-      <div class="download-grid download-grid-mirror">
-        <a href="https://82.156.107.151/releases/v0.6.1/Penglai_0.6.1_macos_aarch64.dmg">
-          <strong>China mirror · Apple Silicon</strong>
-          <span>Beijing HTTPS · 271.2 MiB</span>
-          <em>Penglai_0.6.1_macos_aarch64.dmg</em>
-          <code>91393e2e760871694e836c2582b903f6fee509e9fa11391724567e472f9946e9</code>
-        </a>
-        <a href="https://82.156.107.151/releases/v0.6.1/Penglai_0.6.1_windows_x64_setup.exe">
-          <strong>China mirror · Windows x64</strong>
-          <span>Beijing HTTPS · 354.1 MiB</span>
-          <em>Penglai_0.6.1_windows_x64_setup.exe</em>
-          <code>d4fb670edea847024abcb2a1ac760cc2f7c5814d0c60f77f80ec647c59f51791</code>
-        </a>
-        <a href="https://82.156.107.151/releases/v0.6.1/Penglai_0.6.1_uos_loong64.deb">
-          <strong>China mirror · UOS LoongArch</strong>
-          <span>Beijing HTTPS · 279.5 MiB</span>
-          <em>Penglai_0.6.1_uos_loong64.deb</em>
-          <code>cd38c06e37151f226e7f9eb2519dba0800fc9ed7f4449d2b7edd5a282efb5934</code>
-        </a>
-      </div>
-      <p class="note-panel">The immutable GitHub Release is the authoritative public download source: <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.1">v0.6.1</a>. All three installers come from source <code>7ad7c29ecda5d9e867fdde0fe3fefd5c42d3ab1b</code>. Check the file against <code>SHA256SUMS</code> on that page. The release is three installers and ten assets. The signed updater covers Apple Silicon and Windows x64. Intel Mac is not a 0.6.1 installer. Linux amd64 and Windows ARM are not targets. Updates are never silent. Published 0.5.10, 0.5.11, 0.5.12, and 0.6.0 remain immutable.</p>
+      <p class="note-panel">The immutable GitHub Release is the authoritative public download source: <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.2">v0.6.2</a>. All three installers come from source <code>83ce4aa3c153b63d9f84c6a5d650a3727e8cfec6</code>. Check the file against <code>SHA256SUMS</code> on that page. The release is three installers and ten assets. The signed updater covers Apple Silicon and Windows x64. Intel Mac is not a 0.6.2 installer. Linux amd64 and Windows ARM are not targets. Updates are never silent. Published 0.5.10, 0.5.11, 0.5.12, 0.6.0, and 0.6.1 remain immutable.</p>
       <div class="actions">
-        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/RELEASE_NOTES_0.6.1.md">Release notes</a>
+        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/RELEASE_NOTES_0.6.2.md">Release notes</a>
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">Security notes</a>
       </div>
     </section>
@@ -252,7 +231,7 @@
       <p class="eyebrow">Why Penglai</p>
       <blockquote>I spent more than ten years around networking, security, and operations, but I was not a software developer. Penglai began with one stubborn idea: ordinary people should be able to reach a real assistant from the computer they already have.</blockquote>
       <p>Computers travelled from command lines to windows and then into everyone's pocket. Agents should make the same trip. If I can send a message, I should be able to reach my own assistant. If it acts for me, I should be able to see what it was allowed to do, what actually happened, and what it cost.</p>
-      <p>Penglai has been rebuilt more than once. The important decision in 0.5 was to stop building another agent and stand on DeepSeek Harness instead. 0.6.1 keeps that decision and puts the same product on three computers, including UnionTech UOS 20 LoongArch. Older generations remain in Git history; their runtimes are not mixed into this core.</p>
+      <p>Penglai has been rebuilt more than once. The important decision in 0.5 was to stop building another agent and stand on DeepSeek Harness instead. 0.6.2 keeps that decision and puts the same product on three computers, including UnionTech UOS 20 LoongArch. Older generations remain in Git history; their runtimes are not mixed into this core.</p>
       <p class="signature">Kevin Chen / 陈克文</p>
     </section>
 
@@ -266,7 +245,7 @@
         </article>
         <article>
           <h3>Which version should I download?</h3>
-          <p>This page describes Penglai 0.6.1. Download the matching installer from the immutable <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.1">v0.6.1</a> GitHub Release. Intel Mac is not a 0.6.1 installer. Published 0.5.10, 0.5.11, 0.5.12, and 0.6.0 remain historical and immutable.</p>
+          <p>This page describes Penglai 0.6.2. Download the matching installer from the immutable <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.2">v0.6.2</a> GitHub Release. Intel Mac is not a 0.6.2 installer. Published 0.5.10, 0.5.11, 0.5.12, 0.6.0, and 0.6.1 remain historical and immutable.</p>
         </article>
         <article>
           <h3>Why does Gatekeeper warn?</h3>
@@ -293,7 +272,7 @@
         <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/PRODUCT.md">Product contract</a>
         <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/ARCHITECTURE.md">Architecture</a>
         <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/PLUGIN_CENTER.md">Plugin Center</a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/0.6.1/ACCEPTANCE_DELTA.md">0.6.1 acceptance delta</a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/0.6.2/ACCEPTANCE_DELTA.md">0.6.2 acceptance delta</a>
       </p>
     </section>
   </main>

--- a/website/zh/index.html
+++ b/website/zh/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>蓬莱 0.6.1 | 把该做的事，留在自己的电脑上</title>
-  <meta name="description" content="蓬莱 0.6.1 把官方 DeepSeek Harness 0.1.5-rc.1 装进个人电脑，办公、记忆、消息连接与本地语音都在同一个客户端里。支持 Apple 芯片、Windows x64 与统信 UOS 20 龙芯。">
-  <meta property="og:title" content="蓬莱 0.6.1">
+  <title>蓬莱 0.6.2 | 把该做的事，留在自己的电脑上</title>
+  <meta name="description" content="蓬莱 0.6.2 把官方 DeepSeek Harness 0.1.5-rc.2 装进个人电脑，办公、记忆、消息连接与本地语音都在同一个客户端里。支持 Apple 芯片、Windows x64 与统信 UOS 20 龙芯。">
+  <meta property="og:title" content="蓬莱 0.6.2">
   <meta property="og:description" content="官方 DeepSeek Harness，装进你的电脑。办公和记忆默认开启。第一条真实回复之后，引导才算完成。">
   <meta name="theme-color" content="#F3EEE4">
   <meta property="og:type" content="website">
@@ -42,7 +42,7 @@
     <section class="hero" id="top">
       <div class="hero-inner">
         <div class="hero-copy">
-          <p class="eyebrow">Penglai 0.6.1</p>
+          <p class="eyebrow">Penglai 0.6.2</p>
           <h1>真正能做事的助手，不该先让你学会搭系统。</h1>
           <p class="lead">装好蓬莱，填入你自己的模型密钥，在选好的 Workspace 里开始。办公和记忆已经就位，消息、语音和主动陪伴等你需要时再来。</p>
           <div class="actions">
@@ -61,7 +61,7 @@
             <div class="app-chrome" aria-hidden="true"><i></i><i></i><i></i><span>蓬莱</span></div>
             <img src="../shots/0.5.5/welcome.png" alt="蓬莱首次引导欢迎页：语言、外观和七步引导">
           </div>
-          <figcaption>0.5.5 安装版首次引导欢迎页，作为界面参考。这不是 0.6.1 截图。</figcaption>
+          <figcaption>0.5.5 安装版首次引导欢迎页，作为界面参考。这不是 0.6.2 截图。</figcaption>
         </figure>
       </div>
     </section>
@@ -95,13 +95,13 @@
       </div>
       <div>
         <p>官方 DeepSeek Harness 是唯一 Agent 核心。模型、工具、审批、Workspace、Session、Turn 和会话界面都归它。蓬莱负责安装包、首次引导、进程监管、升级、卸载、本地目录和一组经过审核的插件。这里没有第二套蓬莱 Agent，也没有另做一张聊天页。全新安装会列出官方 <code>deepseek-flash</code>（DeepSeek-V41-Flash），支持文本和图片输入。你已经明确选过的模型留在官方设置里。</p>
-        <p class="identity">Penglai 0.6.1 · DSH <code>0.1.5-rc.1</code> · tag <code>dsh-v0.1.5-rc.1</code> · commit <code>183f08e9c6dde7e36cd2318eaee70b0da08fb35e</code> · 279 包</p>
+        <p class="identity">Penglai 0.6.2 · DSH <code>0.1.5-rc.2</code> · tag <code>dsh-v0.1.5-rc.2</code> · commit <code>fb2c4b9e698e30edb738bca4cf0618587db7d203</code> · 279 包</p>
       </div>
     </section>
 
     <figure class="wide-shot" data-reveal>
       <img src="../shots/0.5.5/plugin-center.png" alt="运行在官方 DSH 设置里的蓬莱插件中心，可见办公、记忆、消息和语音">
-      <figcaption>0.5.5 安装版插件中心，运行在官方 DSH 设置里。界面状态不等于已安装或健康。这不是 0.6.1 截图。</figcaption>
+      <figcaption>0.5.5 安装版插件中心，运行在官方 DSH 设置里。界面状态不等于已安装或健康。这不是 0.6.2 截图。</figcaption>
     </figure>
 
     <section class="section split" data-reveal>
@@ -162,7 +162,7 @@
             <span class="state">独立更新</span>
             <h3>插件中心</h3>
           </div>
-          <p>目录来自不可变 GitHub Release。当前线上目录是 <code>plugin-catalog-v1.000006</code>：没有可下载的额外插件，并保留对旧 office-reader 的撤销。通过审核、兼容 DSH 0.1.5-rc.1 的插件可以后加入，不必重发桌面版本。签名、哈希、权限和回滚保护分发；插件仍与本地 DSH 共享进程。</p>
+          <p>目录来自不可变 GitHub Release。当前线上目录是 <code>plugin-catalog-v1.000006</code>：没有可下载的额外插件，并保留对旧 office-reader 的撤销。通过审核、兼容 DSH 0.1.5-rc.2 的插件可以后加入，不必重发桌面版本。签名、哈希、权限和回滚保护分发；插件仍与本地 DSH 共享进程。</p>
         </article>
       </div>
     </section>
@@ -197,53 +197,32 @@
     </section>
 
     <section class="section download" id="download" data-reveal>
-      <p class="eyebrow">Penglai 0.6.1</p>
+      <p class="eyebrow">Penglai 0.6.2</p>
       <h2>认准自己的电脑，下载这一份就好。</h2>
-      <p class="download-hint" id="downloadHint" hidden data-mac="当前浏览器像是 Mac。0.6.1 的 Mac 安装包是 Apple 芯片。Intel Mac 不是 0.6.1 目标。" data-windows="当前浏览器像是 Windows。请使用 64 位安装器。" data-linux="当前浏览器像是 Linux。公开的 Linux 包只覆盖统信 UOS 20 龙芯。"></p>
+      <p class="download-hint" id="downloadHint" hidden data-mac="当前浏览器像是 Mac。0.6.2 的 Mac 安装包是 Apple 芯片。Intel Mac 不是 0.6.2 目标。" data-windows="当前浏览器像是 Windows。请使用 64 位安装器。" data-linux="当前浏览器像是 Linux。公开的 Linux 包只覆盖统信 UOS 20 龙芯。"></p>
       <div class="download-grid">
-        <a data-family="mac" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.1/Penglai_0.6.1_macos_aarch64.dmg">
+        <a data-family="mac" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/Penglai_0.6.2_macos_aarch64.dmg">
           <strong>macOS · Apple 芯片</strong>
-          <span>GitHub · 271.2 MiB · macOS 13+ · M1 及更新</span>
-          <em>Penglai_0.6.1_macos_aarch64.dmg</em>
-          <code>91393e2e760871694e836c2582b903f6fee509e9fa11391724567e472f9946e9</code>
+          <span>GitHub · 271.4 MiB · macOS 13+ · M1 及更新</span>
+          <em>Penglai_0.6.2_macos_aarch64.dmg</em>
+          <code>7a9e6d851c954e74d8af8ad8d4054838ad212dd575a82ad783cabd09bfdd9348</code>
         </a>
-        <a data-family="windows" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.1/Penglai_0.6.1_windows_x64_setup.exe">
+        <a data-family="windows" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/Penglai_0.6.2_windows_x64_setup.exe">
           <strong>Windows · x64</strong>
           <span>GitHub · 354.1 MiB · 64 位安装器</span>
-          <em>Penglai_0.6.1_windows_x64_setup.exe</em>
-          <code>d4fb670edea847024abcb2a1ac760cc2f7c5814d0c60f77f80ec647c59f51791</code>
+          <em>Penglai_0.6.2_windows_x64_setup.exe</em>
+          <code>3e97111bfcefa3c1ab72e70aad6b160acb76f6bef70391f8be4818d80edb8cda</code>
         </a>
-        <a data-family="linux" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.1/Penglai_0.6.1_uos_loong64.deb">
+        <a data-family="linux" href="https://github.com/kevinchennewbee/PenglaiAgent/releases/download/v0.6.2/Penglai_0.6.2_uos_loong64.deb">
           <strong>UOS 20 · 龙芯</strong>
           <span>GitHub · 279.5 MiB · 统信 UOS 20 专业版 1070，旧世界。真机功能为 Owner 发布后测试。</span>
-          <em>Penglai_0.6.1_uos_loong64.deb</em>
-          <code>cd38c06e37151f226e7f9eb2519dba0800fc9ed7f4449d2b7edd5a282efb5934</code>
+          <em>Penglai_0.6.2_uos_loong64.deb</em>
+          <code>d16d6b9569095b4d599e9da5afd5c325ebbb661ac7de21ce993fd281bf2998f7</code>
         </a>
       </div>
-      <p class="quiet">国内访问 GitHub 较慢时，可下载同一份安装包的北京镜像。请用 GitHub 的 <code>SHA256SUMS</code> 核对文件；应用内更新仍走 GitHub。</p>
-      <div class="download-grid download-grid-mirror">
-        <a href="https://82.156.107.151/releases/v0.6.1/Penglai_0.6.1_macos_aarch64.dmg">
-          <strong>国内镜像 · Apple 芯片</strong>
-          <span>北京 HTTPS · 271.2 MiB</span>
-          <em>Penglai_0.6.1_macos_aarch64.dmg</em>
-          <code>91393e2e760871694e836c2582b903f6fee509e9fa11391724567e472f9946e9</code>
-        </a>
-        <a href="https://82.156.107.151/releases/v0.6.1/Penglai_0.6.1_windows_x64_setup.exe">
-          <strong>国内镜像 · Windows x64</strong>
-          <span>北京 HTTPS · 354.1 MiB</span>
-          <em>Penglai_0.6.1_windows_x64_setup.exe</em>
-          <code>d4fb670edea847024abcb2a1ac760cc2f7c5814d0c60f77f80ec647c59f51791</code>
-        </a>
-        <a href="https://82.156.107.151/releases/v0.6.1/Penglai_0.6.1_uos_loong64.deb">
-          <strong>国内镜像 · 龙芯</strong>
-          <span>北京 HTTPS · 279.5 MiB</span>
-          <em>Penglai_0.6.1_uos_loong64.deb</em>
-          <code>cd38c06e37151f226e7f9eb2519dba0800fc9ed7f4449d2b7edd5a282efb5934</code>
-        </a>
-      </div>
-      <p class="note-panel">权威公开下载源是不可变 GitHub Release：<a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.1">v0.6.1</a>。三个安装包来自源码 <code>7ad7c29ecda5d9e867fdde0fe3fefd5c42d3ab1b</code>。请用该页的 <code>SHA256SUMS</code> 核对文件。发布是三个安装包、十个文件。签名升级覆盖 Apple 芯片和 Windows x64。Intel Mac 不是 0.6.1 安装目标。Linux amd64 与 Windows ARM 不是目标。更新不会静默执行。已发布的 0.5.10、0.5.11、0.5.12、0.6.0 保持不可变。</p>
+      <p class="note-panel">权威公开下载源是不可变 GitHub Release：<a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.2">v0.6.2</a>。三个安装包来自源码 <code>83ce4aa3c153b63d9f84c6a5d650a3727e8cfec6</code>。请用该页的 <code>SHA256SUMS</code> 核对文件。发布是三个安装包、十个文件。签名升级覆盖 Apple 芯片和 Windows x64。Intel Mac 不是 0.6.2 安装目标。Linux amd64 与 Windows ARM 不是目标。更新不会静默执行。已发布的 0.5.10、0.5.11、0.5.12、0.6.0、0.6.1 保持不可变。</p>
       <div class="actions">
-        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/RELEASE_NOTES_0.6.1.md">发布说明</a>
+        <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/RELEASE_NOTES_0.6.2.md">发布说明</a>
         <a class="button ghost" href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/SECURITY.md">安全说明</a>
       </div>
     </section>
@@ -252,7 +231,7 @@
       <p class="eyebrow">为什么叫蓬莱</p>
       <blockquote>我做了十多年网络、安全和运维，却不是软件开发者。蓬莱一开始就想证明一件事：普通人应该能从自己已经有的电脑，找到真正能用的助手。</blockquote>
       <p>从命令行到窗口，再到每个人口袋里的手机，计算机一直在降低使用门槛。Agent 也应该走同一条路。会发消息，就应该能找到自己的助手；它替你做了什么、能看什么、花了多少，也应该讲得清楚。</p>
-      <p>蓬莱已经重做过不止一次。0.5 最重要的决定，是停止再造一个 Agent，转而站在 DeepSeek Harness 上。0.6.1 把同一件事做到三台电脑上，包括统信 UOS 20 龙芯。旧版本留在 Git 历史里讲这段路，但不会和新的核心混在一起。</p>
+      <p>蓬莱已经重做过不止一次。0.5 最重要的决定，是停止再造一个 Agent，转而站在 DeepSeek Harness 上。0.6.2 把同一件事做到三台电脑上，包括统信 UOS 20 龙芯。旧版本留在 Git 历史里讲这段路，但不会和新的核心混在一起。</p>
       <p class="signature">陈克文 / Kevin Chen</p>
     </section>
 
@@ -266,7 +245,7 @@
         </article>
         <article>
           <h3>现在该下载哪个版本？</h3>
-          <p>本页描述的是 Penglai 0.6.1。请从不可变 <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.1">v0.6.1</a> GitHub Release 下载对应安装包。Intel Mac 不是 0.6.1 安装目标。已发布的 0.5.10、0.5.11、0.5.12、0.6.0 仍是不可变历史版本。</p>
+          <p>本页描述的是 Penglai 0.6.2。请从不可变 <a href="https://github.com/kevinchennewbee/PenglaiAgent/releases/tag/v0.6.2">v0.6.2</a> GitHub Release 下载对应安装包。Intel Mac 不是 0.6.2 安装目标。已发布的 0.5.10、0.5.11、0.5.12、0.6.0、0.6.1 仍是不可变历史版本。</p>
         </article>
         <article>
           <h3>为什么 Gatekeeper 会提示？</h3>
@@ -293,7 +272,7 @@
         <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/PRODUCT.md">产品契约</a>
         <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/ARCHITECTURE.md">架构</a>
         <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/PLUGIN_CENTER.md">插件中心</a>
-        <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/0.6.1/ACCEPTANCE_DELTA.md">0.6.1 验收增量</a>
+        <a href="https://github.com/kevinchennewbee/PenglaiAgent/blob/main/docs/0.6.2/ACCEPTANCE_DELTA.md">0.6.2 验收增量</a>
       </p>
     </section>
   </main>


### PR DESCRIPTION
## Summary

- record the immutable v0.6.2 ten-asset public readback and exact source identity
- update README, security policy, release notes, and bilingual website to the published release
- remove the stale 0.6.1 Beijing mirror links because no verified 0.6.2 mirror publication exists
- preserve UOS native use as OWNER_POST_RELEASE and the two-hour soak as OWNER_EXCLUDED

## Evidence

- release source: `83ce4aa3c153b63d9f84c6a5d650a3727e8cfec6`
- native run: 34709915417 (exact aggregate PASS)
- publish/readback run: 34712617415 (immutable public bytes PASS)
- local: format, typecheck, contracts, dependencies, secrets, release adaptation, unit (1124 pass / 1 skip), contract (157 pass), security (14 pass), publication tests (14 pass)
- local Node is 22.22.2; CI re-runs with the required 22.23.2

## Boundaries

- installer source remains the tagged SHA above; this documentation commit is not package provenance
- no release tag or asset is modified
- UOS native install/start/UI/function is not claimed as PASS
- no notarization, Authenticode, private-account IM, or default-Defender claim is added