### PR TITLE
docs: record 0.6.2 website deployment

### DIFF
--- a/docs/0.6.2/TODO.md
+++ b/docs/0.6.2/TODO.md
@@ -21,7 +21,7 @@ turn an unrun native or public check into PASS.
       and default-uninstall evidence on the exact frozen SHA.
 - [x] Build and verify the exact UOS package on that same SHA.
 - [x] Publish and read back the exact immutable asset set.
-- [ ] Replace candidate wording with observed public sizes, hashes, and source
+- [x] Replace candidate wording with observed public sizes, hashes, and source
       identity; deploy and read back both public websites.
 - [ ] Owner post-release UOS native test: install, start, UI, file picker,
       sleep/resume, model conversation, Office, and Memory.

--- a/docs/PUBLICATION_0.6.2.md
+++ b/docs/PUBLICATION_0.6.2.md
@@ -17,9 +17,11 @@ immutable public assets passed download readback in [run 34712617415](https://gi
 
 The later README, security entry, bilingual website, and these publication
 records are a separate public-documentation commit. They do not change the
-installer source. Website deployment independently checks that only allowed
-publication files changed, binds every download to the immutable release, and
-compares every deployed file at Cloudflare Pages and GitHub Pages.
+installer source. Website [deployment run 34714111473](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34714111473)
+verified that only allowed publication files changed, bound every download to
+the immutable release, deployed the sealed website, and passed the complete
+file-by-file readback at both [Cloudflare Pages](https://penglai.pages.dev/)
+and [GitHub Pages](https://kevinchennewbee.github.io/PenglaiAgent/).
 
 macOS is ad-hoc signed and not notarized. Windows has no Authenticode. UOS
 package identity, ABI, dependency closure, plugins, and licenses passed, while
@@ -33,8 +35,8 @@ Penglai 0.6.2 已公开三个安装包和七项配套文件，精确公开字节
 原生任务、完整草稿验证与不可变公网回读均绑定该 SHA。
 
 README、安全入口、双语官网和发布记录属于随后独立提交的公开文档，不能把文档
-提交写成安装包来源。官网部署会另行核对变更边界、真实下载信息，并逐文件回读
-Cloudflare Pages 与 GitHub Pages。
+提交写成安装包来源。官网部署任务 `34714111473` 已核对变更边界与真实下载信息，
+并逐文件回读 Cloudflare Pages 与 GitHub Pages，结果为 PASS。
 
 macOS 未公证，Windows 无 Authenticode。UOS 包身份、ABI、依赖闭包、插件与许可
 已经通过，真机安装、启动、界面、文件选择器、休眠恢复和功能仍为

--- a/docs/PUBLICATION_MANIFEST_0.6.2.md
+++ b/docs/PUBLICATION_MANIFEST_0.6.2.md
@@ -24,6 +24,7 @@ are not substituted for generated release identity.
 | CodeQL run | [34709659600](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34709659600) on the build SHA; zero open alerts at release |
 | Native targets | [34709915417](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34709915417): darwin-aarch64, win32-x86_64, linux-loong64; exact aggregate PASS; Intel Mac excluded |
 | Publish and readback | [34712617415](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34712617415) |
+| Website deploy and readback | [34714111473](https://github.com/kevinchennewbee/PenglaiAgent/actions/runs/34714111473): sealed website deployed; every public file matched at Cloudflare Pages and GitHub Pages |
 | Trust | community-verified; macOS ad-hoc, not notarized; Windows no Authenticode; UOS Electron 31.7.7 / Chromium 126 and Node 22.16.0 unmaintained, without Mac/Windows security parity |
 | Native UOS | `OWNER_POST_RELEASE` |
 | Signed updater | Apple Silicon and Windows x64 |


### PR DESCRIPTION
## Summary

- record successful website deploy/readback run 34714111473
- mark the public documentation and two-origin website item complete
- leave website bytes unchanged

## Verification

- format check: PASS
- publication/document tests: 14 PASS
- `git diff -- website`: empty
- deployment run verified every sealed file at Cloudflare Pages and GitHub Pages

## Boundaries

- no installer, Release asset, tag, runtime source, or website byte changes
- UOS native use remains OWNER_POST_RELEASE
- two-hour soak remains OWNER_EXCLUDED